### PR TITLE
Downsampling routines and dropping of IFGs not meeting spatial percentage requirement

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -88,7 +88,7 @@ class InterpCube(object):
         est = interp1d(self.hgts, vals, kind='cubic')
         return est(h) + self.offset
 
-def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir='./', outputFormat='ENVI', num_threads='2', cell_resolution=None):
+def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir='./', outputFormat='ENVI', num_threads='2'):
     '''
         Function to load and export DEM, lat, lon arrays.
         If "Download" flag is specified, DEM will be donwloaded on the fly.
@@ -424,7 +424,6 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, arrshap
                         gdal.Warp(k+'tmp', k, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], resampleAlg='lanczos',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
                         # Update VRT
                         gdal.BuildVRT(k+'.vrt', k+'tmp')#, options=gdal.BuildVRTOptions(options=['-overwrite'])
-                        print('Built VRT')
 
                         # Apply mask (if specified).
                         if mask is not None:

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -412,6 +412,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, arrshap
                     outFileConnComp=os.path.join(outDir,'connectedComponents',product_dict[1][i[0]][0])
 
                     # calling the stitching methods
+                    print('Stitching')
                     if stitchMethodType == 'overlap':
                         product_stitch_overlap(unw_files,conn_files,prod_bbox_files,bounds,prods_TOTbbox, outFileUnw=outFileUnw,outFileConnComp=outFileConnComp,outputFormat = outputFormat,verbose=verbose)
                     elif stitchMethodType == '2stage':
@@ -419,9 +420,10 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, arrshap
 
                     # Updating output files to specified resolution
                     for k in [outFileUnw,outFileConnComp]:
-                        gdal.Warp(k, k+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
+                        # Temporarily copy to separate file
+                        gdal.Warp(k+'tmp', k, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], resampleAlg='lanczos',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
                         # Update VRT
-                        gdal.BuildVRT(k+'.vrt', k, options=gdal.BuildVRTOptions(options=['-overwrite']))
+                        gdal.BuildVRT(k+'.vrt', k+'tmp')#, options=gdal.BuildVRTOptions(options=['-overwrite'])
                         print('Built VRT')
 
                         # Apply mask (if specified).

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -42,7 +42,7 @@ def createParser():
     parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection and bbox (if specified).")
     parser.add_argument('-bp', '--bperp', action='store_true', dest='bperp', help="If turned on, extracts perpendicular baseline grids. Default: A single perpendicular baseline value is calculated and included in the metadata of stack cubes for each pair.")
     parser.add_argument('-verbose', '--verbose', action='store_true', dest='verbose', help="Toggle verbose mode on.")
-    parser.add_argument('-r', '--resolution', dest='cell_resolution', default=0.000833333333333, type=float, help='Pixel resolution in degrees. Default = 3 arcsec = 0.000833333333333 degrees.')
+    parser.add_argument('-r', '--resolution', dest='cell_resolution', default=None, type=float, help='Pixel resolution in degrees. Default = 3 arcsec = 0.000833333333333 degrees.') # 0.000833333333333
 
     return parser
 
@@ -253,8 +253,12 @@ def main(inps=None):
 
     # extract/merge productBoundingBox layers for each pair and update dict,
     # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-    print('Cell resolution: {}'.format(inps.cell_resolution))
-    standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, cell_resolution=inps.cell_resolution)
+    # if cell resolution is to be changed from default, this is where it is done
+    if inps.cell_resolution:
+        print('Cell resolution: {}'.format(inps.cell_resolution))
+        standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, cell_resolution=inps.cell_resolution)
+    else:
+        stardardproduct_into.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads)
 
     # Load or download mask (if specified).
     if inps.mask is not None:

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -42,7 +42,7 @@ def createParser():
     parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection and bbox (if specified).")
     parser.add_argument('-bp', '--bperp', action='store_true', dest='bperp', help="If turned on, extracts perpendicular baseline grids. Default: A single perpendicular baseline value is calculated and included in the metadata of stack cubes for each pair.")
     parser.add_argument('-verbose', '--verbose', action='store_true', dest='verbose', help="Toggle verbose mode on.")
-    parser.add_argument('-r', '--resolution', dest='cell_resolution', default=None, type=float, help='Pixel resolution in degrees. Default = 3 arcsec = 0.000833333333333 degrees.') # 0.000833333333333
+    parser.add_argument('-looks', '--looks', dest='looks', default=None, type=int, help='Number of looks to take. Default 1 pixel = 3 arcsec = 0.000833333333333 degrees.')
 
     return parser
 
@@ -253,12 +253,16 @@ def main(inps=None):
 
     # extract/merge productBoundingBox layers for each pair and update dict,
     # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-    # if cell resolution is to be changed from default, this is where it is done
-    if inps.cell_resolution:
-        print('Cell resolution: {}'.format(inps.cell_resolution))
-        standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, cell_resolution=inps.cell_resolution)
+    # if cell resolution is to be different from default, this is where that change should be specified
+    if inps.looks:
+        # convert number of looks to cell resolution
+        default_resolution=1/1200 # arcsec = 1/3600; default = 3/3600 = 1/1200
+        cell_resolution=inps.looks*default_resolution
+        print('Using {} looks - output cell resolution: {}'.format(inps.looks,cell_resolution))
     else:
-        stardardproduct_into.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads)
+        # do not attempt to change the resolution of any products
+        cell_resolution=None
+    standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, cell_resolution=cell_resolution)
 
     # Load or download mask (if specified).
     if inps.mask is not None:
@@ -271,21 +275,30 @@ def main(inps=None):
         inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Extract
+    # arrshape is an optional parameter for most export_products applications; to keep this optional,
+    #  use parameter "resampled_arrshape" that is None unless multilooking is used
+    if inps.looks:
+        resampled_arrshape=arrshape # use same shape as multilooked bbox and dem
+    else:
+        resampled_arrshape=None # no multilooking specified
+
     layers=['unwrappedPhase','coherence']
     print('\nExtracting unwrapped phase, coherence, and connected components for each interferogram pair')
-    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, arrshape=arrshape, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
+    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, arrshape=resampled_arrshape, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
 
     layers=['incidenceAngle','lookAngle','azimuthAngle']
     print('\nExtracting single incidence angle, look angle and azimuth angle files valid over common interferometric grid')
-    export_products([dict(zip([k for k in set(k for d in standardproduct_info.products[1] for k in d)], [[item for sublist in [list(set(d[k])) for d in standardproduct_info.products[1] if k in d] for item in sublist] for k in set(k for d in standardproduct_info.products[1] for k in d)]))], standardproduct_info.bbox_file, prods_TOTbbox, layers, arrshape=arrshape, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
+    export_products([dict(zip([k for k in set(k for d in standardproduct_info.products[1] for k in d)], [[item for sublist in [list(set(d[k])) for d in standardproduct_info.products[1] if k in d] for item in sublist] for k in set(k for d in standardproduct_info.products[1] for k in d)]))], standardproduct_info.bbox_file, prods_TOTbbox, layers, arrshape=resampled_arrshape, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
 
     if inps.bperp==True:
         layers=['bPerpendicular']
         print('\nExtracting perpendicular baseline grids for each interferogram pair')
-        export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, arrshape=arrshape, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
+        export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, arrshape=resampled_arrshape, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
 
     # Extracting other layers, if specified
+    ### RZ why are these specified here is they are also hardcoded above?
     if inps.layers:
+        # specify which layers
         if inps.layers.lower()=='all':
             inps.layers=list(standardproduct_info.products[1][0].keys())
             # Must also remove productBoundingBoxes & pair-names because they are not raster layers
@@ -297,7 +310,7 @@ def main(inps=None):
 
         if layers!=[]:
             print('\nExtracting optional, user-specified layers %s for each interferogram pair'%(layers))
-            export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, arrshape=arrshape, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
+            export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, arrshape=resampled_arrshape, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads)
 
     # Perform GACOS-based tropospheric corrections (if specified).
     if inps.tropo_products:


### PR DESCRIPTION
Hello all, 

I have incorporated a set of optional resampling routines in case the products need to be downsampled for timeseries creation. The modified scripts are tsSetup and extractProducts. 

I have tested these implementations on ARIA Track 41 data -- using the full dataset for the non-tropo-corrected products; and using a limited dataset for the tropo-corrected products. 

Could you please review these changes when you get the chance and let me know if these work for your system? 

Cheers,
Rob