### PR TITLE
Backport: Fix bug which unnecessarily deleted existing files.

### DIFF
--- a/tools/ARIAtools/productPlot.py
+++ b/tools/ARIAtools/productPlot.py
@@ -366,13 +366,7 @@ class plot_class:
         '''
             Generate average coherence raster.
         '''
-
-        # Import functions
-        import glob
-
         outname=os.path.join(self.workdir,'avgcoherence{}'.format(self.mask_ext))
-        #Delete existing average coherence file
-        for i in glob.glob(os.path.join(self.workdir,'avgcoherence*')): os.remove(i)
 
         # building the VRT
         gdal.BuildVRT(outname +'.vrt', self.product_dict[0], options=gdal.BuildVRTOptions(resolution='highest', resampleAlg='average'))


### PR DESCRIPTION
In the productPlot script, existing "avgcoherence*'" files were deleted before computing average coherence rasters. This is not necessary as existing files would be overwritten, plus this would have the unintended consequence of deleting other plots the user may wish to generate in the same command-line input. E.g. if the user ran "ariaPlot.py -f 'products/S1-*' -verbose -w test_plotseparate -nt 8 --plotcoh --plotbperpcoh --makeavgoh", the requested coherence plot will be deleted by this check.