### PR TITLE
fix metadata bugs for tsSetup

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -107,7 +107,7 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir
 
     # File must be physically extracted, cannot proceed with VRT format. Defaulting to ENVI format.
     if outputFormat=='VRT':
-       outputFormat='ENVI'
+        outputFormat='ENVI'
 
     # Download DEM
     if demfilename.lower()=='download':
@@ -176,7 +176,7 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
 
     # File must be physically extracted, cannot proceed with VRT format. Defaulting to ENVI format.
     if outputFormat=='VRT':
-       outputFormat='ENVI'
+        outputFormat='ENVI'
 
     # Download mask
     if maskfilename.lower()=='download':

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -156,19 +156,19 @@ def generateStack(aria_prod,inputFiles,outputFileName,workdir='./'):
     ysize = ymax - ymin
 
     # extraction of radar meta-data
-    wavelength = aria_prod.products[0][0]['wavelength'][0].data
-    startRange = aria_prod.products[0][0]['slantRangeStart'][0].data
-    endRange = aria_prod.products[0][0]['slantRangeEnd'][0].data
-    rangeSpacing = aria_prod.products[0][0]['slantRangeSpacing'][0].data
+    wavelength = aria_prod.products[0][0]['wavelength'][0]
+    startRange = aria_prod.products[0][0]['slantRangeStart'][0]
+    endRange = aria_prod.products[0][0]['slantRangeEnd'][0]
+    rangeSpacing = aria_prod.products[0][0]['slantRangeSpacing'][0]
     orbitDirection = str.split(os.path.basename(aria_prod.files[0]),'-')[2]
 
     with open( os.path.join(workdir,'stack', (outputFileName+'.vrt')), 'w') as fid:
         fid.write( '''<VRTDataset rasterXSize="{xsize}" rasterYSize="{ysize}">
-        <SRS>{proj}</SRS>">
-        <GeoTransform>{GT0},{GT1},{GT2},{GT3},{GT4},{GT5}</GeoTransform>
-        '''.format(xsize=xsize, ysize=ysize,
-        proj=projection,
-        GT0=gt[0],GT1=gt[1],GT2=gt[2],GT3=gt[3],GT4=gt[4],GT5=gt[5]))
+        <SRS>{proj}</SRS>
+        <GeoTransform>{GT0},{GT1},{GT2},{GT3},{GT4},{GT5}</GeoTransform>\n'''.format(
+            xsize=xsize, ysize=ysize,
+            proj=projection,
+            GT0=gt[0],GT1=gt[1],GT2=gt[2],GT3=gt[3],GT4=gt[4],GT5=gt[5]))
 
         for data in enumerate(Dlist):
             metadata = {}


### PR DESCRIPTION
This PR includes the following changes:

1. remote `.data` while asigning the following metadata, otherwise it results in `<memory at >` instead of the real number:
- wavelength
- startRange
- endRange
- rangeSpacing

2. remove unnecessary "> in SRS in the beginging of xml file

3. add line break at the end of <GeoTransform>