### PR TITLE
Bug when date missing in tropo_correction.

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -44,7 +44,9 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         ### Determine if file input is single file, a list, or wildcard.
         # If list of files
         if len([str(val) for val in filearg.split(',')])>1:
-            self.files=[str(val) for val in filearg.split(',')]
+            self.files=[str(i) for i in filearg.split(',')]
+            # If wildcard
+            self.files=[os.path.abspath(item) for sublist in [self.glob.glob(os.path.expanduser(os.path.expandvars(i))) if '*' in i else [i] for i in self.files] for item in sublist]
         # If single file or wildcard
         else:
             # If single file
@@ -54,7 +56,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             else:
                 self.files=self.glob.glob(os.path.expanduser(os.path.expandvars(filearg)))
             # Convert relative paths to absolute paths
-            self.files=[os.path.normpath(os.path.join(os.getcwd(),i)) if not os.path.isabs(i) else i for i in self.files]
+            self.files=[os.path.abspath(i) for i in self.files]
         if len(self.files)==0:
             raise Exception('No file match found')
         # If specified workdir doesn't exist, create it

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -504,20 +504,22 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
         date_list.append(i[0][:8]); date_list.append(i[0][9:])
     date_list=list(set(date_list))
 
-    ### Determine if tropo input is single directory, a list, or wildcard.
-    # If list of directories/files
+    ### Determine if file input is single file, a list, or wildcard.
+    # If list of files
     if len([str(val) for val in tropo_products.split(',')])>1:
-        tropo_products=[str(val) for val in tropo_products.split(',')]
-    # If single directory or wildcard
+        tropo_products=[str(i) for i in tropo_products.split(',')]
+        # If wildcard
+        tropo_products=[os.path.abspath(item) for sublist in [glob.glob(os.path.expanduser(os.path.expandvars(i))) if '*' in i else [i] for i in tropo_products] for item in sublist]
+    # If single file or wildcard
     else:
-        # If single directory/file
-        if os.path.exists(tropo_products):
+        # If single file
+        if os.path.isfile(tropo_products):
             tropo_products=[tropo_products]
         # If wildcard
         else:
             tropo_products=glob.glob(os.path.expanduser(os.path.expandvars(tropo_products)))
         # Convert relative paths to absolute paths
-        tropo_products=[os.path.normpath(os.path.join(os.getcwd(),i)) if not os.path.isabs(i) else i for i in tropo_products]
+        tropo_products=[os.path.abspath(i) for i in tropo_products]
     if len(tropo_products)==0:
         raise Exception('No file match found')
 
@@ -559,7 +561,8 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             os.mkdir(os.path.join(outDir,'merged_GACOS'))
 
         for i in tropo_date_dict:
-            if 'UTC' not in i:
+            # only make rsc/vrt files if valid product
+            if 'UTC' not in i and tropo_date_dict[i]!=[]:
                 outname=os.path.join(outDir,'merged_GACOS',i+'.ztd.vrt')
                 # building the VRT
                 gdal.BuildVRT(outname, tropo_date_dict[i])


### PR DESCRIPTION
Fixed bug in tropo_products function where code attempted to generate vrt/rsc in cases where products are unavailable for a scene in a given IFG.

Also fixed bug in ARIAProducts and tropo_products where the code crashed if the user were to input relative paths for files.

Now a list of wildcard inputs supported (e.g. -f 'products/*20141123_20141030*,products/*20141217_20141123*'), or a mix of wildcard and individual files (e.g. -f 'products/*20141123_20141030*,products/*20141217_20141123*,products/S1-GUNW-A-R-014-tops-20141229_20141217-152722-15181N_13762N-PP-1692-v2_0_1.nc')