### PR TITLE
Backport: DEM/mask bug-fixes/enhancements. Duplicate products now removed

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -226,7 +226,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         for i, j in enumerate(self.products[:-1]):
             # If scenes share >90% spatial overlap AND same dates, they MUST be duplicates. Reject the latter.
             if (self.products[i+1][0]['pair_name'][9:]==j[0]['pair_name'][9:]) and (self.products[i+1][0]['pair_name'][:8]==j[0]['pair_name'][:8]) and (open_shapefile(self.products[i+1][1]['productBoundingBox'], 'productBoundingBox', 1).intersection(open_shapefile(j[1]['productBoundingBox'], 'productBoundingBox', 1)).area)/(open_shapefile(j[1]['productBoundingBox'], 'productBoundingBox', 1).area)>0.9:
-                print("WARNING: Duplicate date captured. Rejecting scene %s"%(self.products[i+1][1]['unwrappedPhase'].split('"')[1]))
+                print("WARNING: Duplicate product captured. Rejecting scene %s"%(self.products[i+1][1]['unwrappedPhase'].split('"')[1]))
                 # Overwrite latter scene with former
                 self.products[i+1]=j
         # Delete duplicate products

--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -218,10 +218,6 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         sorted_products=[]
         track_rejected_pairs=[]
 
-        # If only one pair in list, add it to list.
-        if len(self.products)==1:
-            sorted_products.extend([[dict(zip(self.products[0][0].keys(), [list(a) for a in zip(self.products[0][0].values())])), dict(zip(self.products[0][1].keys(), [list(a) for a in zip(self.products[0][1].values())]))]])
-
         # Check for (and remove) duplicate products
         for i, j in enumerate(self.products[:-1]):
             # If scenes share >90% spatial overlap AND same dates, they MUST be duplicates. Reject the latter.
@@ -231,6 +227,10 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
                 self.products[i+1]=j
         # Delete duplicate products
         self.products=list(self.products for self.products,_ in itertools.groupby(self.products))
+
+        # If only one pair in list, add it to list.
+        if len(self.products)==1:
+            sorted_products.extend([[dict(zip(self.products[0][0].keys(), [list(a) for a in zip(self.products[0][0].values())])), dict(zip(self.products[0][1].keys(), [list(a) for a in zip(self.products[0][1].values())]))]])
 
         # If multiple pairs in list, cycle through and evaluate temporal connectivity.
         for i, j in enumerate(self.products[:-1]):


### PR DESCRIPTION
Bug-fixes/enchancements reflecting those introduced in dev commit #df72e26 (sands tropo):
1. Fixed bug in prep_dem/prep_mask which may lead to cropping inconsistent with interferometric grid when user provides custon DEM/mask.
2. In continuous_time, search for duplicate standard products, and then print warning and delete duplicate products from list.
3. Clean up sections where %overlap is computed for interferometric grid vs user bounding box in merged_productbbox