### PR TITLE
Multithreading now supported. Other changes.

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -43,8 +43,8 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
 
         ### Determine if file input is single file, a list, or wildcard.
         # If list of files
-        if len([str(val) for val in filearg.split()])>1:
-            self.files=[str(val) for val in filearg.split()]
+        if len([str(val) for val in filearg.split(',')])>1:
+            self.files=[str(val) for val in filearg.split(',')]
         # If single file or wildcard
         else:
             # If single file

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -9,6 +9,7 @@
 import os
 import sys
 import numpy as np
+import glob
 
 from osgeo import gdal
 gdal.UseExceptions()
@@ -37,6 +38,7 @@ def createParser():
     parser.add_argument('-b', '--bbox', dest='bbox', type=str, default=None, help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
     parser.add_argument('-m', '--mask', dest='mask', type=str, default=None, help="Path to mask file or 'Download'. File needs to be GDAL compatabile, contain spatial reference information, and have invalid/valid data represented by 0/1, respectively. If 'Download', will use GSHHS water mask")
     parser.add_argument('-at', '--amp_thresh', dest='amp_thresh', default=None, type=str, help='Amplitude threshold below which to mask. Specify "None" to not use amplitude mask. By default "None".')
+    parser.add_argument('-nt', '--num_threads', dest='num_threads', default=2, type=str, help='Specify number of threads for multiprocessing operation in gdal. By default "2". Can also specify "All" to use all available threads.')
 #    parser.add_argument('-sm', '--stitchMethod', dest='stitchMethodType',  type=str, default='overlap', help="Method applied to stitch the unwrapped data. Either 'overlap', where product overlap is minimized, or '2stage', where minimization is done on connected components, are allowed methods. Default is 'overlap'.")
     parser.add_argument('-of', '--outputFormat', dest='outputFormat', type=str, default='VRT', help='GDAL compatible output format (e.g., "ENVI", "GTiff"). By default files are generated virtually except for "bPerpendicular", "bParallel", "incidenceAngle", "lookAngle","azimuthAngle", "unwrappedPhase" as these are require either DEM intersection or corrections to be applied')
     parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection and bbox (if specified).")
@@ -85,13 +87,20 @@ class InterpCube(object):
         est = interp1d(self.hgts, vals, kind='cubic')
         return est(h) + self.offset
 
-def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir='./', outputFormat='ENVI'):
+def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir='./', outputFormat='ENVI', num_threads='2'):
     '''
         Function to load and export DEM, lat, lon arrays.
         If "Download" flag is specified, DEM will be donwloaded on the fly.
     '''
 
     _world_dem = '/vsicurl/https://cloud.sdsc.edu/v1/AUTH_opentopography/Raster/SRTM_GL1_Ellip/SRTM_GL1_Ellip_srtm.vrt'
+
+    # If specified DEM subdirectory exists, delete contents
+    workdir=os.path.join(workdir,'DEM')
+    if os.path.exists(workdir) and demfilename!=os.path.join(workdir,os.path.basename(demfilename).split('.')[0].split('uncropped')[0]+'.dem') and demfilename!=os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'.dem') or demfilename.lower()=='download':
+        for i in glob.glob(os.path.join(workdir,'*dem*')): os.remove(i)
+    if not os.path.exists(workdir):
+        os.mkdir(workdir)
 
     # Get bounds of user bbox_file
     bounds=open_shapefile(bbox_file, 0, 0).bounds
@@ -102,15 +111,34 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir
 
     # Download DEM
     if demfilename.lower()=='download':
