### PR TITLE
Multiple minor bug-fixes/changes reflecting latest dev commit #bb7faea

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -43,8 +43,8 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
 
         ### Determine if file input is single file, a list, or wildcard.
         # If list of files
-        if len([str(val) for val in filearg.split()])>1:
-            self.files=[str(val) for val in filearg.split()]
+        if len([str(val) for val in filearg.split(',')])>1:
+            self.files=[str(val) for val in filearg.split(',')]
         # If single file or wildcard
         else:
             # If single file


### PR DESCRIPTION
The bug-fixes/changes pushed here reflect everything in the latest dev commit #bb7faea, but without the introduction of the tropo_correction functions. Hence this is simply an update to the stable repo.

In tsSetup: Added option/check to extract additional layers not necessary for ts. Fixed bug in prep_mask call, which had neglected to pass product dictionary. 

In ARIAProduct: A comma-delimited list of files is expected as input (as referenced in the ARIA-docs), as opposed to a space-delimited list.

In extractProduct: Added print statement in the prep_dem function to confirm a DEM has been successfully downloaded. Fixed bug with the handling of the amp_thresh variable in the prep_mask function. Made minor tweaks to the function description and removed unused OrderedDict module in the export_product function. In finalize_metadata remove reference to 2D grid nearest neighbor interpolation, which is no longer performed. Simplified inps.layer call when all is specified.  