### PR TITLE
Sss rankedresamplebeta

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -435,12 +435,11 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, dem=Non
 
                     #If necessary, resample both unw/conn_comp files
                     if multilooking is not None:
-                        resampleRaster(outFileUnw, multilooking, bounds, prods_TOTbbox, outputFormat=outputFormat, num_threads=num_threads)
                         resampleRaster(outFileConnComp, multilooking, bounds, prods_TOTbbox, outputFormat=outputFormat, num_threads=num_threads)
+
             #If necessary, resample raster
             if multilooking is not None and key!='unwrappedPhase' and key!='connectedComponents':
                 resampleRaster(outname, multilooking, bounds, prods_TOTbbox, outputFormat=outputFormat, num_threads=num_threads)
-                print("outname",outname)
 
         prog_bar.close()
     return

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -433,8 +433,13 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, dem=Non
                         product_stitch_overlap(unw_files,conn_files,prod_bbox_files,bounds,prods_TOTbbox, outFileUnw=outFileUnw,outFileConnComp= outFileConnComp, mask=mask,outputFormat = outputFormat,verbose=verbose)
                     elif stitchMethodType == '2stage':
                         product_stitch_2stage(unw_files,conn_files,bounds,prods_TOTbbox,outFileUnw=outFileUnw,outFileConnComp= outFileConnComp, mask=mask,outputFormat = outputFormat,verbose=verbose)
+                        
+                    #If necessary, resample both unw/conn_comp files
+                    if cellResolution is not None:
+                        resampleRaster(outFileUnw, cellResolution, bounds, prods_TOTbbox, outputFormat=outputFormat, num_threads=num_threads)
+                        resampleRaster(outFileConnComp, cellResolution, bounds, prods_TOTbbox, outputFormat=outputFormat, num_threads=num_threads)
             #If necessary, resample raster
-            if cellResolution is not None:
+            if cellResolution is not None and key!='unwrappedPhase' and key!='connectedComponents':
                 resampleRaster(outname, cellResolution, bounds, prods_TOTbbox, outputFormat=outputFormat, num_threads=num_threads)
 
         prog_bar.close()

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -433,7 +433,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, dem=Non
                         product_stitch_overlap(unw_files,conn_files,prod_bbox_files,bounds,prods_TOTbbox, outFileUnw=outFileUnw,outFileConnComp= outFileConnComp, mask=mask,outputFormat = outputFormat,verbose=verbose)
                     elif stitchMethodType == '2stage':
                         product_stitch_2stage(unw_files,conn_files,bounds,prods_TOTbbox,outFileUnw=outFileUnw,outFileConnComp= outFileConnComp, mask=mask,outputFormat = outputFormat,verbose=verbose)
-                        
+
                     #If necessary, resample both unw/conn_comp files
                     if cellResolution is not None:
                         resampleRaster(outFileUnw, cellResolution, bounds, prods_TOTbbox, outputFormat=outputFormat, num_threads=num_threads)

--- a/tools/ARIAtools/shapefile_util.py
+++ b/tools/ARIAtools/shapefile_util.py
@@ -63,6 +63,26 @@ def save_shapefile(fname, polygon, drivername):
 
     return
 
+def shapefile_area(file_bbox):
+    '''
+        Compute km\u00b2 area of shapefile.
+    '''
+
+    # import dependencies
+    from pyproj import Proj
+    from shapely.geometry import shape
+
+    #get coords
+    lon, lat=file_bbox.exterior.coords.xy
+
+    #use equal area projection centered on/bracketing AOI
+    pa = Proj("+proj=aea +lat_1=%f +lat_2=%f +lat_0=%f +lon_0=%f"%(min(lat),max(lat), (max(lat)+min(lat))/2, (max(lon)+min(lon))/2))
+    x, y = pa(lon, lat)
+    cop = {"type": "Polygon", "coordinates": [zip(x, y)]}
+    shape_area=shape(cop).area/1e6  # area in km^2
+
+    return shape_area
+
 def plot_shapefile(fname):
     import matplotlib.path as mpath
     import matplotlib.patches as mpatches

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -41,8 +41,8 @@ def createParser():
     parser.add_argument('-of', '--outputFormat', dest='outputFormat', type=str, default='VRT', help='GDAL compatible output format (e.g., "ENVI", "GTiff"). By default files are generated virtually except for "bPerpendicular", "bParallel", "incidenceAngle", "lookAngle","azimuthAngle", "unwrappedPhase" as these are require either DEM intersection or corrections to be applied')
     parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection and bbox (if specified).")
     parser.add_argument('-bp', '--bperp', action='store_true', dest='bperp', help="If turned on, extracts perpendicular baseline grids. Default: A single perpendicular baseline value is calculated and included in the metadata of stack cubes for each pair.")
