### PR TITLE
Fix bug when calling mask; no outputFormat in tsSetup

### DIFF
--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -229,7 +229,7 @@ def main(inps=None):
 
     # Load or download mask (if specified).
     if inps.mask is not None:
-        inps.mask = prep_mask(inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat)
+        inps.mask = prep_mask(inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir)#, outputFormat=inps.outputFormat)
 
 
     # Download/Load DEM & Lat/Lon arrays, providing bbox, expected DEM shape, and output dir as input.


### PR DESCRIPTION
Error occurs when using a mask in tsSetup.py; there is no outputFormat given to
tsSetup argparse inputs and thus no way of changing output type of mask from here

Traceback (most recent call last):
  File "/Miniconda3/envs/ARIA/bin/ariaTSsetup.py", line 18, in <module>
    main(inps)
  File "Miniconda3/envs/ARIA/lib/python3.6/site-packages/ARIAtools/tsSetup.py", line 232, in main
    inps.mask = prep_mask(inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat
=inps.outputFormat)
AttributeError: 'Namespace' object has no attribute 'outputFormat'