### PR TITLE
Sss demupdate

### DIFF
--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -239,7 +239,7 @@ def main(inps=None):
     if inps.demfile is not None:
         print('Download/cropping DEM')
         # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat))
+        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat)
 
     # Extract
     layers=['unwrappedPhase','coherence']


### PR DESCRIPTION
Print statements now passed once DEM and/or mask have been successfully downloaded.

Also, linear method to interpolate meta-data to interferogram grid (instead of nearest neighbor interpolation) to avoid coarse output (looked like grid-points before!).