-    parser.add_argument('-cr', '--cellResolution', dest='cellResolution', type=float, default=None, help='Resolution input WRT percentage of original dimensions. E.g. 50. = 50%%"')
-    parser.add_argument('-po', '--percentOverlap', dest='percentOverlap', type=float, default=5., help='Minimum percentage of overlap of scenes wrt specified bounding box. Default 5. = 5%%"')
+    parser.add_argument('-ml', '--multilooking', dest='multilooking', type=int, default=None, help='Multilooking factor is an integer multiple of standard resolution. E.g. 2 = 90m*2 = 180m')
+    parser.add_argument('-mo', '--minimumOverlap', dest='minimumOverlap', type=float, default=0.0081, help='Minimum km\u00b2 area of overlap of scenes wrt specified bounding box. Default 0.0081 = 0.0081km\u00b2 = area of single pixel at standard 90m resolution"')
     parser.add_argument('-verbose', '--verbose', action='store_true', dest='verbose', help="Toggle verbose mode on.")
 
     return parser
@@ -254,7 +254,7 @@ def main(inps=None):
 
     # extract/merge productBoundingBox layers for each pair and update dict,
     # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-    standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, percentOverlap=inps.percentOverlap)
+    standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap)
 
     # Load or download mask (if specified).
     if inps.mask is not None:
@@ -269,16 +269,16 @@ def main(inps=None):
     # Extract
     layers=['unwrappedPhase','coherence']
     print('\nExtracting unwrapped phase, coherence, and connected components for each interferogram pair')
-    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, cellResolution=inps.cellResolution)
+    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
 
     layers=['incidenceAngle','lookAngle','azimuthAngle']
     print('\nExtracting single incidence angle, look angle and azimuth angle files valid over common interferometric grid')
-    export_products([dict(zip([k for k in set(k for d in standardproduct_info.products[1] for k in d)], [[item for sublist in [list(set(d[k])) for d in standardproduct_info.products[1] if k in d] for item in sublist] for k in set(k for d in standardproduct_info.products[1] for k in d)]))], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, cellResolution=inps.cellResolution)
+    export_products([dict(zip([k for k in set(k for d in standardproduct_info.products[1] for k in d)], [[item for sublist in [list(set(d[k])) for d in standardproduct_info.products[1] if k in d] for item in sublist] for k in set(k for d in standardproduct_info.products[1] for k in d)]))], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
 
     if inps.bperp==True:
         layers=['bPerpendicular']
         print('\nExtracting perpendicular baseline grids for each interferogram pair')
-        export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, cellResolution=inps.cellResolution)
+        export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
 
     # Extracting other layers, if specified
     if inps.layers:
@@ -293,20 +293,20 @@ def main(inps=None):
 
         if layers!=[]:
             print('\nExtracting optional, user-specified layers %s for each interferogram pair'%(layers))
-            export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, cellResolution=inps.cellResolution)
+            export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
 
     # If necessary, resample DEM/mask AFTER they have been used to extract metadata layers and mask output layers, respectively
-    if inps.cellResolution is not None:
+    if inps.multilooking is not None:
         # Import functions
         from ARIAtools.shapefile_util import open_shapefile
         from ARIAtools.vrtmanager import resampleRaster
         bounds=open_shapefile(standardproduct_info.bbox_file, 0, 0).bounds
         # Resample mask
         if inps.mask is not None:
