### PR TITLE
add environment.yml for conda create env

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ Below we outline the different steps for setting up the ARIA-tools while leverag
 
 ```
 git clone https://github.com/aria-tools/ARIA-tools.git
-conda config --add channels conda-forge
-conda create -n ARIA-tools --file ./ARIA-tools/requirements.txt --yes
+conda env create -f ./ARIA-tools/environment.yml
 conda activate ARIA-tools
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,28 @@
+# create environment : conda env create -f environment.yml
+# update dependencies: conda env update -f environment.yml
+# remove environment : conda env remove -n ARIA-tools
+# enter  environment : conda activate ARIA-tools
+# exit   environment : conda deactivate
+name: ARIA-tools
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.6
+  - cartopy
+  - gdal>=3.0
+  - hdf5
+  - joblib
+  - jupyterlab
+  - jupyter_contrib_nbextensions
+  - libgdal
+  - matplotlib
+  - netcdf4
+  - pandas
+  - pip
+  - requests
+  - rise
+  - shapely
+  - scipy
+  - pip:
+    - h5py


### PR DESCRIPTION
This PR 

+ adds environment.yml file to config the ARIA-tools conda environment, with pip install h5py, so that all dependencies of ARIA-tools and mintpy/prep_aria.py can be installed in one line command as the `ARIA-tools` environment.

+ updates README.md to use `conda env create` instead of `conda create -n`