-        demfilename=os.path.join(workdir,'SRTM_3arcsec'+'.dem')
-        gdal.Warp(demfilename, _world_dem, options=gdal.WarpOptions(format=outputFormat, outputBounds=bounds, outputType=gdal.GDT_Int16, width=arrshape[1], height=arrshape[0], dstNodata=-32768.0, srcNodata=-32768.0))
-        gdal.Open(demfilename,gdal.GA_Update).SetProjection(proj)
+        # update demfilename 
+        demfilename=os.path.join(workdir,'SRTM_3arcsec.dem')
+        # save uncropped DEM
+        gdal.BuildVRT(os.path.join(workdir,'SRTM_3arcsec_uncropped.dem.vrt'), _world_dem, options=gdal.BuildVRTOptions(outputBounds=bounds))
+        # save cropped DEM
+        gdal.Warp(demfilename, os.path.join(workdir,'SRTM_3arcsec_uncropped.dem.vrt'), options=gdal.WarpOptions(format=outputFormat, outputBounds=bounds, outputType=gdal.GDT_Int16, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+        update_file=gdal.Open(demfilename,gdal.GA_Update)
+        update_file.SetProjection(proj) ; del update_file
         gdal.Translate(demfilename+'.vrt', demfilename, options=gdal.TranslateOptions(format="VRT")) #Make VRT
         print('Downloaded 3 arc-sec SRTM DEM here: '+ demfilename)
 
     # Load DEM and setup lat and lon arrays
     try:
-        demfile = gdal.Warp('', demfilename, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, dstNodata=0))
+        # Check if uncropped/cropped DEMs exist in 'DEM' subdirectory
+        if not os.path.exists(os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'.dem')):
+            # save uncropped DEM
+            gdal.BuildVRT(os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'_uncropped.dem.vrt'), demfilename, options=gdal.BuildVRTOptions(outputBounds=bounds))
+            # update demfilename 
+            demfilename=os.path.join(workdir,os.path.basename(demfilename).split('.')[0].split('uncropped')[0]+'.dem')
+            # save cropped DEM
+            gdal.Warp(demfilename, os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'_uncropped.dem.vrt'), options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+            update_file=gdal.Open(demfilename,gdal.GA_Update)
+            update_file.SetProjection(proj) ; del update_file
+            gdal.Translate(demfilename+'.vrt', demfilename, options=gdal.TranslateOptions(format="VRT"))
+            print('Saved DEM cropped to interferometric grid here: '+ demfilename)
+
+        #pass cropped DEM
+        demfile = gdal.Warp('', demfilename, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, dstNodata=0, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
         demfile.SetProjection(proj)
 
         ##SS Do we need lon lat if we would be doing gdal reproject using projection and transformation? See our earlier discussions.
@@ -125,7 +153,7 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir
 
     return demfilename, demfile, Latitude, Longitude
 
-def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_thresh=None, arrshape=None, workdir='./', outputFormat='ENVI'):
+def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_thresh=None, arrshape=None, workdir='./', outputFormat='ENVI', num_threads='2'):
     '''
         Function to load and export mask file.
         If "Download" flag is specified, GSHHS water mask will be donwloaded on the fly.
@@ -133,9 +161,15 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
 
     # Import functions
     from ARIAtools.vrtmanager import renderVRT
-    import glob
 
     _world_watermask = [' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L1.shp',' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L2.shp',' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L3.shp', ' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L4.shp',' /vsizip/vsicurl/https://osmdata.openstreetmap.de/download/land-polygons-complete-4326.zip/land-polygons-complete-4326/land_polygons.shp']
+
+    # If specified DEM subdirectory exists, delete contents
+    workdir=os.path.join(workdir,'mask')
+    if os.path.exists(workdir) and maskfilename!=os.path.join(workdir,os.path.basename(maskfilename).split('.')[0].split('uncropped')[0]+'.msk') and maskfilename!=os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'.msk') or maskfilename.lower()=='download':
+        for i in glob.glob(os.path.join(workdir,'*.*')): os.remove(i)
+    if not os.path.exists(workdir):
+        os.mkdir(workdir)
 
     # Get bounds of user bbox_file
     bounds=open_shapefile(bbox_file, 0, 0).bounds
@@ -155,8 +189,14 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
         os.system('ogrmerge.py -o ' + os.path.join(workdir,'watermsk_lakes.vrt') + ''.join(_world_watermask[1::2]) + ' -field_strategy Union -f VRT -single')
 
         ###Initiate water-mask with coastlines/islands union VRT
-        gdal.Rasterize(maskfilename, os.path.join(workdir,'watermsk_shorelines.vrt'), options=gdal.RasterizeOptions(format=outputFormat, outputBounds=bounds, outputType=gdal.GDT_Byte, width=arrshape[1], height=arrshape[0], burnValues=[1], layers='merged'))
-        gdal.Open(maskfilename,gdal.GA_Update).SetProjection(proj)
+        # save uncropped mask
+        gdal.Rasterize(os.path.join(workdir,'watermask_uncropped.msk'), os.path.join(workdir,'watermsk_shorelines.vrt'), options=gdal.RasterizeOptions(format=outputFormat, outputBounds=bounds, outputType=gdal.GDT_Byte, width=arrshape[1], height=arrshape[0], burnValues=[1], layers='merged'))
+        gdal.Translate(os.path.join(workdir,'watermask_uncropped.msk.vrt'), os.path.join(workdir,'watermask_uncropped.msk'), options=gdal.TranslateOptions(format="VRT"))
+        # save cropped mask
+        gdal.Warp(maskfilename, os.path.join(workdir,'watermask_uncropped.msk.vrt'), options=gdal.WarpOptions(format=outputFormat, outputBounds=bounds, outputType=gdal.GDT_Byte, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+        update_file=gdal.Open(maskfilename,gdal.GA_Update)
+        update_file.SetProjection(proj)
+        update_file.GetRasterBand(1).SetNoDataValue(0.) ; del update_file
         gdal.Translate(maskfilename+'.vrt', maskfilename, options=gdal.TranslateOptions(format="VRT"))
 
         ###Must take inverse of lakes/ponds union because of opposite designation (1 for water, 0 for land) as desired (0 for water, 1 for land)
@@ -166,54 +206,55 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
 
         if amp_thresh:
             ###Make average amplitude mask
-            # Iterate through all IFGs
-            for i,j in enumerate(product_dict[0]):
-                amp_file=gdal.Warp('', j, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds))
-                amp_file_arr=np.ma.masked_where(amp_file.ReadAsArray() == amp_file.GetRasterBand(1).GetNoDataValue(), amp_file.ReadAsArray())
+            # Delete existing average amplitude file
+            for i in glob.glob(os.path.join(workdir,'avgamplitude*')): os.remove(i)
 
-                # Iteratively update average amplitude file
-                # If looping through first amplitude file, nothing to sum so just save to file
-                if os.path.exists(os.path.join(workdir,'avgamplitude.msk')):
-                    amp_file=gdal.Open(os.path.join(workdir,'avgamplitude.msk'),gdal.GA_Update)
-                    amp_file=amp_file.GetRasterBand(1).WriteArray(amp_file_arr+amp_file.ReadAsArray())
-                else:
-                    renderVRT(os.path.join(workdir,'avgamplitude.msk'), amp_file_arr, geotrans=amp_file.GetGeoTransform(), drivername=outputFormat, gdal_fmt=amp_file_arr.dtype.name, proj=amp_file.GetProjection(), nodata=amp_file.GetRasterBand(1).GetNoDataValue())
-                amp_file = coh_val = amp_file_arr = None
+            # building the VRT
+            gdal.BuildVRT(os.path.join(workdir,'avgamplitude') +'.vrt', product_dict[0], options=gdal.BuildVRTOptions(resolution='highest', resampleAlg='average'))
+            # taking average of all scenes and generating raster
+            gdal.Warp(os.path.join(workdir,'avgamplitude'), os.path.join(workdir,'avgamplitude')+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, resampleAlg='average', multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+            # Update VRT
+            gdal.Translate(os.path.join(workdir,'avgamplitude')+'.vrt', os.path.join(workdir,'avgamplitude'), options=gdal.TranslateOptions(format="VRT"))
+            print('Saved average amplitude here: '+ os.path.join(workdir,'avgamplitude'))
 
-            # Take average of amplitude sum
-            amp_file=gdal.Open(os.path.join(workdir,'avgamplitude.msk'),gdal.GA_Update)
-            arr_mean = amp_file.ReadAsArray()/len(product_dict[0])
-            arr_mean = np.where(arr_mean < float(amp_thresh), 0, 1)
-            amp_file=amp_file.GetRasterBand(1).WriteArray(arr_mean)
-            amp_file = None ; arr_mean = None
-            amp_file=gdal.Open(os.path.join(workdir,'avgamplitude.msk')).ReadAsArray()
+            # Using specified amplitude threshold, pass amplitude mask
+            amp_file=gdal.Open(os.path.join(workdir,'avgamplitude')).ReadAsArray()
+            amp_file = np.where(amp_file < float(amp_thresh), 0, 1)
         else:
             amp_file=np.ones((lake_masks.shape[0],lake_masks.shape[1]))
 
         ###Update water-mask with lakes/ponds union and average amplitude
-        update_file=gdal.Open(maskfilename,gdal.GA_Update)
-        update_file=update_file.GetRasterBand(1).WriteArray(update_file.ReadAsArray()*lake_masks*amp_file)
-        print('Downloaded water-mask here: '+ maskfilename)
-        update_file=None ; lake_masks=None; amp_file = None
+        mask_file = gdal.Open(maskfilename,gdal.GA_Update)
+        mask_file.GetRasterBand(1).WriteArray(lake_masks*gdal.Open(maskfilename).ReadAsArray()*amp_file)
         #Delete temp files
+        del lake_masks, amp_file, mask_file
         os.remove(os.path.join(workdir,'watermsk_shorelines.vrt')); os.remove(os.path.join(workdir,'watermsk_lakes.vrt'))
-        for i in glob.glob(os.path.join(workdir,'avgamplitude.msk*')): os.remove(i)
 
     # Load mask
     try:
-        mask=gdal.Warp('', maskfilename, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, dstNodata=0))
+        # Check if uncropped/cropped maskfiles exist in 'mask' subdirectory
+        if not os.path.exists(os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'.msk')):
+            # save uncropped masfile
+            gdal.BuildVRT(os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'_uncropped.msk.vrt'), maskfilename, options=gdal.BuildVRTOptions(outputBounds=bounds))
+            # update maskfilename 
+            maskfilename=os.path.join(workdir,os.path.basename(maskfilename).split('.')[0].split('uncropped')[0]+'.msk')
+            # save cropped maskfile
+            gdal.Warp(maskfilename, os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'_uncropped.msk.vrt'), options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+            mask_file = gdal.Open(maskfilename,gdal.GA_Update)
+            mask_file.SetProjection(proj) ; del mask_file
+            gdal.Translate(maskfilename+'.vrt', maskfilename, options=gdal.TranslateOptions(format="VRT"))
+
+        #pass cropped DEM
+        mask=gdal.Warp('', maskfilename, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
         mask.SetProjection(proj)
-        # If no data value
-        if mask.GetRasterBand(1).GetNoDataValue():
-            mask=np.ma.masked_where(mask.ReadAsArray() == mask.GetRasterBand(1).GetNoDataValue(), mask.ReadAsArray())
-        else:
-            mask=mask.ReadAsArray()
+        mask=mask.ReadAsArray()
+
     except:
         raise Exception('Failed to open user mask')
 
     return mask
 
-def merged_productbbox(product_dict, workdir='./', bbox_file=None, croptounion=False):
+def merged_productbbox(product_dict, workdir='./', bbox_file=None, croptounion=False, num_threads='2'):
     '''
         Extract/merge productBoundingBox layers for each pair and update dict, report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
     '''
@@ -277,16 +318,16 @@ def merged_productbbox(product_dict, workdir='./', bbox_file=None, croptounion=F
         bbox_file=prods_TOTbbox
 
     # Warp the first scene with the output-bounds defined above
-    ds=gdal.Warp('', gdal.BuildVRT('', product_dict[0]['unwrappedPhase'][0]), options=gdal.WarpOptions(format="MEM", outputBounds=open_shapefile(bbox_file, 0, 0).bounds))
+    ds=gdal.Warp('', gdal.BuildVRT('', product_dict[0]['unwrappedPhase'][0]), options=gdal.WarpOptions(format="MEM", outputBounds=open_shapefile(bbox_file, 0, 0).bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
     # Get shape of full res layers
     arrshape=[ds.RasterYSize, ds.RasterXSize]
     # Get projection of full res layers
     proj=ds.GetProjection()
-    ds = None
+    del ds
 
     return product_dict, bbox_file, prods_TOTbbox, arrshape, proj
 
-def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, dem=None, lat=None, lon=None, mask=None, outDir='./',outputFormat='VRT', stitchMethodType='overlap', verbose=None):
+def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, dem=None, lat=None, lon=None, mask=None, outDir='./',outputFormat='VRT', stitchMethodType='overlap', verbose=None, num_threads='2'):
     """
         Export layer and 2D meta-data layers (at the product resolution).
         The function finalize_metadata is called to derive the 2D metadata layer. Dem/lat/lon arrays must be passed for this process.
@@ -334,7 +375,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, dem=Non
                     # building the virtual vrt
                     gdal.BuildVRT(outname+ "_uncropped" +'.vrt', j)
                     # building the cropped vrt
-                    gdal.Warp(outname+'.vrt', outname+"_uncropped"+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds))
+                    gdal.Warp(outname+'.vrt', outname+"_uncropped"+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
                 else:
                     # building the VRT
                     gdal.BuildVRT(outname +'.vrt', j)
@@ -342,7 +383,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, dem=Non
                     # Mask specified, so file must be physically extracted, cannot proceed with VRT format. Defaulting to ENVI format.
                     if outputFormat=='VRT' and mask is not None:
                        outputFormat='ENVI'
-                    gdal.Warp(outname, outname+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds))
+                    gdal.Warp(outname, outname+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
 
                     # Update VRT
                     gdal.Translate(outname+'.vrt', outname, options=gdal.TranslateOptions(format="VRT"))
@@ -350,8 +391,8 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, dem=Non
                     # Apply mask (if specified).
                     if mask is not None:
                         update_file=gdal.Open(outname,gdal.GA_Update)
-                        update_file=update_file.GetRasterBand(1).WriteArray(mask*gdal.Open(outname+'.vrt').ReadAsArray())
-                        update_file=None
+                        update_file.GetRasterBand(1).WriteArray(mask*gdal.Open(outname+'.vrt').ReadAsArray())
+                        del update_file
 
             # Extract/crop "unw" and "conn_comp" layers leveraging the two stage unwrapper
             else:
@@ -374,7 +415,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, dem=Non
     return
 
 
-def finalize_metadata(outname, bbox_bounds, prods_TOTbbox, dem, lat, lon, mask=None, outputFormat='ENVI', verbose=None):
+def finalize_metadata(outname, bbox_bounds, prods_TOTbbox, dem, lat, lon, mask=None, outputFormat='ENVI', verbose=None, num_threads='2'):
     '''
         2D metadata layer is derived by interpolating and then intersecting 3D layers with a DEM. Lat/lon arrays must also be passed for this process.
     '''
@@ -392,9 +433,9 @@ def finalize_metadata(outname, bbox_bounds, prods_TOTbbox, dem, lat, lon, mask=N
     # Check and buffer bounds if <4pix in x/y, which would raise interpolation error
     geotrans=gdal.Open(outname+'.vrt').GetGeoTransform()
     if round((max(bbox_bounds[0::2])-min(bbox_bounds[0::2])),2)<round((abs(geotrans[1])*4),2) or round((max(bbox_bounds[1::2])-min(bbox_bounds[1::2])),2)<round((abs(geotrans[-1])*4),2):
-        data_array=gdal.Warp('', outname+'.vrt', options=gdal.WarpOptions(format="MEM"))
+        data_array=gdal.Warp('', outname+'.vrt', options=gdal.WarpOptions(format="MEM", multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
     else:
-        data_array=gdal.Warp('', outname+'.vrt', options=gdal.WarpOptions(format="MEM", outputBounds=bbox_bounds))
+        data_array=gdal.Warp('', outname+'.vrt', options=gdal.WarpOptions(format="MEM", outputBounds=bbox_bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
 
     # Define lat/lon/height arrays for metadata layers
     heightsMeta=np.array(gdal.Open(outname+'.vrt').GetMetadataItem('NETCDF_DIM_heightsMeta_VALUES')[1:-1].split(','), dtype='float32')
@@ -423,15 +464,14 @@ def finalize_metadata(outname, bbox_bounds, prods_TOTbbox, dem, lat, lon, mask=N
 
     # Since metadata layer extends at least one grid node outside of the expected track bounds, it must be cut to conform with these bounds.
     # Crop to track extents
-    out_interpolated=gdal.Warp('', outname, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, dstNodata=data_array.GetRasterBand(1).GetNoDataValue())).ReadAsArray()
+    out_interpolated=gdal.Warp('', outname, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, dstNodata=data_array.GetRasterBand(1).GetNoDataValue(), multithread=True, options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
 
     # Apply mask (if specified).
     if mask is not None:
-        ##SS Just to double check if the no-data is being tracked here. The vrt is setting a no-data value, but here no-data is not used.
-        out_interpolated = np.multiply(out_interpolated, mask, out=out_interpolated, where=mask==0)
+        out_interpolated = mask*out_interpolated
 
     update_file=gdal.Open(outname,gdal.GA_Update)
-    update_file=update_file.GetRasterBand(1).WriteArray(out_interpolated)
+    update_file.GetRasterBand(1).WriteArray(out_interpolated)
 
     del out_interpolated, interpolator, interp_2d, data_array, update_file
 
@@ -461,22 +501,29 @@ def main(inps=None):
 
     else:
         inps.layers=list(inps.layers.split(','))
+        inps.layers=[i.replace(' ','') for i in inps.layers]
 
+    # pass number of threads for gdal multiprocessing computation
+    if inps.num_threads.lower()=='all':
+        import multiprocessing
+        print('User specified use of all %s threads for gdal multiprocessing'%(str(multiprocessing.cpu_count())))
+        inps.num_threads='ALL_CPUS'
+    print('Thread count specified for gdal multiprocessing = %s'%(inps.num_threads))
 
     # extract/merge productBoundingBox layers for each pair and update dict,
     # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-    standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion)
+    standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads)
     # Load or download mask (if specified).
     if inps.mask is not None:
-        inps.mask = prep_mask([[j['amplitude'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat)
+        inps.mask = prep_mask([[item for sublist in [list(set(d['amplitude'])) for d in standardproduct_info.products[1] if 'amplitude' in d] for item in sublist], [item for sublist in [list(set(d['pair_name'])) for d in standardproduct_info.products[1] if 'pair_name' in d] for item in sublist]], inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
 
     # Download/Load DEM & Lat/Lon arrays, providing bbox, expected DEM shape, and output dir as input.
     if inps.demfile is not None:
         # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat)
+        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
     else:
         demfile=None ; Latitude=None ; Longitude=None
 
     # Extract user expected layers
-    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, inps.layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose)
+    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, inps.layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)

--- a/tools/ARIAtools/productPlot.py
+++ b/tools/ARIAtools/productPlot.py
@@ -33,6 +33,7 @@ def createParser():
     parser.add_argument('-b', '--bbox', dest='bbox', type=str, default=None, help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
     parser.add_argument('-m', '--mask', dest='mask', type=str, default=None, help="Path to mask file or 'Download'. File needs to be GDAL compatabile, contain spatial reference information, and have invalid/valid data represented by 0/1, respectively. If 'Download', will use GSHHS water mask")
     parser.add_argument('-at', '--amp_thresh', dest='amp_thresh', default=None, type=str, help='Amplitude threshold below which to mask. Specify "None" to not use amplitude mask. By default "None".')
+    parser.add_argument('-nt', '--num_threads', dest='num_threads', default=2, type=str, help='Specify number of threads for multiprocessing operation in gdal. By default "2". Can also specify "All" to use all available threads.')
     parser.add_argument('-of', '--outputFormat', dest='outputFormat', type=str, default='ENVI', help='GDAL compatible output format (e.g., "ENVI", "GTiff"). By default files are generated with ENVI format.')
     parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection and bbox (if specified).")
     parser.add_argument('-plottracks', '--plottracks', action='store_true', dest='plottracks', help="Make plot of track latitude extents vs bounding bbox/common track extent.")
@@ -67,7 +68,7 @@ class plot_class:
     import warnings
     register_matplotlib_converters()
 
-    def __init__(self, product_dict, workdir='./', bbox_file=None, prods_TOTbbox=None, mask=None, outputFormat='ENVI', croptounion=False):
+    def __init__(self, product_dict, workdir='./', bbox_file=None, prods_TOTbbox=None, mask=None, outputFormat='ENVI', croptounion=False, num_threads='2'):
         # Pass inputs, and initialize list of pairs
         self.product_dict = product_dict
         self.bbox_file = bbox_file
@@ -78,6 +79,7 @@ class plot_class:
         self.mask = mask
         self.outputFormat = outputFormat
         self.croptounion = croptounion
+        self.num_threads = num_threads
         # File must be physically extracted, cannot proceed with VRT format. Defaulting to ENVI format.
         if  self.outputFormat=='VRT':
             self.outputFormat='ENVI'
@@ -301,20 +303,18 @@ class plot_class:
         # Iterate through all IFGs
         masters = []; slaves = []
         for i,j in enumerate(self.product_dict[0]):
-            coh_file=gdal.Warp('', j, options=gdal.WarpOptions(format="MEM", cutlineDSName=self.prods_TOTbbox, outputBounds=self.bbox_file))
-            coh_file_arr=np.ma.masked_where(coh_file.ReadAsArray() == coh_file.GetRasterBand(1).GetNoDataValue(), coh_file.ReadAsArray())
+            # Open coherence file
+            coh_file=gdal.Warp('', j, options=gdal.WarpOptions(format="MEM", cutlineDSName=self.prods_TOTbbox, outputBounds=self.bbox_file, resampleAlg='average', multithread=True, options=['NUM_THREADS=%s'%(self.num_threads)]))
 
             # Apply mask (if specified).
             if self.mask is not None:
-                coh_file_arr=np.ma.masked_where(self.mask == 0.0, coh_file_arr)
-
-            # Report mean
-            coh_val=coh_file_arr.mean()
+                coh_file.GetRasterBand(1).WriteArray(self.mask*coh_file.ReadAsArray())
 
             # Record average coherence val for histogram
-            coh_hist.append(coh_val)
+            coh_hist.append(coh_file.GetRasterBand(1).GetStatistics(0,1)[2])
             slaves.append(self.pd.to_datetime(self.product_dict[1][i][0][:8]))
             masters.append(self.pd.to_datetime(self.product_dict[1][i][0][9:]))
+            del coh_file
 
         # Plot average coherence per IFG
         cols, mapper = self._create_colors_coh(coh_hist)
@@ -374,28 +374,19 @@ class plot_class:
         outname=os.path.join(self.workdir,'avgcoherence{}'.format(self.mask_ext))
         #Delete existing average coherence file
         for i in glob.glob(os.path.join(self.workdir,'avgcoherence*')): os.remove(i)
-        # Iterate through all IFGs
-        for i,j in enumerate(self.product_dict[0]):
-            coh_file=gdal.Warp('', j, options=gdal.WarpOptions(format="MEM", cutlineDSName=self.prods_TOTbbox, outputBounds=self.bbox_file))
-            coh_file_arr=np.ma.masked_where(coh_file.ReadAsArray() == coh_file.GetRasterBand(1).GetNoDataValue(), coh_file.ReadAsArray())
 
-            # Apply mask (if specified).
-            if self.mask is not None:
-                coh_file_arr=np.ma.masked_where(self.mask == 0.0, coh_file_arr)
+        # building the VRT
+        gdal.BuildVRT(outname +'.vrt', self.product_dict[0], options=gdal.BuildVRTOptions(resolution='highest', resampleAlg='average'))
+        # taking average of all scenes and generating raster
+        gdal.Warp(outname, outname+'.vrt', options=gdal.WarpOptions(format=self.outputFormat, cutlineDSName=self.prods_TOTbbox, outputBounds=self.bbox_file, resampleAlg='average', multithread=True, options=['NUM_THREADS=%s'%(self.num_threads)]))
+        # Update VRT
+        gdal.Translate(outname+'.vrt', outname, options=gdal.TranslateOptions(format="VRT"))
 
-            # Iteratively update average coherence file
-            # If looping through first coherence file, nothing to sum so just save to file
-            if os.path.exists(outname):
-                coh_file=gdal.Open(outname,gdal.GA_Update)
-                coh_file=coh_file.GetRasterBand(1).WriteArray(coh_file_arr+coh_file.ReadAsArray())
-            else:
-                renderVRT(outname, coh_file_arr, geotrans=coh_file.GetGeoTransform(), drivername=self.outputFormat, gdal_fmt=coh_file_arr.dtype.name, proj=coh_file.GetProjection(), nodata=coh_file.GetRasterBand(1).GetNoDataValue())
-            coh_file = coh_val = coh_file_arr = None
-
-        # Take average of coherence sum
-        coh_file=gdal.Open(outname,gdal.GA_Update)
-        coh_file=coh_file.GetRasterBand(1).WriteArray(coh_file.ReadAsArray()/len(self.product_dict[0]))
-        coh_file = None
+        # Apply mask (if specified).
+        if self.mask is not None:
+            update_file=gdal.Open(outname,gdal.GA_Update)
+            update_file.GetRasterBand(1).WriteArray(self.mask*gdal.Open(outname+'.vrt').ReadAsArray())
+            del update_file
 
         return
 
@@ -437,19 +428,17 @@ class plot_class:
             slaves.append(self.pd.to_datetime(j[:8]))
             masters.append(self.pd.to_datetime(j[9:]))
             # Open coherence file
-            coh_file=gdal.Warp('', self.product_dict[2][i], options=gdal.WarpOptions(format="MEM", cutlineDSName=self.prods_TOTbbox, outputBounds=self.bbox_file))
-            coh_file_arr=np.ma.masked_where(coh_file.ReadAsArray() == coh_file.GetRasterBand(1).GetNoDataValue(), coh_file.ReadAsArray())
+            coh_file=gdal.Warp('', self.product_dict[2][i], options=gdal.WarpOptions(format="MEM", cutlineDSName=self.prods_TOTbbox, outputBounds=self.bbox_file, resampleAlg='average', multithread=True, options=['NUM_THREADS=%s'%(self.num_threads)]))
 
             # Apply mask (if specified).
             if self.mask is not None:
-                coh_file_arr=np.ma.masked_where(self.mask == 0.0, coh_file_arr)
+                coh_file.GetRasterBand(1).WriteArray(self.mask*coh_file.ReadAsArray())
 
-            # Report mean
-            coh_val=coh_file_arr.mean()
-            coh_vals.append(coh_val)
+            # Record average coherence val for histogram
+            coh_vals.append(coh_file.GetRasterBand(1).GetStatistics(0,1)[2])
             y1.append(offset_dict[j[9:]])
             y2.append(offset_dict[j[:8]])
-            coh_file = coh_file_arr = coh_val = None
+            del coh_file
 
         cols, mapper = self._create_colors_coh(coh_vals, 'autumn') # don't use hot
         ax.set_prop_cycle(color=cols)
@@ -534,6 +523,12 @@ def main(inps=None):
         inps.plotbperpcoh=True
         inps.makeavgoh=True
 
+    # pass number of threads for gdal multiprocessing computation
+    if inps.num_threads.lower()=='all':
+        import multiprocessing
+        print('User specified use of all %s threads for gdal multiprocessing'%(str(multiprocessing.cpu_count())))
+        inps.num_threads='ALL_CPUS'
+    print('Thread count specified for gdal multiprocessing = %s'%(inps.num_threads))
 
     if inps.plottracks or inps.plotcoh or inps.makeavgoh or inps.plotbperpcoh:
         # Import functions
@@ -545,7 +540,7 @@ def main(inps=None):
 
         # Load or download mask (if specified).
         if inps.mask is not None:
-            inps.mask = prep_mask(inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat)
+            inps.mask = prep_mask([[j['amplitude'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]],inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
 
     # Make spatial extent plot
@@ -565,14 +560,14 @@ def main(inps=None):
     # Make average land coherence plot
     if inps.plotcoh:
         print("- Make average IFG coherence plot in time, and histogram of average IFG coherence.")
-        make_plot=plot_class([[j['coherence'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, mask=inps.mask)
+        make_plot=plot_class([[j['coherence'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, mask=inps.mask, num_threads=inps.num_threads)
         make_plot.plot_coherence()
 
 
     # Generate average land coherence raster
     if inps.makeavgoh:
         print("- Generate 2D raster of average coherence.")
-        make_plot=plot_class([[j['coherence'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, mask=inps.mask, outputFormat=inps.outputFormat)
+        make_plot=plot_class([[item for sublist in [list(set(d['coherence'])) for d in standardproduct_info.products[1] if 'coherence' in d] for item in sublist], [item for sublist in [list(set(d['pair_name'])) for d in standardproduct_info.products[1] if 'pair_name' in d] for item in sublist]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, mask=inps.mask, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
         make_plot.plot_avgcoherence()
 
 

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -20,7 +20,7 @@ gdal.PushErrorHandler('CPLQuietErrorHandler')
 # Import functions
 from ARIAtools.ARIAProduct import ARIA_standardproduct
 from ARIAtools.shapefile_util import open_shapefile
-from ARIAtools.extractProduct import merged_productbbox, prep_dem, prep_mask, export_products, finalize_metadata
+from ARIAtools.extractProduct import merged_productbbox, prep_dem, prep_mask, export_products, finalize_metadata, tropo_correction
 
 
 def createParser():
@@ -32,6 +32,7 @@ def createParser():
     parser = argparse.ArgumentParser(description='Get DEM')
     parser.add_argument('-f', '--file', dest='imgfile', type=str, required=True, help='ARIA file')
     parser.add_argument('-w', '--workdir', dest='workdir', default='./', help='Specify directory to deposit all outputs. Default is local directory where script is launched.')
+    parser.add_argument('-tp', '--tropo_products', dest='tropo_products', type=str, default=None, help='Path to director(ies) or tar file(s) containing GACOS products.')
     parser.add_argument('-l', '--layers', dest='layers', default=None, help='Specify layers to extract as a comma deliminated list bounded by single quotes. Allowed keys are: "unwrappedPhase", "coherence", "amplitude", "bPerpendicular", "bParallel", "incidenceAngle", "lookAngle","azimuthAngle". If "all" is specified, then all layers are extracted. If blank, will only extract bounding box.')
     parser.add_argument('-d', '--demfile', dest='demfile', type=str, default='download', help='DEM file. Default is to download new DEM.')
     parser.add_argument('-p', '--projection', dest='projection', default='WGS84', type=str, help='projection for DEM. By default WGS84.')
@@ -277,6 +278,10 @@ def main(inps=None):
         if layers!=[]:
             print('Extracting optional, user-specified layers %s for each interferogram pair'%(layers))
             export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
+
+    # Perform GACOS-based tropospheric corrections (if specified).
+    if inps.tropo_products:
+        tropo_correction(standardproduct_info.products, inps.tropo_products, standardproduct_info.bbox_file, prods_TOTbbox, outDir=inps.workdir, outputFormat=inps.outputFormat, verbose=inps.verbose, num_threads=inps.num_threads)
 
     # Generate Stack
     generateStack(standardproduct_info,'unwrappedPhase','unwrapStack',workdir=inps.workdir)

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -38,6 +38,7 @@ def createParser():
     parser.add_argument('-b', '--bbox', dest='bbox', type=str, default=None, help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
     parser.add_argument('-m', '--mask', dest='mask', type=str, default=None, help="Path to mask file or 'Download'. File needs to be GDAL compatabile, contain spatial reference information, and have invalid/valid data represented by 0/1, respectively. If 'Download', will use GSHHS water mask")
     parser.add_argument('-at', '--amp_thresh', dest='amp_thresh', default=None, type=str, help='Amplitude threshold below which to mask. Specify "None" to not use amplitude mask. By default "None".')
+    parser.add_argument('-nt', '--num_threads', dest='num_threads', default=2, type=str, help='Specify number of threads for multiprocessing operation in gdal. By default "2". Can also specify "All" to use all available threads.')
 #    parser.add_argument('-sm', '--stitchMethod', dest='stitchMethodType',  type=str, default='overlap', help="Method applied to stitch the unwrapped data. Either 'overlap', where product overlap is minimized, or '2stage', where minimization is done on connected components, are allowed methods. Default is 'overlap'.")
     parser.add_argument('-of', '--outputFormat', dest='outputFormat', type=str, default='VRT', help='GDAL compatible output format (e.g., "ENVI", "GTiff"). By default files are generated virtually except for "bPerpendicular", "bParallel", "incidenceAngle", "lookAngle","azimuthAngle", "unwrappedPhase" as these are require either DEM intersection or corrections to be applied')
     parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection and bbox (if specified).")
@@ -227,33 +228,40 @@ def main(inps=None):
     # In addition, path to bbox file ['standardproduct_info.bbox_file'] (if bbox specified)
     standardproduct_info = ARIA_standardproduct(inps.imgfile, bbox=inps.bbox, workdir=inps.workdir, verbose=inps.verbose)
 
+    # pass number of threads for gdal multiprocessing computation
+    if inps.num_threads.lower()=='all':
+        import multiprocessing
+        print('User specified use of all %s threads for gdal multiprocessing'%(str(multiprocessing.cpu_count())))
+        inps.num_threads='ALL_CPUS'
+    print('Thread count specified for gdal multiprocessing = %s'%(inps.num_threads))
+
     # extract/merge productBoundingBox layers for each pair and update dict,
     # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-    standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion)
+    standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads)
 
     # Load or download mask (if specified).
     if inps.mask is not None:
-        inps.mask = prep_mask([[j['amplitude'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat)
+        inps.mask = prep_mask([[j['amplitude'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Download/Load DEM & Lat/Lon arrays, providing bbox, expected DEM shape, and output dir as input.
     if inps.demfile is not None:
         print('Download/cropping DEM')
         # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat)
+        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Extract
     layers=['unwrappedPhase','coherence']
     print('Extracting unwrapped phase, coherence, and connected components for each interferogram pair')
-    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose)
+    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
 
     layers=['incidenceAngle','lookAngle','azimuthAngle']
-    print('Extracting incidence angle, look angle and azimuth angle grids of the first interferogram pair')
-    export_products([standardproduct_info.products[1][0]], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose)
+    print('Extracting single incidence angle, look angle and azimuth angle files valid over common interferometric grid')
+    export_products([dict(zip([k for k in set(k for d in standardproduct_info.products[1] for k in d)], [[item for sublist in [list(set(d[k])) for d in standardproduct_info.products[1] if k in d] for item in sublist] for k in set(k for d in standardproduct_info.products[1] for k in d)]))], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
 
     if inps.bperp==True:
         layers=['bPerpendicular']
         print('Extracting perpendicular baseline grids for each interferogram pair')
-        export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose)
+        export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
 
     # Extracting other layers, if specified
     if inps.layers:
@@ -264,10 +272,11 @@ def main(inps=None):
         else:
             inps.layers=list(inps.layers.split(','))
             layers=[i for i in inps.layers if i not in ['unwrappedPhase','coherence','incidenceAngle','lookAngle','azimuthAngle','bPerpendicular']]
+            layers=[i.replace(' ','') for i in layers]
 
         if layers!=[]:
             print('Extracting optional, user-specified layers %s for each interferogram pair'%(layers))
-            export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose)
+            export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
 
     # Generate Stack
     generateStack(standardproduct_info,'unwrappedPhase','unwrapStack',workdir=inps.workdir)


### PR DESCRIPTION
Multithreading now supported. Average rasters now computed directly and efficiently through gdal warp. Multiple other miscellaneous changes:

1. Multithreading now supported for gdalwarp calls in "extractProduct.py" "tsSetup.py" and "productPlot.py". The -nt flag can be used specify number of threads used (by default 2, but the user can also specify "all" to use all available threads). 
2. Masks and DEMs now saved to separate subdirectories, and uncropped/cropped versions of each are saved. If a user launches another run later in the same workspace and doesn't use the cropped mask/DEM that had already been generated, the existing mask/DEM subdirectories are emptied.
3. Removed redundant specification of destination/source no-data value when downloading the DEM in the "prep_dem" function.
4. Now in the "prep_mask" function a user specifies a amplitude threshold to generate a water mask, the average amplitude raster is kept instead of being deleted.
5. Proposed update to Brett's request to pass amplitude layers from dictionary in "prep_mask" call in "productPlot.py".
6. Originally in "tsSetup.py", the single LOS grid generated corresponding to the first product in the stack may not encompass the entire extent of the track in the case the user specifies the "croptounion" option. Hence, an average LOS grid using all files is now passed. 
7. Finally computation of average coherence raster is simplified as averaging is handled directly through gdalwarp, not iteratively through a loop (which would produce errouneous mean estimates for "croptounion" cases).