-            resampleRaster(inps.mask.GetDescription(), inps.cellResolution, bounds, prods_TOTbbox, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+            resampleRaster(inps.mask.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
         # Resample DEM
         if demfile is not None:
-            resampleRaster(demfile.GetDescription(), inps.cellResolution, bounds, prods_TOTbbox, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+            resampleRaster(demfile.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Perform GACOS-based tropospheric corrections (if specified).
     if inps.tropo_products:

--- a/tools/ARIAtools/unwrapStitching.py
+++ b/tools/ARIAtools/unwrapStitching.py
@@ -289,7 +289,10 @@ class Stitching:
         # Apply mask (if specified).
         if self.mask is not None:
             update_file=gdal.Open(self.outFileConnComp,gdal.GA_Update)
-            update_file=update_file.GetRasterBand(1).WriteArray(self.mask.ReadAsArray()*gdal.Open(self.outFileConnComp+'.vrt').ReadAsArray())
+            #mask value for conncomp must be set to nodata value -1
+            ma_update_file=np.ma.masked_where(self.mask.ReadAsArray() == 0., gdal.Open(self.outFileConnComp+'.vrt').ReadAsArray())
+            np.ma.set_fill_value(ma_update_file, update_file.GetRasterBand(1).GetNoDataValue())
+            update_file=update_file.GetRasterBand(1).WriteArray(ma_update_file.filled())
             update_file=None
 
         cmd = "gdal_translate -of png -scale -ot Byte -q " + self.outFileUnw + ".vrt " + self.outFileUnw + ".png"

--- a/tools/ARIAtools/unwrapStitching.py
+++ b/tools/ARIAtools/unwrapStitching.py
@@ -276,7 +276,7 @@ class Stitching:
         # Apply mask (if specified).
         if self.mask is not None:
             update_file=gdal.Open(self.outFileUnw,gdal.GA_Update)
-            update_file=update_file.GetRasterBand(1).WriteArray(self.mask*gdal.Open(self.outFileUnw+'.vrt').ReadAsArray())
+            update_file=update_file.GetRasterBand(1).WriteArray(self.mask.ReadAsArray()*gdal.Open(self.outFileUnw+'.vrt').ReadAsArray())
             update_file=None
 
         # remove existing output file(s)
@@ -289,7 +289,7 @@ class Stitching:
         # Apply mask (if specified).
         if self.mask is not None:
             update_file=gdal.Open(self.outFileConnComp,gdal.GA_Update)
-            update_file=update_file.GetRasterBand(1).WriteArray(self.mask*gdal.Open(self.outFileConnComp+'.vrt').ReadAsArray())
+            update_file=update_file.GetRasterBand(1).WriteArray(self.mask.ReadAsArray()*gdal.Open(self.outFileConnComp+'.vrt').ReadAsArray())
             update_file=None
 
         cmd = "gdal_translate -of png -scale -ot Byte -q " + self.outFileUnw + ".vrt " + self.outFileUnw + ".png"

--- a/tools/ARIAtools/vrtmanager.py
+++ b/tools/ARIAtools/vrtmanager.py
@@ -69,7 +69,7 @@ def renderOGRVRT(vrt_filename, src_datasets):
 
 
 ###Resample raster
-def resampleRaster(fname, cellResolution, bounds, prods_TOTbbox, outputFormat='ENVI', num_threads='2'):
+def resampleRaster(fname, multilooking, bounds, prods_TOTbbox, outputFormat='ENVI', num_threads='2'):
     '''
         Resample rasters and update corresponding VRTs.
     '''
@@ -79,7 +79,7 @@ def resampleRaster(fname, cellResolution, bounds, prods_TOTbbox, outputFormat='E
 
     # Access original shape
     ds=gdal.Warp('', fname, options=gdal.WarpOptions(format="MEM", outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
-    arrshape=[abs(ds.GetGeoTransform()[1])/(cellResolution/100.), abs(ds.GetGeoTransform()[-1])/(cellResolution/100.)] # Get output res
+    arrshape=[abs(ds.GetGeoTransform()[1])*multilooking, abs(ds.GetGeoTransform()[-1])*multilooking] # Get output res
 
     # Must resample mask/connected components files with nearest-neighbor
     if fname.split('/')[-2]=='mask' or fname.split('/')[-2]=='connectedComponents':

--- a/tools/ARIAtools/vrtmanager.py
+++ b/tools/ARIAtools/vrtmanager.py
@@ -79,17 +79,16 @@ def resampleRaster(fname, cellResolution, bounds, prods_TOTbbox, outputFormat='E
 
     # Access original shape
     ds=gdal.Warp('', fname, options=gdal.WarpOptions(format="MEM", outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
-    arrshape=[ds.RasterYSize, ds.RasterXSize] # Get shape of full res layers
-    arrshape=[int(i*(cellResolution/100.)) for i in arrshape]
+    arrshape=[abs(ds.GetGeoTransform()[1])/(cellResolution/100.), abs(ds.GetGeoTransform()[-1])/(cellResolution/100.)] # Get output res
 
     # Must resample mask/connected components files with nearest-neighbor
     if fname.split('/')[-2]=='mask' or fname.split('/')[-2]=='connectedComponents':
         # Resample raster
-        gdal.Warp(fname, fname, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], resampleAlg='near',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
+        gdal.Warp(fname, fname, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, xRes=arrshape[0], yRes=arrshape[1], resampleAlg='near',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
     # Resample all other files with lanczos
     else:
         # Resample raster
-        gdal.Warp(fname, fname, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], resampleAlg='lanczos',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
+        gdal.Warp(fname, fname, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, xRes=arrshape[0], yRes=arrshape[1], resampleAlg='lanczos',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
     # update VRT
     gdal.BuildVRT(fname+'.vrt', fname, options=gdal.BuildVRTOptions(options=['-overwrite']))
 

--- a/tools/ARIAtools/vrtmanager.py
+++ b/tools/ARIAtools/vrtmanager.py
@@ -75,7 +75,7 @@ def resampleRaster(fname, cellResolution, bounds, prods_TOTbbox, outputFormat='E
     '''
 
     if outputFormat=='VRT':
-       outputFormat='ENVI'
+        fname+='.vrt'
 
     # Access original shape
     ds=gdal.Warp('', fname, options=gdal.WarpOptions(format="MEM", outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
@@ -89,7 +89,9 @@ def resampleRaster(fname, cellResolution, bounds, prods_TOTbbox, outputFormat='E
     else:
         # Resample raster
         gdal.Warp(fname, fname, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, xRes=arrshape[0], yRes=arrshape[1], resampleAlg='lanczos',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
-    # update VRT
-    gdal.BuildVRT(fname+'.vrt', fname, options=gdal.BuildVRTOptions(options=['-overwrite']))
+
+    if outputFormat!='VRT':
+        # update VRT
+        gdal.BuildVRT(fname+'.vrt', fname, options=gdal.BuildVRTOptions(options=['-overwrite']))
 
     return

--- a/tools/ARIAtools/vrtmanager.py
+++ b/tools/ARIAtools/vrtmanager.py
@@ -83,6 +83,7 @@ def resampleRaster(fname, multilooking, bounds, prods_TOTbbox, outputFormat='ENV
     # Also get datasource name (inputname)
     if outputFormat=='VRT' and os.path.exists(fname.split('.vrt')[0]):
         outputFormat='ENVI'
+    if os.path.exists(fname.split('.vrt')[0]):
         inputname=fname
     else:
         fname+='.vrt'

--- a/tools/ARIAtools/vrtmanager.py
+++ b/tools/ARIAtools/vrtmanager.py
@@ -66,3 +66,31 @@ def renderOGRVRT(vrt_filename, src_datasets):
         vrt_write.write(vrt_tail)
 
     return
+
+
+###Resample raster
+def resampleRaster(fname, cellResolution, bounds, prods_TOTbbox, outputFormat='ENVI', num_threads='2'):
+    '''
+        Resample rasters and update corresponding VRTs.
+    '''
+
+    if outputFormat=='VRT':
+       outputFormat='ENVI'
+
+    # Access original shape
+    ds=gdal.Warp('', fname, options=gdal.WarpOptions(format="MEM", outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+    arrshape=[ds.RasterYSize, ds.RasterXSize] # Get shape of full res layers
+    arrshape=[int(i*(cellResolution/100.)) for i in arrshape]
+
+    # Must resample mask/connected components files with nearest-neighbor
+    if fname.split('/')[-2]=='mask' or fname.split('/')[-2]=='connectedComponents':
+        # Resample raster
+        gdal.Warp(fname, fname, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], resampleAlg='near',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
+    # Resample all other files with lanczos
+    else:
+        # Resample raster
+        gdal.Warp(fname, fname, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], resampleAlg='lanczos',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
+    # update VRT
+    gdal.BuildVRT(fname+'.vrt', fname, options=gdal.BuildVRTOptions(options=['-overwrite']))
+
+    return

--- a/tools/ARIAtools/vrtmanager.py
+++ b/tools/ARIAtools/vrtmanager.py
@@ -132,7 +132,7 @@ def resampleRaster(fname, multilooking, bounds, prods_TOTbbox, outputFormat='ENV
             concompmap.append(concompmap_row)
 
         #finalize arrays
-        unwmap=np.array(unwmap) 
+        unwmap=np.array(unwmap)
         unwmap=np.ma.masked_invalid(unwmap) ; np.ma.set_fill_value(unwmap, ds_unw_nodata)
         concompmap=np.array(concompmap)
         concompmap=np.ma.masked_where(concompmap == ds_concomp_nodata, concompmap) ; np.ma.set_fill_value(concompmap, ds_concomp_nodata)


### PR DESCRIPTION
Building off of commits from the "sss_resampleANDdownselection" branch, downsampling for unw phase is driven by the mode of the connected component pixels over the same corresponding window. E.g., if a user wishes to downsample by a factor of 2, in a given 2x2 connected component window of [[1,2],[2,1]] and corresponding unw phase window of [[3.4,5.0],[5.0,3.4]], the downsampled pixels will be mode(conn_comp)=1 and mean([3.4,3.4])=3.4, respectively.

Currently this pixel function is implemented in a loop, but in the long term it would be more efficient to directly take the mode of the conn_comp file through gdal and code an alternative way to resample the unw phase.