### PR TITLE
Solid Earth tide corrections implemented

### DIFF
--- a/solidearth_code/solid_grid.f
+++ b/solidearth_code/solid_grid.f
@@ -1,0 +1,1613 @@
+      subroutine solidwrapped(iyr,imo,idy,ihh,imm,iss,glad1,glod1,
+     *                        glad2,glod2,steplon,steplat,increm,myfile)
+
+*** will compute 1 year of tide at given location starting at date hour 
+*** driver to test solid earth tide
+*** UTC version
+
+      implicit double precision(a-h,o-z), CHARACTER*512(m) 
+      dimension rsun(3),rmoon(3),etide(3),xsta(3)
+      logical lflag                    
+      !***^ leap second table limit flag
+      common/stuff/rad,pi,pi2
+      common/comgrs/a,e2
+
+*** constants
+
+      pi=4.d0*datan(1.d0)
+      pi2=pi+pi
+      rad=180.d0/pi
+
+*** grs80
+
+      a=6378137.d0
+      e2=6.69438002290341574957d-03
+
+      lout=1
+      open(lout,file=myfile,form='formatted',status='unknown')
+
+*** input section
+
+      if(iyr.lt.1901.or.iyr.gt.2099) then
+        write(*,'(*(i5,:,","))') 'error with input year=',iyr
+        go to 98
+      endif
+
+      if(imo.lt.1.or.imo.gt.12) then
+        write(*,'(*(i5,:,","))') 'error with input month=',imo
+        go to 98
+      endif
+
+      if(idy.lt.1.or.idy.gt.31) then
+        write(*,'(*(i5,:,","))') 'error with input day=',idy
+        go to 98
+      endif
+
+      if(ihh.gt.24) then
+        write(*,'(*(i5,:,","))') 'error with input hour=',ihh
+        go to 98
+      endif
+
+      if(imm.gt.60) then
+        write(*,'(*(i5,:,","))') 'error with input minute=',imm
+        go to 98
+      endif
+
+      if(iss.gt.60) then
+        write(*,'(*(i5,:,","))') 'error with input second=',iss
+        go to 98
+      endif
+
+      if(glad1.lt.-90.d0.or.glad1.gt.90.d0) then
+        write(*,'(*(G0.9,:,","))') 'error with input minlat=',glad1
+        go to 98
+      endif
+
+      if(glod1.lt.-360.d0.or.glod1.gt.360.d0) then
+        write(*,'(*(G0.9,:,","))') 'error with input minlon=',glod1
+        go to 98
+      endif
+
+      if(glad2.lt.-90.d0.or.glad2.gt.90.d0) then
+        write(*,'(*(G0.9,:,","))') 'error with input maxlat=',glad2
+        go to 98
+      endif
+
+      if(glod2.lt.-360.d0.or.glod2.gt.360.d0) then
+        write(*,'(*(G0.9,:,","))') 'error with input maxlon=',glod2
+        go to 98
+      endif
+
+*** header
+
+      write(lout,'(a,i5,2i3)') 'year/month/day= ',iyr,imo,idy
+      write(lout,'(a,i5,2i3)') 'hour/minute/second= ',ihh,imm,iss
+      write(lout,'(*(G0.9:," "))') 'steplon/steplat= ',steplon,steplat
+      write(lout,'(a)') 'lon,lat,ut,vt,wt'
+
+
+      nlat=((glad2-glad1)/steplat)                              
+      !***^ 10 grid points per degree
+      nlon=((glod2-glod1)/steplon)
+
+      do ilat=0,nlat,increm
+        do ilon=0,nlon,increm
+
+        glad=glad1+ilat*steplat
+        glod=glod1+ilon*steplon
+
+
+*** position of observing point (positive East)
+
+        if(glod.lt.  0.d0) glod=glod+360.d0
+        if(glod.ge.360.d0) glod=glod-360.d0
+
+        gla0=glad/rad
+        glo0=glod/rad
+        eht0=0.d0
+        call geoxyz(gla0,glo0,eht0,x0,y0,z0)
+        xsta(1)=x0
+        xsta(2)=y0
+        xsta(3)=z0
+
+
+*** here comes the sun  (and the moon)  (go, tide!)
+
+        ihr=   ihh
+        imn=   imm
+        sec=   iss                                       
+      !***^ UTC time system
+        call civmjd(iyr,imo,idy,ihr,imn,sec,mjd,fmjd)
+        call mjdciv(mjd,fmjd,iyr,imo,idy,ihr,imn,sec)    
+      !***^ normalize civil time
+        call setjd0(iyr,imo,idy)
+
+        lflag=.false.                                  
+      !***^ false means flag not raised
+        call sunxyz (mjd,fmjd,rsun,lflag)                   
+      !***^ mjd/fmjd in UTC
+        call moonxyz(mjd,fmjd,rmoon,lflag)                  
+      !***^ mjd/fmjd in UTC
+        call detide (xsta,mjd,fmjd,rsun,rmoon,etide,lflag)  
+      !***^ mjd/fmjd in UTC
+        xt = etide(1)
+        yt = etide(2)
+        zt = etide(3)
+
+*** determine local geodetic horizon components (topocentric)
+
+        call rge(gla0,glo0,ut,vt,wt,xt,   yt,   zt)       
+      !***^ tide vector
+
+        call mjdciv(mjd,fmjd               +0.001d0/86400.d0,
+     *              iyr,imo,idy,ihr,imn,sec-0.001d0)
+
+        write(lout,'(*(G0.9,:,","))') glod,glad,ut,vt,wt
+
+        enddo
+      enddo
+
+*** test flag and end of processing
+
+      if(lflag) then
+        write(*,'(a)') 'Mild Warning -- time crossed leap second table'
+        write(*,'(a)') '  boundaries.  Boundary edge value used instead'
+      endif
+
+      go to 99
+   98 write(*,'(a)') 'Check arguments ' 
+
+      return
+   99 end
+
+*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+      subroutine detide(xsta,mjd,fmjd,xsun,xmon,dxtide,lflag)
+
+*** computation of tidal corrections of station displacements caused
+***    by lunar and solar gravitational attraction
+*** UTC version
+
+*** step 1 (here general degree 2 and 3 corrections +
+***         call st1idiu + call st1isem + call st1l1)
+***   + step 2 (call step2diu + call step2lon + call step2idiu)
+*** it has been decided that the step 3 un-correction for permanent tide
+*** would *not* be applied in order to avoid jump in the reference frame
+*** (this step 3 must added in order to get the mean tide station position
+*** and to be conformed with the iag resolution.)
+
+*** inputs
+***   xsta(i),i=1,2,3   -- geocentric position of the station (ITRF/ECEF)
+***   xsun(i),i=1,2,3   -- geoc. position of the sun (ECEF)
+***   xmon(i),i=1,2,3   -- geoc. position of the moon (ECEF)
+***   mjd,fmjd          -- modified julian day (and fraction) (in UTC time)
+
+****old calling sequence*****************************************************
+***   dmjd               -- time in mean julian date (including day fraction)
+***   fhr=hr+zmin/60.+sec/3600.   -- hr in the day
+
+*** outputs
+***   dxtide(i),i=1,2,3  -- displacement vector (ITRF)
+***   lflag              -- leap second table limit flag, false:flag not raised
+
+*** author iers 1996 :  v. dehant, s. mathews and j. gipson
+***    (test between two subroutines)
+*** author iers 2000 :  v. dehant, c. bruyninx and s. mathews
+***    (test in the bernese program by c. bruyninx)
+
+*** created:  96/03/23 (see above)
+*** modified from dehanttideinelMJD.f by Dennis Milbert 2006sep10
+*** bug fix regarding fhr (changed calling sequence, too)
+*** modified to reflect table 7.5a and b IERS Conventions 2003
+*** modified to use TT time system to call step 2 functions
+*** sign correction by V.Dehant to match eq.16b, p.81, Conventions
+*** applied by Dennis Milbert 2007may05
+*** UTC version by Dennis Milbert 2018june01
+
+      implicit double precision(a-h,o-z)
+      double precision xsta(3),xsun(3),xmon(3),dxtide(3),xcorsta(3)
+      double precision h20,l20,h3,l3,h2,l2
+      double precision mass_ratio_sun,mass_ratio_moon
+      logical lflag,leapflag
+      save  /limitflag/                
+      !***^ leap second table limit flag
+      common/limitflag/leapflag        
+      !***^ leap second table limit flag
+
+*** nominal second degree and third degree love numbers and shida numbers
+
+      data h20/0.6078d0/,l20/0.0847d0/,h3/0.292d0/,l3/0.015d0/
+
+*** internal support for new calling sequence
+*** first, convert UTC time into TT time (and, bring leapflag into variable)
+
+      leapflag=lflag
+      tsecutc =fmjd*86400.d0                       
+      !***^ UTC time (sec of day)
+      tsectt  =utc2ttt(tsecutc)                    
+      !***^ TT  time (sec of day)
+      fmjdtt  =tsectt/86400.d0                     
+      !***^ TT  time (fract. day)
+      lflag   = leapflag
+
+      dmjdtt=mjd+fmjdtt                           
+      !***^ float MJD in TT
+*** commented line was live code in dehanttideinelMJD.f
+*** changed on the suggestion of Dr. Don Kim, UNB -- 09mar21
+*** Julian date for 2000 January 1 00:00:00.0 UT is  JD 2451544.5
+*** MJD         for 2000 January 1 00:00:00.0 UT is MJD   51544.0
+***** t=(dmjdtt-51545.d0)/36525.d0                
+      !***^ days to centuries, TT
+      t=(dmjdtt-51544.d0)/36525.d0                
+      !***^ days to centuries, TT
+      fhr=(dmjdtt-int(dmjdtt))*24.d0              
+      !***^ hours in the day, TT
+
+*** scalar product of station vector with sun/moon vector
+
+      call sprod(xsta,xsun,scs,rsta,rsun)
+      call sprod(xsta,xmon,scm,rsta,rmon)
+      scsun=scs/rsta/rsun
+      scmon=scm/rsta/rmon
+
+*** computation of new h2 and l2
+
+      cosphi=dsqrt(xsta(1)*xsta(1) + xsta(2)*xsta(2))/rsta
+      h2=h20-0.0006d0*(1.d0-3.d0/2.d0*cosphi*cosphi)
+      l2=l20+0.0002d0*(1.d0-3.d0/2.d0*cosphi*cosphi)
+
+*** p2-term
+
+      p2sun=3.d0*(h2/2.d0-l2)*scsun*scsun-h2/2.d0
+      p2mon=3.d0*(h2/2.d0-l2)*scmon*scmon-h2/2.d0
+
+*** p3-term
+
+      p3sun=5.d0/2.d0*(h3-3.d0*l3)*scsun**3+3.d0/2.d0*(l3-h3)*scsun
+      p3mon=5.d0/2.d0*(h3-3.d0*l3)*scmon**3+3.d0/2.d0*(l3-h3)*scmon
+
+*** term in direction of sun/moon vector
+
+      x2sun=3.d0*l2*scsun
+      x2mon=3.d0*l2*scmon
+      x3sun=3.d0*l3/2.d0*(5.d0*scsun*scsun-1.d0)
+      x3mon=3.d0*l3/2.d0*(5.d0*scmon*scmon-1.d0)
+
+*** factors for sun/moon
+
+      mass_ratio_sun=332945.943062d0
+      mass_ratio_moon=0.012300034d0
+      re =6378136.55d0
+      fac2sun=mass_ratio_sun*re*(re/rsun)**3
+      fac2mon=mass_ratio_moon*re*(re/rmon)**3
+      fac3sun=fac2sun*(re/rsun)
+      fac3mon=fac2mon*(re/rmon)
+
+*** total displacement
+
+      do i=1,3
+        dxtide(i)=fac2sun*( x2sun*xsun(i)/rsun + p2sun*xsta(i)/rsta ) +
+     *            fac2mon*( x2mon*xmon(i)/rmon + p2mon*xsta(i)/rsta ) +
+     *            fac3sun*( x3sun*xsun(i)/rsun + p3sun*xsta(i)/rsta ) +
+     *            fac3mon*( x3mon*xmon(i)/rmon + p3mon*xsta(i)/rsta )
+      enddo
+      call zero_vec8(xcorsta)
+
+*** corrections for the out-of-phase part of love numbers
+***     (part h_2^(0)i and l_2^(0)i )
+
+*** first, for the diurnal band
+
+      call st1idiu(xsta,xsun,xmon,fac2sun,fac2mon,xcorsta)
+      dxtide(1)=dxtide(1)+xcorsta(1)
+      dxtide(2)=dxtide(2)+xcorsta(2)
+      dxtide(3)=dxtide(3)+xcorsta(3)
+
+*** second, for the semi-diurnal band
+
+      call st1isem(xsta,xsun,xmon,fac2sun,fac2mon,xcorsta)
+      dxtide(1)=dxtide(1)+xcorsta(1)
+      dxtide(2)=dxtide(2)+xcorsta(2)
+      dxtide(3)=dxtide(3)+xcorsta(3)
+
+*** corrections for the latitude dependence of love numbers (part l^(1) )
+
+      call st1l1(xsta,xsun,xmon,fac2sun,fac2mon,xcorsta)
+      dxtide(1)=dxtide(1)+xcorsta(1)
+      dxtide(2)=dxtide(2)+xcorsta(2)
+      dxtide(3)=dxtide(3)+xcorsta(3)
+
+*** consider corrections for step 2
+*** corrections for the diurnal band:
+
+***  first, we need to know the date converted in julian centuries
+
+***  this is now handled at top of code   (also convert to TT time system)
+***** t=(dmjd-51545.)/36525.
+***** fhr=dmjd-int(dmjd)             
+      !***^ this is/was a buggy line (day vs. hr)
+
+***  second, the diurnal band corrections,
+***   (in-phase and out-of-phase frequency dependence):
+
+      call step2diu(xsta,fhr,t,xcorsta)
+      dxtide(1)=dxtide(1)+xcorsta(1)
+      dxtide(2)=dxtide(2)+xcorsta(2)
+      dxtide(3)=dxtide(3)+xcorsta(3)
+
+***  corrections for the long-period band,
+***   (in-phase and out-of-phase frequency dependence):
+
+      call step2lon(xsta,fhr,t,xcorsta)
+      dxtide(1)=dxtide(1)+xcorsta(1)
+      dxtide(2)=dxtide(2)+xcorsta(2)
+      dxtide(3)=dxtide(3)+xcorsta(3)
+
+*** consider corrections for step 3
+*-----------------------------------------------------------------------
+* The code below is commented to prevent restoring deformation
+* due to permanent tide.  All the code above removes
+* total tidal deformation with conventional Love numbers.
+* The code above realizes a conventional tide free crust (i.e. ITRF). 
+* This does NOT conform to Resolution 16 of the 18th General Assembly
+* of the IAG (1983).  This resolution has not been implemented by 
+* the space geodesy community in general (c.f. IERS Conventions 2003).
+*-----------------------------------------------------------------------
+
+*** uncorrect for the permanent tide  (only if you want mean tide system)
+
+***   pi=3.141592654
+***   sinphi=xsta(3)/rsta
+***   cosphi=dsqrt(xsta(1)**2+xsta(2)**2)/rsta
+***   cosla=xsta(1)/cosphi/rsta
+***   sinla=xsta(2)/cosphi/rsta
+***   dr=-dsqrt(5./4./pi)*h2*0.31460*(3./2.*sinphi**2-0.5)
+***   dn=-dsqrt(5./4./pi)*l2*0.31460*3.*cosphi*sinphi
+***   dxtide(1)=dxtide(1)-dr*cosla*cosphi+dn*cosla*sinphi
+***   dxtide(2)=dxtide(2)-dr*sinla*cosphi+dn*sinla*sinphi
+***   dxtide(3)=dxtide(3)-dr*sinphi      -dn*cosphi
+
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine st1l1(xsta,xsun,xmon,fac2sun,fac2mon,xcorsta)
+
+*** this subroutine gives the corrections induced by the latitude dependence
+*** given by l^(1) in mahtews et al (1991)
+
+***  input: xsta,xsun,xmon,fac3sun,fac3mon
+*** output: xcorsta
+
+      implicit double precision (a-h,o-z)
+      dimension xsta(3),xsun(3),xmon(3),xcorsta(3)
+      double precision l1,l1d,l1sd
+      data l1d/0.0012d0/,l1sd/0.0024d0/
+
+      rsta=enorm8(xsta)
+      sinphi=xsta(3)/rsta
+      cosphi=dsqrt(xsta(1)**2+xsta(2)**2)/rsta
+      sinla=xsta(2)/cosphi/rsta
+      cosla=xsta(1)/cosphi/rsta
+      rmon=enorm8(xmon)
+      rsun=enorm8(xsun)
+
+*** for the diurnal band
+
+      l1=l1d
+      dnsun=-l1*sinphi**2*fac2sun*xsun(3)*(xsun(1)*cosla+xsun(2)*sinla)
+     *            /rsun**2
+      dnmon=-l1*sinphi**2*fac2mon*xmon(3)*(xmon(1)*cosla+xmon(2)*sinla)
+     *            /rmon**2
+      desun=l1*sinphi*(cosphi**2-sinphi**2)*fac2sun*xsun(3)*
+     * (xsun(1)*sinla-xsun(2)*cosla)/rsun**2
+      demon=l1*sinphi*(cosphi**2-sinphi**2)*fac2mon*xmon(3)*
+     * (xmon(1)*sinla-xmon(2)*cosla)/rmon**2
+      de=3.d0*(desun+demon)
+      dn=3.d0*(dnsun+dnmon)
+      xcorsta(1)=-de*sinla-dn*sinphi*cosla
+      xcorsta(2)= de*cosla-dn*sinphi*sinla
+      xcorsta(3)=          dn*cosphi
+
+*** for the semi-diurnal band
+
+      l1=l1sd
+      costwola=cosla**2-sinla**2
+      sintwola=2.d0*cosla*sinla
+      dnsun=-l1/2.d0*sinphi*cosphi*fac2sun*((xsun(1)**2-xsun(2)**2)*
+     * costwola+2.d0*xsun(1)*xsun(2)*sintwola)/rsun**2
+      dnmon=-l1/2.d0*sinphi*cosphi*fac2mon*((xmon(1)**2-xmon(2)**2)*
+     * costwola+2.d0*xmon(1)*xmon(2)*sintwola)/rmon**2
+      desun=-l1/2.d0*sinphi**2*cosphi*fac2sun*((xsun(1)**2-xsun(2)**2)*
+     * sintwola-2.d0*xsun(1)*xsun(2)*costwola)/rsun**2
+      demon=-l1/2.d0*sinphi**2*cosphi*fac2mon*((xmon(1)**2-xmon(2)**2)*
+     * sintwola-2.d0*xmon(1)*xmon(2)*costwola)/rmon**2
+      de=3.d0*(desun+demon)
+      dn=3.d0*(dnsun+dnmon)
+      xcorsta(1)=xcorsta(1)-de*sinla-dn*sinphi*cosla
+      xcorsta(2)=xcorsta(2)+de*cosla-dn*sinphi*sinla
+      xcorsta(3)=xcorsta(3)         +dn*cosphi
+
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine step2diu(xsta,fhr,t,xcorsta)
+
+*** last change:  vd   17 may 00   1:20 pm
+*** these are the subroutines for the step2 of the tidal corrections.
+*** they are called to account for the frequency dependence
+*** of the love numbers.
+
+      implicit double precision (a-h,o-z)
+      double precision xsta(3),xcorsta(3),datdi(9,31)
+      double precision deg2rad
+      data deg2rad/0.017453292519943295769d0/
+
+*** note, following table is derived from dehanttideinelMJD.f (2000oct30 16:10)
+*** has minor differences from that of dehanttideinel.f (2000apr17 14:10)
+*** D.M. edited to strictly follow published table 7.5a (2006aug08 13:46)
+
+*** cf. table 7.5a of IERS conventions 2003 (TN.32, pg.82)
+*** columns are s,h,p,N',ps, dR(ip),dR(op),dT(ip),dT(op)
+*** units of mm
+
+      data ((datdi(i,j),i=1,9),j=1,31)/
+     * -3., 0., 2., 0., 0.,-0.01,-0.01, 0.0 , 0.0,
+     * -3., 2., 0., 0., 0.,-0.01,-0.01, 0.0 , 0.0,
+     * -2., 0., 1.,-1., 0.,-0.02,-0.01, 0.0 , 0.0,
+*****-----------------------------------------------------------------------
+****** -2., 0., 1., 0., 0.,-0.08,-0.05, 0.01,-0.02,      
+      !***^ original entry
+     * -2., 0., 1., 0., 0.,-0.08, 0.00, 0.01, 0.01,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+     * -2., 2.,-1., 0., 0.,-0.02,-0.01, 0.0 , 0.0,
+*****-----------------------------------------------------------------------
+****** -1., 0., 0.,-1., 0.,-0.10,-0.05, 0.0 ,-0.02,      
+      !***^ original entry
+     * -1., 0., 0.,-1., 0.,-0.10, 0.00, 0.00, 0.00,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+****** -1., 0., 0., 0., 0.,-0.51,-0.26,-0.02,-0.12,      
+      !***^ original entry
+     * -1., 0., 0., 0., 0.,-0.51, 0.00,-0.02, 0.03,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+     * -1., 2., 0., 0., 0., 0.01, 0.0 , 0.0 , 0.0,
+     *  0.,-2., 1., 0., 0., 0.01, 0.0 , 0.0 , 0.0,
+     *  0., 0.,-1., 0., 0., 0.02, 0.01, 0.0 , 0.0,
+*****-----------------------------------------------------------------------
+******  0., 0., 1., 0., 0., 0.06, 0.02, 0.0 , 0.01,      
+      !***^ original entry
+     *  0., 0., 1., 0., 0., 0.06, 0.00, 0.00, 0.00,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+     *  0., 0., 1., 1., 0., 0.01, 0.0 , 0.0 , 0.0,
+     *  0., 2.,-1., 0., 0., 0.01, 0.0 , 0.0 , 0.0,
+     *  1.,-3., 0., 0., 1.,-0.06, 0.00, 0.00, 0.00,      
+      !***^ table 7.5a
+     *  1.,-2., 0., 1., 0., 0.01, 0.0 , 0.0 , 0.0,
+*****-----------------------------------------------------------------------
+******  1.,-2., 0., 0., 0.,-1.23,-0.05, 0.06,-0.06,      
+      !***^ original entry
+     *  1.,-2., 0., 0., 0.,-1.23,-0.07, 0.06, 0.01,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+     *  1.,-1., 0., 0.,-1., 0.02, 0.0 , 0.0 , 0.0,
+     *  1.,-1., 0., 0., 1., 0.04, 0.0 , 0.0 , 0.0,
+     *  1., 0., 0.,-1., 0.,-0.22, 0.01, 0.01, 0.00,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+******  1., 0., 0., 0., 0.,12.02,-0.45,-0.66, 0.17,      
+      !***^ original entry
+     *  1., 0., 0., 0., 0.,12.00,-0.78,-0.67,-0.03,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+******  1., 0., 0., 1., 0., 1.73,-0.07,-0.10, 0.02,      
+      !***^ original entry
+     *  1., 0., 0., 1., 0., 1.73,-0.12,-0.10, 0.00,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+     *  1., 0., 0., 2., 0.,-0.04, 0.0 , 0.0 , 0.0,
+*****-----------------------------------------------------------------------
+******  1., 1., 0., 0.,-1.,-0.50, 0.0 , 0.03, 0.0,       
+      !***^ original entry
+     *  1., 1., 0., 0.,-1.,-0.50,-0.01, 0.03, 0.00,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+     *  1., 1., 0., 0., 1., 0.01, 0.0 , 0.0 , 0.0,
+*****-----------------------------------------------------------------------
+******  0., 1., 0., 1.,-1.,-0.01, 0.0 , 0.0 , 0.0,       
+      !***^ original entry
+     *  1., 1., 0., 1.,-1.,-0.01, 0.0 , 0.0 , 0.0,       
+      !***^ v.dehant 2007
+*****-----------------------------------------------------------------------
+     *  1., 2.,-2., 0., 0.,-0.01, 0.0 , 0.0 , 0.0,
+*****-----------------------------------------------------------------------
+******  1., 2., 0., 0., 0.,-0.12, 0.01, 0.01, 0.0,       
+      !***^ original entry
+     *  1., 2., 0., 0., 0.,-0.11, 0.01, 0.01, 0.00,      
+      !***^ table 7.5a
+*****-----------------------------------------------------------------------
+     *  2.,-2., 1., 0., 0.,-0.01, 0.0 , 0.0 , 0.0,
+     *  2., 0.,-1., 0., 0.,-0.02, 0.02, 0.0 , 0.01,
+     *  3., 0., 0., 0., 0., 0.0 , 0.01, 0.0 , 0.01,
+     *  3., 0., 0., 1., 0., 0.0 , 0.01, 0.0 , 0.0/
+
+      s=218.31664563d0+481267.88194d0*t-0.0014663889d0*t*t
+     * +0.00000185139d0*t**3
+      tau=fhr*15.d0+280.4606184d0+36000.7700536d0*t+0.00038793d0*t*t
+     * -0.0000000258d0*t**3-s
+      pr=1.396971278*t+0.000308889*t*t+0.000000021*t**3
+     * +0.000000007*t**4
+      s=s+pr
+      h=280.46645d0+36000.7697489d0*t+0.00030322222d0*t*t
+     * +0.000000020*t**3-0.00000000654*t**4
+      p=83.35324312d0+4069.01363525d0*t-0.01032172222d0*t*t
+     * -0.0000124991d0*t**3+0.00000005263d0*t**4
+      zns=234.95544499d0 +1934.13626197d0*t-0.00207561111d0*t*t
+     * -0.00000213944d0*t**3+0.00000001650d0*t**4
+      ps=282.93734098d0+1.71945766667d0*t+0.00045688889d0*t*t
+     * -0.00000001778d0*t**3-0.00000000334d0*t**4
+
+*** reduce angles to between 0 and 360
+
+      s=  dmod(  s,360.d0)
+      tau=dmod(tau,360.d0)
+      h=  dmod(  h,360.d0)
+      p=  dmod(  p,360.d0)
+      zns=dmod(zns,360.d0)
+      ps= dmod( ps,360.d0)
+
+      rsta=dsqrt(xsta(1)**2+xsta(2)**2+xsta(3)**2)
+      sinphi=xsta(3)/rsta
+      cosphi=dsqrt(xsta(1)**2+xsta(2)**2)/rsta
+
+      cosla=xsta(1)/cosphi/rsta
+      sinla=xsta(2)/cosphi/rsta
+      zla = datan2(xsta(2),xsta(1))
+      do i=1,3
+        xcorsta(i)=0.d0
+      enddo
+      do j=1,31
+        thetaf=(tau+datdi(1,j)*s+datdi(2,j)*h+datdi(3,j)*p+
+     *   datdi(4,j)*zns+datdi(5,j)*ps)*deg2rad
+        dr=datdi(6,j)*2.d0*sinphi*cosphi*sin(thetaf+zla)+
+     *     datdi(7,j)*2.d0*sinphi*cosphi*cos(thetaf+zla)
+        dn=datdi(8,j)*(cosphi**2-sinphi**2)*sin(thetaf+zla)+
+     *     datdi(9,j)*(cosphi**2-sinphi**2)*cos(thetaf+zla)
+***** following correction by V.Dehant to match eq.16b, p.81, 2003 Conventions
+*****   de=datdi(8,j)*sinphi*cos(thetaf+zla)+
+        de=datdi(8,j)*sinphi*cos(thetaf+zla)-
+     *     datdi(9,j)*sinphi*sin(thetaf+zla)
+        xcorsta(1)=xcorsta(1)+dr*cosla*cosphi-de*sinla
+     *   -dn*sinphi*cosla
+        xcorsta(2)=xcorsta(2)+dr*sinla*cosphi+de*cosla
+     *   -dn*sinphi*sinla
+        xcorsta(3)=xcorsta(3)+dr*sinphi+dn*cosphi
+      enddo
+
+      do i=1,3
+         xcorsta(i)=xcorsta(i)/1000.d0
+      enddo
+
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine step2lon(xsta,fhr,t,xcorsta)
+
+      implicit double precision (a-h,o-z)
+      double precision deg2rad
+      double precision xsta(3),xcorsta(3),datdi(9,5)
+      data deg2rad/0.017453292519943295769d0/
+
+*** cf. table 7.5b of IERS conventions 2003 (TN.32, pg.82)
+*** columns are s,h,p,N',ps, dR(ip),dT(ip),dR(op),dT(op)
+*** IERS cols.= s,h,p,N',ps, dR(ip),dR(op),dT(ip),dT(op)
+*** units of mm
+
+      data ((datdi(i,j),i=1,9),j=1,5)/
+     *   0, 0, 0, 1, 0,   0.47, 0.23, 0.16, 0.07,
+     *   0, 2, 0, 0, 0,  -0.20,-0.12,-0.11,-0.05,
+     *   1, 0,-1, 0, 0,  -0.11,-0.08,-0.09,-0.04,
+     *   2, 0, 0, 0, 0,  -0.13,-0.11,-0.15,-0.07,
+     *   2, 0, 0, 1, 0,  -0.05,-0.05,-0.06,-0.03/
+
+      s=218.31664563d0+481267.88194d0*t-0.0014663889d0*t*t
+     * +0.00000185139d0*t**3
+      pr=1.396971278*t+0.000308889*t*t+0.000000021*t**3
+     * +0.000000007*t**4
+      s=s+pr
+      h=280.46645d0+36000.7697489d0*t+0.00030322222d0*t*t
+     * +0.000000020*t**3-0.00000000654*t**4
+      p=83.35324312d0+4069.01363525d0*t-0.01032172222d0*t*t
+     * -0.0000124991d0*t**3+0.00000005263d0*t**4
+      zns=234.95544499d0 +1934.13626197d0*t-0.00207561111d0*t*t
+     * -0.00000213944d0*t**3+0.00000001650d0*t**4
+      ps=282.93734098d0+1.71945766667d0*t+0.00045688889d0*t*t
+     * -0.00000001778d0*t**3-0.00000000334d0*t**4
+      rsta=dsqrt(xsta(1)**2+xsta(2)**2+xsta(3)**2)
+      sinphi=xsta(3)/rsta
+      cosphi=dsqrt(xsta(1)**2+xsta(2)**2)/rsta
+      cosla=xsta(1)/cosphi/rsta
+      sinla=xsta(2)/cosphi/rsta
+
+*** reduce angles to between 0 and 360
+
+      s=  dmod(  s,360.d0)
+***** tau=dmod(tau,360.d0)       
+      !***^ tau not used here--09jul28
+      h=  dmod(  h,360.d0)
+      p=  dmod(  p,360.d0)
+      zns=dmod(zns,360.d0)
+      ps= dmod( ps,360.d0)
+
+      dr_tot=0.d0
+      dn_tot=0.d0
+      do i=1,3
+        xcorsta(i)=0.d0
+      enddo
+
+***             1 2 3 4   5   6      7      8      9
+*** columns are s,h,p,N',ps, dR(ip),dT(ip),dR(op),dT(op)
+
+      do j=1,5
+        thetaf=(datdi(1,j)*s+datdi(2,j)*h+datdi(3,j)*p+
+     *   datdi(4,j)*zns+datdi(5,j)*ps)*deg2rad
+        dr=datdi(6,j)*(3.d0*sinphi**2-1.d0)/2.*cos(thetaf)+
+     *       datdi(8,j)*(3.d0*sinphi**2-1.d0)/2.*sin(thetaf)
+        dn=datdi(7,j)*(cosphi*sinphi*2.d0)*cos(thetaf)+
+     *       datdi(9,j)*(cosphi*sinphi*2.d0)*sin(thetaf)
+        de=0.d0
+        dr_tot=dr_tot+dr
+        dn_tot=dn_tot+dn
+        xcorsta(1)=xcorsta(1)+dr*cosla*cosphi-de*sinla
+     *   -dn*sinphi*cosla
+        xcorsta(2)=xcorsta(2)+dr*sinla*cosphi+de*cosla
+     *   -dn*sinphi*sinla
+        xcorsta(3)=xcorsta(3)+dr*sinphi+dn*cosphi
+      enddo
+
+      do i=1,3
+        xcorsta(i)=xcorsta(i)/1000.d0
+      enddo
+
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine st1idiu(xsta,xsun,xmon,fac2sun,fac2mon,xcorsta)
+
+*** this subroutine gives the out-of-phase corrections induced by
+*** mantle inelasticity in the diurnal band
+
+***  input: xsta,xsun,xmon,fac2sun,fac2mon
+*** output: xcorsta
+
+      implicit double precision (a-h,o-z)
+      dimension xsta(3),xsun(3),xmon(3),xcorsta(3)
+      data dhi/-0.0025d0/,dli/-0.0007d0/
+
+      rsta=enorm8(xsta)
+      sinphi=xsta(3)/rsta
+      cosphi=dsqrt(xsta(1)**2+xsta(2)**2)/rsta
+      cos2phi=cosphi**2-sinphi**2
+      sinla=xsta(2)/cosphi/rsta
+      cosla=xsta(1)/cosphi/rsta
+      rmon=enorm8(xmon)
+      rsun=enorm8(xsun)
+      drsun=-3.d0*dhi*sinphi*cosphi*fac2sun*xsun(3)*(xsun(1)*
+     *            sinla-xsun(2)*cosla)/rsun**2
+      drmon=-3.d0*dhi*sinphi*cosphi*fac2mon*xmon(3)*(xmon(1)*
+     *            sinla-xmon(2)*cosla)/rmon**2
+      dnsun=-3.d0*dli*cos2phi*fac2sun*xsun(3)*(xsun(1)*sinla-
+     *            xsun(2)*cosla)/rsun**2
+      dnmon=-3.d0*dli*cos2phi*fac2mon*xmon(3)*(xmon(1)*sinla-
+     *            xmon(2)*cosla)/rmon**2
+      desun=-3.d0*dli*sinphi*fac2sun*xsun(3)*
+     * (xsun(1)*cosla+xsun(2)*sinla)/rsun**2
+      demon=-3.d0*dli*sinphi*fac2mon*xmon(3)*
+     * (xmon(1)*cosla+xmon(2)*sinla)/rmon**2
+      dr=drsun+drmon
+      dn=dnsun+dnmon
+      de=desun+demon
+      xcorsta(1)=dr*cosla*cosphi-de*sinla-dn*sinphi*cosla
+      xcorsta(2)=dr*sinla*cosphi+de*cosla-dn*sinphi*sinla
+      xcorsta(3)=dr*sinphi               +dn*cosphi
+
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine st1isem(xsta,xsun,xmon,fac2sun,fac2mon,xcorsta)
+
+*** this subroutine gives the out-of-phase corrections induced by
+*** mantle inelasticity in the diurnal band
+
+***  input: xsta,xsun,xmon,fac2sun,fac2mon
+*** output: xcorsta
+
+      implicit double precision (a-h,o-z)
+      dimension xsta(3),xsun(3),xmon(3),xcorsta(3)
+      data dhi/-0.0022d0/,dli/-0.0007d0/
+
+      rsta=enorm8(xsta)
+      sinphi=xsta(3)/rsta
+      cosphi=dsqrt(xsta(1)**2+xsta(2)**2)/rsta
+      sinla=xsta(2)/cosphi/rsta
+      cosla=xsta(1)/cosphi/rsta
+      costwola=cosla**2-sinla**2
+      sintwola=2.d0*cosla*sinla
+      rmon=enorm8(xmon)
+      rsun=enorm8(xsun)
+      drsun=-3.d0/4.d0*dhi*cosphi**2*fac2sun*((xsun(1)**2-xsun(2)**2)*
+     * sintwola-2.*xsun(1)*xsun(2)*costwola)/rsun**2
+      drmon=-3.d0/4.d0*dhi*cosphi**2*fac2mon*((xmon(1)**2-xmon(2)**2)*
+     * sintwola-2.*xmon(1)*xmon(2)*costwola)/rmon**2
+      dnsun=1.5d0*dli*sinphi*cosphi*fac2sun*((xsun(1)**2-xsun(2)**2)*
+     * sintwola-2.d0*xsun(1)*xsun(2)*costwola)/rsun**2
+      dnmon=1.5d0*dli*sinphi*cosphi*fac2mon*((xmon(1)**2-xmon(2)**2)*
+     * sintwola-2.d0*xmon(1)*xmon(2)*costwola)/rmon**2
+      desun=-3.d0/2.d0*dli*cosphi*fac2sun*((xsun(1)**2-xsun(2)**2)*
+     * costwola+2.*xsun(1)*xsun(2)*sintwola)/rsun**2
+      demon=-3.d0/2.d0*dli*cosphi*fac2mon*((xmon(1)**2-xmon(2)**2)*
+     * costwola+2.d0*xmon(1)*xmon(2)*sintwola)/rmon**2
+      dr=drsun+drmon
+      dn=dnsun+dnmon
+      de=desun+demon
+      xcorsta(1)=dr*cosla*cosphi-de*sinla-dn*sinphi*cosla
+      xcorsta(2)=dr*sinla*cosphi+de*cosla-dn*sinphi*sinla
+      xcorsta(3)=dr*sinphi+dn*cosphi
+
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine sprod(x,y,scal,r1,r2)
+
+***  computation of the scalar-product of two vectors and their norms
+
+***  input:   x(i),i=1,2,3  -- components of vector x
+***           y(i),i=1,2,3  -- components of vector y
+***  output:  scal          -- scalar product of x and y
+***           r1,r2         -- lengths of the two vectors x and y
+
+      implicit double precision (a-h,o-z)
+      double precision x(3),y(3)
+
+      r1=dsqrt(x(1)*x(1) + x(2)*x(2) + x(3)*x(3))
+      r2=dsqrt(y(1)*y(1) + y(2)*y(2) + y(3)*y(3))
+      scal=    x(1)*y(1) + x(2)*y(2) + x(3)*y(3)
+
+      return
+      end
+*-----------------------------------------------------------------------
+      double precision function enorm8(a)
+
+*** compute euclidian norm of a vector (of length 3)
+
+      double precision a(3)
+
+      enorm8=dsqrt(a(1)*a(1) + a(2)*a(2) + a(3)*a(3))
+
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine zero_vec8(v)
+
+*** initialize a vector (of length 3) to zero
+
+      double precision v(3)
+
+      v(1)=0.d0
+      v(2)=0.d0
+      v(3)=0.d0
+
+      return
+      end
+*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+      subroutine moonxyz(mjd,fmjd,rm,lflag)
+
+*** get low-precision, geocentric coordinates for moon (ECEF)
+*** UTC version
+
+*** input:  mjd/fmjd, is Modified Julian Date (and fractional) in UTC time
+*** output: rm, is geocentric lunar position vector [m] in ECEF
+***         lflag  -- leap second table limit flag,  false:flag not raised
+*** 1."satellite orbits: models, methods, applications" montenbruck & gill(2000)
+*** section 3.3.2, pg. 72-73
+*** 2."astronomy on the personal computer, 4th ed." montenbruck & pfleger (2005)
+*** section 3.2, pg. 38-39  routine MiniMoon
+
+      implicit double precision(a-h,o-z)
+      dimension rm(3)
+      logical lflag,leapflag
+      save  /limitflag/                
+      !***^ leap second table limit flag
+      common/limitflag/leapflag        
+      !***^ leap second table limit flag
+      common/stuff/rad,pi,pi2
+
+*** use TT for lunar ephemerides
+
+      leapflag=lflag
+      tsecutc=fmjd*86400.d0                       
+      !***^ UTC time (sec of day)
+      tsectt =utc2ttt(tsecutc)                    
+      !***^ TT  time (sec of day)
+      fmjdtt =tsectt/86400.d0                     
+      !***^ TT  time (fract. day)
+      lflag   = leapflag
+
+*** julian centuries since 1.5 january 2000 (J2000)
+***   (note: also low precision use of mjd --> tjd)
+
+      tjdtt = mjd+fmjdtt+2400000.5d0              
+      !***^ Julian Date, TT
+      t     = (tjdtt - 2451545.d0)/36525.d0       
+      !***^ julian centuries, TT
+
+*** el0 -- mean longitude of Moon (deg)
+*** el  -- mean anomaly of Moon (deg)
+*** elp -- mean anomaly of Sun  (deg)
+*** f   -- mean angular distance of Moon from ascending node (deg)
+*** d   -- difference between mean longitudes of Sun and Moon (deg)
+
+*** equations 3.47, p.72
+
+      el0=218.31617d0 + 481267.88088d0*t -1.3972*t
+      el =134.96292d0 + 477198.86753d0*t
+      elp=357.52543d0 +  35999.04944d0*t
+      f  = 93.27283d0 + 483202.01873d0*t
+      d  =297.85027d0 + 445267.11135d0*t
+
+*** longitude w.r.t. equinox and ecliptic of year 2000
+
+      selond=el0                                      
+      !***^ eq 3.48, p.72
+     * +22640.d0/3600.d0*dsin((el        )/rad)
+     * +  769.d0/3600.d0*dsin((el+el     )/rad)
+     * - 4586.d0/3600.d0*dsin((el-d-d    )/rad)
+     * + 2370.d0/3600.d0*dsin((d+d       )/rad)
+     * -  668.d0/3600.d0*dsin((elp       )/rad)
+     * -  412.d0/3600.d0*dsin((f+f       )/rad)
+     * -  212.d0/3600.d0*dsin((el+el-d-d )/rad)
+     * -  206.d0/3600.d0*dsin((el+elp-d-d)/rad)
+     * +  192.d0/3600.d0*dsin((el+d+d    )/rad)
+     * -  165.d0/3600.d0*dsin((elp-d-d   )/rad)
+     * +  148.d0/3600.d0*dsin((el-elp    )/rad)
+     * -  125.d0/3600.d0*dsin((d         )/rad)
+     * -  110.d0/3600.d0*dsin((el+elp    )/rad)
+     * -   55.d0/3600.d0*dsin((f+f-d-d   )/rad)
+
+*** latitude w.r.t. equinox and ecliptic of year 2000
+
+      q = 412.d0/3600.d0*dsin((f+f)/rad)              
+      !***^ temporary term
+     *   +541.d0/3600.d0*dsin((elp)/rad)
+
+      selatd=                                         
+      !***^ eq 3.49, p.72
+     * +18520.d0/3600.d0*dsin((f+selond-el0+q)/rad)
+     * -  526.d0/3600.d0*dsin((f-d-d     )/rad)
+     * +   44.d0/3600.d0*dsin((el+f-d-d  )/rad)
+     * -   31.d0/3600.d0*dsin((-el+f-d-d )/rad)
+     * -   25.d0/3600.d0*dsin((-el-el+f  )/rad)
+     * -   23.d0/3600.d0*dsin((elp+f-d-d )/rad)
+     * +   21.d0/3600.d0*dsin((-el+f     )/rad)
+     * +   11.d0/3600.d0*dsin((-elp+f-d-d)/rad)
+
+*** distance from Earth center to Moon (m)
+
+      rse= 385000.d0*1000.d0                          
+      !***^ eq 3.50, p.72
+     *   -  20905.d0*1000.d0*dcos((el        )/rad)
+     *   -   3699.d0*1000.d0*dcos((d+d-el    )/rad)
+     *   -   2956.d0*1000.d0*dcos((d+d       )/rad)
+     *   -    570.d0*1000.d0*dcos((el+el     )/rad)
+     *   +    246.d0*1000.d0*dcos((el+el-d-d )/rad)
+     *   -    205.d0*1000.d0*dcos((elp-d-d   )/rad)
+     *   -    171.d0*1000.d0*dcos((el+d+d    )/rad)
+     *   -    152.d0*1000.d0*dcos((el+elp-d-d)/rad)
+
+*** convert spherical ecliptic coordinates to equatorial cartesian
+
+*** precession of equinox wrt. J2000   (p.71)
+
+      selond=selond + 1.3972d0*t                         
+      !***^ degrees
+
+*** position vector of moon (mean equinox & ecliptic of J2000) (EME2000, ICRF)
+***                         (plus long. advance due to precession -- eq. above)
+
+      oblir=23.43929111d0/rad        
+      !***^ obliquity of the J2000 ecliptic
+
+      sselat=dsin(selatd/rad)
+      cselat=dcos(selatd/rad)
+      sselon=dsin(selond/rad)
+      cselon=dcos(selond/rad)
+
+      t1 = rse*cselon*cselat        
+      !***^ meters          
+      !***^ eq. 3.51, p.72
+      t2 = rse*sselon*cselat        
+      !***^ meters          
+      !***^ eq. 3.51, p.72
+      t3 = rse*       sselat        
+      !***^ meters          
+      !***^ eq. 3.51, p.72
+
+      call rot1(-oblir,t1,t2,t3,rm1,rm2,rm3)             
+      !***^ eq. 3.51, p.72
+
+*** convert position vector of moon to ECEF  (ignore polar motion/LOD)
+
+      call getghar(mjd,fmjd,ghar)                        
+      !***^ sec 2.3.1,p.33
+      call rot3(ghar,rm1,rm2,rm3,rm(1),rm(2),rm(3))      
+      !***^ eq. 2.89, p.37
+
+      return
+      end
+********************************************************************************
+      subroutine getghar(mjd,fmjd,ghar)
+
+*** convert mjd/fmjd in UTC time to Greenwich hour angle (in radians)
+
+*** "satellite orbits: models, methods, applications" montenbruck & gill(2000)
+*** section 2.3.1, pg. 33
+
+      implicit double precision(a-h,o-z)
+      common/stuff/rad,pi,pi2
+
+*** need UTC to get sidereal time ("astronomy on the personal computer", 4th ed)
+***                               (pg.43, montenbruck & pfleger, springer, 2005)
+
+      tsecutc=fmjd*86400.d0                        
+      !***^ UTC time (sec of day)
+      fmjdutc=tsecutc/86400.d0                     
+      !***^ UTC time (fract. day)
+
+***** d = MJD - 51544.5d0                               
+      !***^ footnote
+      d =(mjd-51544) + (fmjdutc-0.5d0)                  
+      !***^ days since J2000
+
+*** greenwich hour angle for J2000  (12:00:00 on 1 Jan 2000)
+
+***** ghad = 100.46061837504d0 + 360.9856473662862d0*d  
+      !***^ eq. 2.85 (+digits)
+      ghad = 280.46061837504d0 + 360.9856473662862d0*d  
+      !***^ corrn.   (+digits)
+
+**** normalize to 0-360 and convert to radians
+
+      i    = ghad/360.d0
+      ghar =(ghad-i*360.d0)/rad
+    1 if(ghar.gt.pi2) then
+        ghar=ghar-pi2
+        go to 1
+      endif
+    2 if(ghar.lt.0.d0) then
+        ghar=ghar+pi2
+        go to 2
+      endif
+
+      return
+      end
+********************************************************************************
+      subroutine sunxyz(mjd,fmjd,rs,lflag)
+
+*** get low-precision, geocentric coordinates for sun (ECEF)
+
+*** input, mjd/fmjd, is Modified Julian Date (and fractional) in UTC time
+*** output, rs, is geocentric solar position vector [m] in ECEF
+***         lflag  -- leap second table limit flag,  false:flag not raised
+*** 1."satellite orbits: models, methods, applications" montenbruck & gill(2000)
+*** section 3.3.2, pg. 70-71
+*** 2."astronomy on the personal computer, 4th ed." montenbruck & pfleger (2005)
+*** section 3.2, pg. 39  routine MiniSun
+
+      implicit double precision(a-h,o-z)
+      dimension rs(3)
+      logical lflag,leapflag
+      save  /limitflag/                
+      !***^ leap second table limit flag
+      common/limitflag/leapflag        
+      !***^ leap second table limit flag
+      common/stuff/rad,pi,pi2
+
+*** mean elements for year 2000, sun ecliptic orbit wrt. Earth
+
+      obe =23.43929111d0/rad        
+      !***^ obliquity of the J2000 ecliptic
+      sobe=dsin(obe)
+      cobe=dcos(obe)
+      opod=282.9400d0               
+      !***^ RAAN + arg.peri.  (deg.)
+
+*** use TT for solar ephemerides
+
+      leapflag=lflag
+      tsecutc=fmjd*86400.d0                       
+      !***^ UTC time (sec of day)
+      tsectt =utc2ttt(tsecutc)                    
+      !***^ TT  time (sec of day)
+      fmjdtt =tsectt/86400.d0                     
+      !***^ TT  time (fract. day)
+      lflag   = leapflag
+
+*** julian centuries since 1.5 january 2000 (J2000)
+***   (note: also low precision use of mjd --> tjd)
+
+      tjdtt = mjd+fmjdtt+2400000.5d0              
+      !***^ Julian Date, TT
+      t     = (tjdtt - 2451545.d0)/36525.d0       
+      !***^ julian centuries, TT
+      emdeg = 357.5256d0 + 35999.049d0*t          
+      !***^ degrees
+      em    = emdeg/rad                           
+      !***^ radians
+      em2   = em+em                               
+      !***^ radians
+
+*** series expansions in mean anomaly, em   (eq. 3.43, p.71)
+
+      r=(149.619d0-2.499d0*dcos(em)-0.021d0*dcos(em2))*1.d9      
+      !***^ m.
+      slond=opod + emdeg + (6892.d0*dsin(em)+72.d0*dsin(em2))/3600.d0
+
+*** precession of equinox wrt. J2000   (p.71)
+
+      slond=slond + 1.3972d0*t                              
+      !***^ degrees
+
+*** position vector of sun (mean equinox & ecliptic of J2000) (EME2000, ICRF)
+***                        (plus long. advance due to precession -- eq. above)
+
+      slon =slond/rad                                       
+      !***^ radians
+      sslon=dsin(slon)
+      cslon=dcos(slon)
+
+      rs1 = r*cslon              
+      !***^ meters             
+      !***^ eq. 3.46, p.71
+      rs2 = r*sslon*cobe         
+      !***^ meters             
+      !***^ eq. 3.46, p.71
+      rs3 = r*sslon*sobe         
+      !***^ meters             
+      !***^ eq. 3.46, p.71
+
+*** convert position vector of sun to ECEF  (ignore polar motion/LOD)
+
+      call getghar(mjd,fmjd,ghar)                        
+      !***^ sec 2.3.1,p.33
+      call rot3(ghar,rs1,rs2,rs3,rs(1),rs(2),rs(3))      
+      !***^ eq. 2.89, p.37
+
+      return
+      end
+********************************************************************************
+      subroutine lhsaaz(u,v,w,ra,az,va)
+
+*** determine range,azimuth,vertical angle from local horizon coord.
+
+      implicit double precision(a-h,o-z)
+      
+      s2=u*u+v*v
+      r2=s2+w*w
+      
+      s =dsqrt(s2)
+      ra=dsqrt(r2)
+      
+      az=datan2(v,u)
+      va=datan2(w,s)
+      
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine geoxyz(gla,glo,eht,x,y,z)
+
+*** convert geodetic lat, long, ellip ht. to x,y,z
+
+      implicit double precision(a-h,o-z)
+      common/comgrs/a,e2
+
+      sla=dsin(gla)
+      cla=dcos(gla)
+      w2=1.d0-e2*sla*sla
+      w=dsqrt(w2)
+      en=a/w
+
+      x=(en+eht)*cla*dcos(glo)
+      y=(en+eht)*cla*dsin(glo)
+      z=(en*(1.d0-e2)+eht)*sla
+
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine rge(gla,glo,u,v,w,x,y,z)
+
+*** given a rectangular cartesian system (x,y,z)
+*** compute a geodetic h cartesian sys   (u,v,w)
+
+      implicit double precision(a-h,o-z)
+
+      sb=dsin(gla)
+      cb=dcos(gla)
+      sl=dsin(glo)
+      cl=dcos(glo)
+
+      u=-sb*cl*x-sb*sl*y+cb*z
+      v=-   sl*x+   cl*y
+      w= cb*cl*x+cb*sl*y+sb*z
+
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine rot1(theta,x,y,z,u,v,w)
+      
+*** rotate coordinate axes about 1 axis by angle of theta radians
+*** x,y,z transformed into u,v,w
+
+      implicit double precision(a-h,o-z)
+      
+      s=dsin(theta)
+      c=dcos(theta)
+            
+      u=x
+      v=c*y+s*z
+      w=c*z-s*y
+            
+      return
+      end
+*-----------------------------------------------------------------------
+      subroutine rot3(theta,x,y,z,u,v,w)
+      
+*** rotate coordinate axes about 3 axis by angle of theta radians
+*** x,y,z transformed into u,v,w
+
+      implicit double precision(a-h,o-z)
+      
+      s=dsin(theta)
+      c=dcos(theta)
+            
+      u=c*x+s*y
+      v=c*y-s*x
+      w=z
+            
+      return
+      end
+************************************************************************
+*** time conversion ****************************************************
+************************************************************************
+      subroutine setjd0(iyr,imo,idy)
+
+*** set the integer part of a modified julian date as epoch, mjd0
+*** the modified julian day is derived from civil time as in civmjd()
+*** allows single number expression of time in seconds w.r.t. mjd0
+
+      implicit double precision(a-h,o-z)
+      integer y
+      save /mjdoff/
+      common/mjdoff/mjd0
+
+      if(iyr.lt.1900) stop 34587
+
+      if(imo.le.2) then
+        y=iyr-1
+        m=imo+12
+      else
+        y=iyr
+        m=imo
+      endif
+
+      it1=365.25d0*y
+      it2=30.6001d0*(m+1)
+      mjd=it1+it2+idy-679019
+
+*** now set the epoch for future time computations
+
+      mjd0=mjd
+
+      return
+      end
+      subroutine civjts(iyr,imo,idy,ihr,imn,sec,tsec)
+
+*** convert civil date to time in seconds past mjd epoch, mjd0
+*** requires initialization of mjd0 by setjd0()
+
+*** imo in range 1-12, idy in range 1-31
+*** only valid in range mar-1900 thru feb-2100     (leap year protocols)
+*** ref: hofmann-wellenhof, 2nd ed., pg 34-35
+*** adapted from civmjd()
+
+      implicit double precision(a-h,o-z)
+      integer y
+      save /mjdoff/
+      common/mjdoff/mjd0
+
+      if(iyr.lt.1900) stop 34589
+
+      if(imo.le.2) then
+        y=iyr-1
+        m=imo+12
+      else
+        y=iyr
+        m=imo
+      endif
+
+      it1=365.25d0*y
+      it2=30.6001d0*(m+1)
+      mjd=it1+it2+idy-679019
+
+      tsec=(mjd-mjd0)*86400.d0+3600*ihr+60*imn+sec
+
+      return
+      end
+      subroutine jtsciv(tsec,iyr,imo,idy,ihr,imn,sec)
+
+*** convert time in seconds past mjd0 epoch into civil date
+*** requires initialization of mjd0 by setjd0()
+
+*** imo in range 1-12, idy in range 1-31
+*** only valid in range mar-1900 thru feb-2100
+*** ref: hofmann-wellenhof, 2nd ed., pg 34-35
+*** adapted from mjdciv()
+
+      implicit double precision(a-h,o-z)
+      save /mjdoff/
+      common/mjdoff/mjd0
+
+      mjd=mjd0+tsec/86400.d0
+*** the following equation preserves significant digits
+      fmjd=dmod(tsec,86400.d0)/86400.d0
+
+      rjd=mjd+fmjd+2400000.5d0
+      ia=(rjd+0.5d0)
+      ib=ia+1537
+      ic=(ib-122.1d0)/365.25d0
+      id=365.25d0*ic
+      ie=(ib-id)/30.6001d0
+
+*** the fractional part of a julian day is (fractional mjd + 0.5)
+*** therefore, fractional part of julian day + 0.5 is (fractional mjd)
+
+      it1=ie*30.6001d0
+      idy=ib-id-it1+fmjd
+      it2=ie/14.d0
+      imo=ie-1-12*it2
+      it3=(7+imo)/10.d0
+      iyr=ic-4715-it3
+
+      tmp=fmjd*24.d0
+      ihr=tmp
+      tmp=(tmp-ihr)*60.d0
+      imn=tmp
+      sec=(tmp-imn)*60.d0
+
+      return
+      end
+************************************************************************
+      subroutine civmjd(iyr,imo,idy,ihr,imn,sec,mjd,fmjd)
+
+*** convert civil date to modified julian date
+
+*** imo in range 1-12, idy in range 1-31
+*** only valid in range mar-1900 thru feb-2100     (leap year protocols)
+*** ref: hofmann-wellenhof, 2nd ed., pg 34-35
+*** operation confirmed against table 3.3 values on pg.34
+
+      implicit double precision(a-h,o-z)
+      integer y
+
+      if(iyr.lt.1900) stop 34588
+
+      if(imo.le.2) then
+        y=iyr-1
+        m=imo+12
+      else
+        y=iyr
+        m=imo
+      endif
+
+      it1=365.25d0*y
+      it2=30.6001d0*(m+1)
+      mjd=it1+it2+idy-679019
+
+      fmjd=(3600*ihr+60*imn+sec)/86400.d0
+
+      return
+      end
+      subroutine mjdciv(mjd,fmjd,iyr,imo,idy,ihr,imn,sec)
+
+*** convert modified julian date to civil date
+
+*** imo in range 1-12, idy in range 1-31
+*** only valid in range mar-1900 thru feb-2100
+*** ref: hofmann-wellenhof, 2nd ed., pg 34-35
+*** operation confirmed for leap years (incl. year 2000)
+
+      implicit double precision(a-h,o-z)
+
+      rjd=mjd+fmjd+2400000.5d0
+      ia=(rjd+0.5d0)
+      ib=ia+1537
+      ic=(ib-122.1d0)/365.25d0
+      id=365.25d0*ic
+      ie=(ib-id)/30.6001d0
+
+*** the fractional part of a julian day is fractional mjd + 0.5
+*** therefore, fractional part of julian day + 0.5 is fractional mjd
+
+      it1=ie*30.6001d0
+      idy=ib-id-it1+fmjd
+      it2=ie/14.d0
+      imo=ie-1-12*it2
+      it3=(7+imo)/10.d0
+      iyr=ic-4715-it3
+
+      tmp=fmjd*24.d0
+      ihr=tmp
+      tmp=(tmp-ihr)*60.d0
+      imn=tmp
+      sec=(tmp-imn)*60.d0
+
+      return
+      end
+************************************************************************
+*** new supplemental time functions ************************************
+************************************************************************
+      double precision function utc2ttt(tutc)
+
+*** convert utc (sec) to terrestrial time (sec)
+
+      implicit double precision(a-h,o-z)
+
+      ttai   = utc2tai(tutc)
+      utc2ttt= tai2tt(ttai)
+
+      return
+      end
+*-----------------------------------------------------------------------
+      double precision function gps2ttt(tgps)
+
+*** convert gps time (sec) to terrestrial time (sec)
+
+      implicit double precision(a-h,o-z)
+
+      ttai   = gps2tai(tgps)
+      gps2ttt= tai2tt(ttai)
+
+      return
+      end
+*-----------------------------------------------------------------------
+      double precision function utc2tai(tutc)
+
+*** convert utc (sec) to tai (sec)
+
+      implicit double precision(a-h,o-z)
+
+      utc2tai = tutc - getutcmtai(tutc)
+
+      return
+      end
+*-----------------------------------------------------------------------
+      double precision function getutcmtai(tsec)
+
+*** get utc - tai (s)
+
+***** "Julian Date Converter"
+***** http://aa.usno.navy.mil/data/docs/JulianDate.php
+
+      implicit double precision(a-h,o-z)
+      parameter(MJDUPPER=58664)    
+      !***^ upper limit, leap second table, 2019jun30
+***** parameter(MJDUPPER=58299)    
+      !***^ upper limit, leap second table, 2018jun30
+      parameter(MJDLOWER=41317)    
+      !***^ lower limit, leap second table, 1972jan01
+
+      logical leapflag             
+      !***^ leap second table limit flag
+      save  /limitflag/
+      common/limitflag/leapflag    
+      !***^ leap second table limit flag
+
+      save  /mjdoff/
+      common/mjdoff/mjd0
+
+*** clone for tests (and do any rollover)
+
+      ttsec=tsec
+      mjd0t=mjd0
+
+    1 if(ttsec.ge.86400.d0) then
+        ttsec=ttsec-86400.d0
+        mjd0t=mjd0t+1
+        go to 1
+      endif
+
+    2 if(ttsec.lt.0.d0) then
+        ttsec=ttsec+86400.d0
+        mjd0t=mjd0t-1
+        go to 2
+      endif
+
+*** test upper table limit         (upper limit set by bulletin C memos)
+
+      if(mjd0t.gt.MJDUPPER) then
+        leapflag  =.true.               
+      !***^ true means flag *IS* raised
+        getutcmtai= -37.d0              
+      !***^ return the upper table value
+        return
+      endif
+
+*** test lower table limit
+
+      if(mjd0t.lt.MJDLOWER) then
+        leapflag=.true.                 
+      !***^ true means flag *IS* raised
+        getutcmtai= -10.d0              
+      !***^ return the lower table value
+        return
+      endif
+
+***** http://maia.usno.navy.mil/ser7/tai-utc.dat
+*** 1972 JAN  1 =JD 2441317.5  TAI-UTC=  10.0s
+*** 1972 JUL  1 =JD 2441499.5  TAI-UTC=  11.0s
+*** 1973 JAN  1 =JD 2441683.5  TAI-UTC=  12.0s
+*** 1974 JAN  1 =JD 2442048.5  TAI-UTC=  13.0s
+*** 1975 JAN  1 =JD 2442413.5  TAI-UTC=  14.0s
+*** 1976 JAN  1 =JD 2442778.5  TAI-UTC=  15.0s
+*** 1977 JAN  1 =JD 2443144.5  TAI-UTC=  16.0s
+*** 1978 JAN  1 =JD 2443509.5  TAI-UTC=  17.0s
+*** 1979 JAN  1 =JD 2443874.5  TAI-UTC=  18.0s
+*** 1980 JAN  1 =JD 2444239.5  TAI-UTC=  19.0s
+*** 1981 JUL  1 =JD 2444786.5  TAI-UTC=  20.0s
+*** 1982 JUL  1 =JD 2445151.5  TAI-UTC=  21.0s
+*** 1983 JUL  1 =JD 2445516.5  TAI-UTC=  22.0s
+*** 1985 JUL  1 =JD 2446247.5  TAI-UTC=  23.0s
+*** 1988 JAN  1 =JD 2447161.5  TAI-UTC=  24.0s
+*** 1990 JAN  1 =JD 2447892.5  TAI-UTC=  25.0s
+*** 1991 JAN  1 =JD 2448257.5  TAI-UTC=  26.0s
+*** 1992 JUL  1 =JD 2448804.5  TAI-UTC=  27.0s
+*** 1993 JUL  1 =JD 2449169.5  TAI-UTC=  28.0s
+*** 1994 JUL  1 =JD 2449534.5  TAI-UTC=  29.0s
+*** 1996 JAN  1 =JD 2450083.5  TAI-UTC=  30.0s
+*** 1997 JUL  1 =JD 2450630.5  TAI-UTC=  31.0s
+*** 1999 JAN  1 =JD 2451179.5  TAI-UTC=  32.0s
+*** 2006 JAN  1 =JD 2453736.5  TAI-UTC=  33.0s
+*** 2009 JAN  1 =JD 2454832.5  TAI-UTC=  34.0s
+*** 2012 JUL  1 =JD 2456109.5  TAI-UTC=  35.0s
+*** 2015 JUL  1 =JD 2457204.5  TAI-UTC=  36.0s
+*** 2017 JAN  1 =JD 2457754.5  TAI-UTC=  37.0s
+***** other leap second references at:
+***** http://hpiers.obspm.fr/eoppc/bul/bulc/Leap_Second_History.dat
+***** http://hpiers.obspm.fr/eoppc/bul/bulc/bulletinc.dat
+
+*** test against newest leaps first
+
+      if    (mjd0t.ge.57754) then       
+      !***^ 2017 JAN 1 = 57754
+        tai_utc = 37.d0
+      elseif(mjd0t.ge.57204) then       
+      !***^ 2015 JUL 1 = 57204
+        tai_utc = 36.d0
+      elseif(mjd0t.ge.56109) then       
+      !***^ 2012 JUL 1 = 56109
+        tai_utc = 35.d0
+      elseif(mjd0t.ge.54832) then       
+      !***^ 2009 JAN 1 = 54832
+        tai_utc = 34.d0
+      elseif(mjd0t.ge.53736) then       
+      !***^ 2006 JAN 1 = 53736
+        tai_utc = 33.d0
+      elseif(mjd0t.ge.51179) then       
+      !***^ 1999 JAN 1 = 51179
+        tai_utc = 32.d0
+      elseif(mjd0t.ge.50630) then       
+      !***^ 1997 JUL 1 = 50630
+        tai_utc = 31.d0
+      elseif(mjd0t.ge.50083) then       
+      !***^ 1996 JAN 1 = 50083
+        tai_utc = 30.d0
+      elseif(mjd0t.ge.49534) then       
+      !***^ 1994 JUL 1 = 49534
+        tai_utc = 29.d0
+      elseif(mjd0t.ge.49169) then       
+      !***^ 1993 JUL 1 = 49169
+        tai_utc = 28.d0
+      elseif(mjd0t.ge.48804) then       
+      !***^ 1992 JUL 1 = 48804
+        tai_utc = 27.d0
+      elseif(mjd0t.ge.48257) then       
+      !***^ 1991 JAN 1 = 48257
+        tai_utc = 26.d0
+      elseif(mjd0t.ge.47892) then       
+      !***^ 1990 JAN 1 = 47892
+        tai_utc = 25.d0
+      elseif(mjd0t.ge.47161) then       
+      !***^ 1988 JAN 1 = 47161
+        tai_utc = 24.d0
+      elseif(mjd0t.ge.46247) then       
+      !***^ 1985 JUL 1 = 46247
+        tai_utc = 23.d0
+      elseif(mjd0t.ge.45516) then       
+      !***^ 1983 JUL 1 = 45516
+        tai_utc = 22.d0
+      elseif(mjd0t.ge.45151) then       
+      !***^ 1982 JUL 1 = 45151
+        tai_utc = 21.d0
+      elseif(mjd0t.ge.44786) then       
+      !***^ 1981 JUL 1 = 44786
+        tai_utc = 20.d0
+      elseif(mjd0t.ge.44239) then       
+      !***^ 1980 JAN 1 = 44239
+        tai_utc = 19.d0
+      elseif(mjd0t.ge.43874) then       
+      !***^ 1979 JAN 1 = 43874
+        tai_utc = 18.d0
+      elseif(mjd0t.ge.43509) then       
+      !***^ 1978 JAN 1 = 43509
+        tai_utc = 17.d0
+      elseif(mjd0t.ge.43144) then       
+      !***^ 1977 JAN 1 = 43144
+        tai_utc = 16.d0
+      elseif(mjd0t.ge.42778) then       
+      !***^ 1976 JAN 1 = 42778
+        tai_utc = 15.d0
+      elseif(mjd0t.ge.42413) then       
+      !***^ 1975 JAN 1 = 42413
+        tai_utc = 14.d0
+      elseif(mjd0t.ge.42048) then       
+      !***^ 1974 JAN 1 = 42048
+        tai_utc = 13.d0
+      elseif(mjd0t.ge.41683) then       
+      !***^ 1973 JAN 1 = 41683
+        tai_utc = 12.d0
+      elseif(mjd0t.ge.41499) then       
+      !***^ 1972 JUL 1 = 41499
+        tai_utc = 11.d0
+      elseif(mjd0t.ge.41317) then       
+      !***^ 1972 JAN 1 = 41317
+        tai_utc = 10.d0
+
+*** should never, ever get here
+
+      else
+        write(*,*) 'FATAL ERROR --'
+        write(*,*) 'fell thru tests in gpsleap()'
+        stop 66768
+      endif
+
+*** return utc - tai (in seconds)
+
+      getutcmtai = -tai_utc
+
+      return
+      end
+*-----------------------------------------------------------------------
+      double precision function tai2tt(ttai)
+
+*** convert tai (sec) to terrestrial time (sec)
+
+      implicit double precision(a-h,o-z)
+
+***** http://tycho.usno.navy.mil/systime.html
+      tai2tt = ttai + 32.184d0
+
+      return
+      end
+*-----------------------------------------------------------------------
+      double precision function gps2tai(tgps)
+
+*** convert gps time (sec) to tai (sec)
+
+      implicit double precision(a-h,o-z)
+
+***** http://leapsecond.com/java/gpsclock.htm
+***** http://tycho.usno.navy.mil/leapsec.html
+      gps2tai = tgps + 19.d0
+
+      return
+      end

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -309,7 +309,7 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
 
 def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None, croptounion=False, num_threads='2', minimumOverlap=0.0081):
     '''
-        Extract/merge productBoundingBox layers for each pair and update dict, report common track bbox (default is to take common intersection, 
+        Extract/merge productBoundingBox layers for each pair and update dict, report common track bbox (default is to take common intersection,
         but user may specify union), and expected shape for DEM.
     '''
 
@@ -790,7 +790,6 @@ def solidtide_correction(full_product_dict, bbox_file, prods_TOTbbox, inDir='unw
     # Import functions
     from ARIAtools.vrtmanager import renderVRT
     from datetime import datetime, timedelta
-    import shutil
     import pandas as pd
     from solid_grid import solidwrapped
 
@@ -847,7 +846,7 @@ def solidtide_correction(full_product_dict, bbox_file, prods_TOTbbox, inDir='unw
     #in y-dim
     dim_buffer=np.arange(ds_bounds[1],ds_bounds[-1],abs(ds_geotrans[-1]))
     ds_bounds[-1]=(2*abs(ds_geotrans[-1]))+dim_buffer[-1]
-   
+
     # Run solid_grid program
     for i in date_list:
         #arguments=yyyy, mm, dd, hh, mm, ss, latmin, lonmin, latmax, lonmax, spacingx, spacingy, increment, path to output file
@@ -890,7 +889,7 @@ def solidtide_correction(full_product_dict, bbox_file, prods_TOTbbox, inDir='unw
         df_reference['AZvalue'] = df_reference.index.map(azfile_lookup['AZvalue'])
         df_secondary['INCvalue'] = df_secondary.index.map(incfile_lookup['INCvalue'])
         df_secondary['AZvalue'] = df_secondary.index.map(azfile_lookup['AZvalue'])
-        #project to LOS, formula=-(x(k)*cos(dlos)+y(k)*sin(dlos))*sin(inc)-z(k)*cos(inc) 
+        #project to LOS, formula=-(x(k)*cos(dlos)+y(k)*sin(dlos))*sin(inc)-z(k)*cos(inc)
         df_reference['PROJvalue'] = (-((df_reference['ut']*np.cos(df_reference['AZvalue']))+(df_reference['vt']*np.sin(df_reference['AZvalue'])))* \
             np.sin(df_reference['INCvalue']))-(df_reference['wt']*np.cos(df_reference['INCvalue']))
         df_secondary['PROJvalue'] = (-((df_secondary['ut']*np.cos(df_secondary['AZvalue']))+(df_secondary['vt']*np.sin(df_secondary['AZvalue'])))* \
@@ -905,9 +904,9 @@ def solidtide_correction(full_product_dict, bbox_file, prods_TOTbbox, inDir='unw
         ds_geotrans[-1]=(min(df_reference['lat'])-max(df_reference['lat']))/se_product.shape[0]
         renderVRT(outname+'_sediff', se_product, geotrans=ds_geotrans, drivername=outputFormat, gdal_fmt='float32', proj=proj, nodata=0.)
         #extrapolate through nodata
-        src_ds = gdal.Open(outname+'_sediff', gdal.GA_Update) 
+        src_ds = gdal.Open(outname+'_sediff', gdal.GA_Update)
         srcband=src_ds.GetRasterBand(1)
-        result = gdal.FillNodata(targetBand=srcband,maskBand=None, maxSearchDist=100, smoothingIterations=1)
+        gdal.FillNodata(targetBand=srcband,maskBand=None, maxSearchDist=100, smoothingIterations=1)
         src_ds = None
         #oversample to full-res
         gdal.Warp(outname+'_sediff', outname+'_sediff', options=gdal.WarpOptions(format=outputFormat, outputBounds=bounds, xRes=abs(geotrans[1]), \

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -25,26 +25,48 @@ def createParser():
     '''
 
     import argparse
-    parser = argparse.ArgumentParser(description='Program to extract data and meta-data layers from ARIA standard GUNW products. Program will handle cropping/stitching when needed. By default, the program will crop all IFGs to bounds determined by the common intersection and bbox (if specified)')
+    parser = argparse.ArgumentParser(description='Program to extract data and meta-data layers from ARIA standard GUNW products.'\
+                                    'Program will handle cropping/stitching when needed. By default, the program will crop all IFGs'\
+                                    'to bounds determined by the common intersection and bbox (if specified)')
     parser.add_argument('-f', '--file', dest='imgfile', type=str,
             required=True, help='ARIA file')
-    parser.add_argument('-w', '--workdir', dest='workdir', default='./', help='Specify directory to deposit all outputs. Default is local directory where script is launched.')
-    parser.add_argument('-tp', '--tropo_products', dest='tropo_products', type=str, default=None, help='Path to director(ies) or tar file(s) containing GACOS products.')
-    parser.add_argument('-l', '--layers', dest='layers', default=None, help='Specify layers to extract as a comma deliminated list bounded by single quotes. Allowed keys are: "unwrappedPhase", "coherence", "amplitude", "bPerpendicular", "bParallel", "incidenceAngle", "lookAngle","azimuthAngle". If "all" is specified, then all layers are extracted. If blank, will only extract bounding box.')
+    parser.add_argument('-w', '--workdir', dest='workdir', default='./', help='Specify directory to deposit all outputs.'\
+                        'Default is local directory where script is launched.')
+    parser.add_argument('-tp', '--tropo_products', dest='tropo_products', type=str, default=None, help='Path to director(ies)'\
+                        'or tar file(s) containing GACOS products.')
+    parser.add_argument('-st', '--solid_tide', action='store_true', dest='solid_tide', help='If turned, solid Earth tide corrections will be applied.')
+    parser.add_argument('-l', '--layers', dest='layers', default=None, help='Specify layers to extract as a comma deliminated list'\
+                        'bounded by single quotes. Allowed keys are: "unwrappedPhase", "coherence", "amplitude", "bPerpendicular",'\
+                        '"bParallel", "incidenceAngle", "lookAngle","azimuthAngle". If "all" is specified, then all layers are extracted.'\
+                        'If blank, will only extract bounding box.')
     parser.add_argument('-d', '--demfile', dest='demfile', type=str,
             default=None, help='DEM file. To download new DEM, specify "Download".')
     parser.add_argument('-p', '--projection', dest='projection', default='WGS84', type=str,
             help='projection for DEM. By default WGS84.')
-    parser.add_argument('-b', '--bbox', dest='bbox', type=str, default=None, help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
-    parser.add_argument('-m', '--mask', dest='mask', type=str, default=None, help="Path to mask file or 'Download'. File needs to be GDAL compatabile, contain spatial reference information, and have invalid/valid data represented by 0/1, respectively. If 'Download', will use GSHHS water mask")
-    parser.add_argument('-at', '--amp_thresh', dest='amp_thresh', default=None, type=str, help='Amplitude threshold below which to mask. Specify "None" to not use amplitude mask. By default "None".')
-    parser.add_argument('-nt', '--num_threads', dest='num_threads', default='2', type=str, help='Specify number of threads for multiprocessing operation in gdal. By default "2". Can also specify "All" to use all available threads.')
+    parser.add_argument('-b', '--bbox', dest='bbox', type=str, default=None, help="Provide either valid shapefile or Lat/Lon Bounding SNWE."\
+                        "-- Example : '19 20 -99.5 -98.5'")
+    parser.add_argument('-m', '--mask', dest='mask', type=str, default=None, help="Path to mask file or 'Download'. File needs to be GDAL"\
+                        "compatabile, contain spatial reference information, and have invalid/valid data represented by 0/1, respectively."\
+                        "If 'Download', will use GSHHS water mask")
+    parser.add_argument('-at', '--amp_thresh', dest='amp_thresh', default=None, type=str, help='Amplitude threshold below which to mask.'\
+                        'Specify "None" to not use amplitude mask. By default "None".')
+    parser.add_argument('-nt', '--num_threads', dest='num_threads', default='2', type=str, help='Specify number of threads for'\
+                        'multiprocessing operation in gdal. By default "2". Can also specify "All" to use all available threads.')
 #    parser.add_argument('-sm', '--stitchMethod', dest='stitchMethodType',  type=str, default='overlap', help="Method applied to stitch the unwrapped data. Either 'overlap', where product overlap is minimized, or '2stage', where minimization is done on connected components, are allowed methods. Default is 'overlap'.")
-    parser.add_argument('-of', '--outputFormat', dest='outputFormat', type=str, default='VRT', help='GDAL compatible output format (e.g., "ENVI", "GTiff"). By default files are generated virtually except for "bPerpendicular", "bParallel", "incidenceAngle", "lookAngle","azimuthAngle", "unwrappedPhase" as these are require either DEM intersection or corrections to be applied')
-    parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection and bbox (if specified).")
-    parser.add_argument('-ml', '--multilooking', dest='multilooking', type=int, default=None, help='Multilooking factor is an integer multiple of standard resolution. E.g. 2 = 90m*2 = 180m')
-    parser.add_argument('-rr', '--rankedResampling', action='store_true', dest='rankedResampling', help="If turned on, IFGs resampled based off of the average of pixels in a given resampling window corresponding to the connected component mode (if multilooking specified). Program defaults to lanczos resampling algorithm through gdal (if multilooking specified).")
-    parser.add_argument('-mo', '--minimumOverlap', dest='minimumOverlap', type=float, default=0.0081, help='Minimum km\u00b2 area of overlap of scenes wrt specified bounding box. Default 0.0081 = 0.0081km\u00b2 = area of single pixel at standard 90m resolution"')
+    parser.add_argument('-of', '--outputFormat', dest='outputFormat', type=str, default='VRT', help='GDAL compatible output format'\
+                        '(e.g., "ENVI", "GTiff"). By default files are generated virtually except for "bPerpendicular", "bParallel",'\
+                        '"incidenceAngle", "lookAngle","azimuthAngle", "unwrappedPhase" as these are require either DEM intersection'\
+                        'or corrections to be applied.')
+    parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds"\
+                        "based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection"\
+                        "and bbox (if specified).")
+    parser.add_argument('-ml', '--multilooking', dest='multilooking', type=int, default=None, help='Multilooking factor is an integer multiple of'\
+                        'standard resolution. E.g. 2 = 90m*2 = 180m')
+    parser.add_argument('-rr', '--rankedResampling', action='store_true', dest='rankedResampling', help="If turned on, IFGs resampled"\
+                        "based off of the average of pixels in a given resampling window corresponding to the connected component mode"\
+                        "(if multilooking specified). Program defaults to lanczos resampling algorithm through gdal (if multilooking specified).")
+    parser.add_argument('-mo', '--minimumOverlap', dest='minimumOverlap', type=float, default=0.0081, help='Minimum km\u00b2 area of overlap of scenes'\
+                        'wrt specified bounding box. Default 0.0081 = 0.0081km\u00b2 = area of single pixel at standard 90m resolution"')
     parser.add_argument('-verbose', '--verbose', action='store_true', dest='verbose', help="Toggle verbose mode on.")
 
     return parser
@@ -100,7 +122,9 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir
 
     # If specified DEM subdirectory exists, delete contents
     workdir=os.path.join(workdir,'DEM')
-    if os.path.exists(workdir) and os.path.abspath(demfilename)!=os.path.abspath(os.path.join(workdir,os.path.basename(demfilename).split('.')[0].split('uncropped')[0]+'.dem')) and os.path.abspath(demfilename)!=os.path.abspath(os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'.dem')) or demfilename.lower()=='download':
+    if os.path.exists(workdir) and os.path.abspath(demfilename)!=os.path.abspath(os.path.join(workdir,os.path.basename(demfilename) \
+        .split('.')[0].split('uncropped')[0]+'.dem')) and os.path.abspath(demfilename)!=os.path.abspath(os.path.join(workdir,os.path.basename \
+        (demfilename).split('.')[0]+'.dem')) or demfilename.lower()=='download':
         for i in glob.glob(os.path.join(workdir,'*dem*')): os.remove(i)
     if not os.path.exists(workdir):
         os.mkdir(workdir)
@@ -119,7 +143,9 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir
         # save uncropped DEM
         gdal.BuildVRT(os.path.join(workdir,'SRTM_3arcsec_uncropped.dem.vrt'), _world_dem, options=gdal.BuildVRTOptions(outputBounds=bounds))
         # save cropped DEM
-        gdal.Warp(demfilename, os.path.join(workdir,'SRTM_3arcsec_uncropped.dem.vrt'), options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, outputType=gdal.GDT_Int16, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+        gdal.Warp(demfilename, os.path.join(workdir,'SRTM_3arcsec_uncropped.dem.vrt'), options=gdal.WarpOptions(format=outputFormat, \
+            cutlineDSName=prods_TOTbbox, outputBounds=bounds, outputType=gdal.GDT_Int16, width=arrshape[1], height=arrshape[0], multithread=True, \
+            options=['NUM_THREADS=%s'%(num_threads)]))
         update_file=gdal.Open(demfilename,gdal.GA_Update)
         update_file.SetProjection(proj) ; del update_file
         gdal.Translate(demfilename+'.vrt', demfilename, options=gdal.TranslateOptions(format="VRT")) #Make VRT
@@ -130,26 +156,32 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir
         # Check if uncropped/cropped DEMs exist in 'DEM' subdirectory
         if not os.path.exists(os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'.dem')):
             # save uncropped DEM
-            gdal.BuildVRT(os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'_uncropped.dem.vrt'), demfilename, options=gdal.BuildVRTOptions(outputBounds=bounds))
+            gdal.BuildVRT(os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'_uncropped.dem.vrt'), demfilename, \
+                options=gdal.BuildVRTOptions(outputBounds=bounds))
             # update demfilename
             demfilename=os.path.join(workdir,os.path.basename(demfilename).split('.')[0].split('uncropped')[0]+'.dem')
             # save cropped DEM
-            gdal.Warp(demfilename, os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'_uncropped.dem.vrt'), options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+            gdal.Warp(demfilename, os.path.join(workdir,os.path.basename(demfilename).split('.')[0]+'_uncropped.dem.vrt'), options=gdal.WarpOptions \
+                (format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], multithread=True, \
+                options=['NUM_THREADS=%s'%(num_threads)]))
             update_file=gdal.Open(demfilename,gdal.GA_Update)
             update_file.SetProjection(proj) ; del update_file
             gdal.Translate(demfilename+'.vrt', demfilename, options=gdal.TranslateOptions(format="VRT"))
             print('Saved DEM cropped to interferometric grid here: '+ demfilename)
 
         #pass cropped DEM
-        demfile = gdal.Warp('', demfilename, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, dstNodata=0, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+        demfile = gdal.Warp('', demfilename, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, \
+            dstNodata=0, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
         demfile.SetProjection(proj)
         demfile.SetDescription(demfilename)
 
         ##SS Do we need lon lat if we would be doing gdal reproject using projection and transformation? See our earlier discussions.
         # Define lat/lon arrays for fullres layers
-        Latitude=np.linspace(demfile.GetGeoTransform()[3],demfile.GetGeoTransform()[3]+(demfile.GetGeoTransform()[5]*demfile.RasterYSize),demfile.RasterYSize)
+        Latitude=np.linspace(demfile.GetGeoTransform()[3],demfile.GetGeoTransform()[3]+(demfile.GetGeoTransform() \
+            [5]*demfile.RasterYSize),demfile.RasterYSize)
         Latitude=np.repeat(Latitude[:, np.newaxis], demfile.RasterXSize, axis=1)
-        Longitude=np.linspace(demfile.GetGeoTransform()[0],demfile.GetGeoTransform()[0]+(demfile.GetGeoTransform()[1]*demfile.RasterXSize),demfile.RasterXSize)
+        Longitude=np.linspace(demfile.GetGeoTransform()[0],demfile.GetGeoTransform()[0]+(demfile.GetGeoTransform() \
+            [1]*demfile.RasterXSize),demfile.RasterXSize)
         Longitude=np.repeat(Longitude[:, np.newaxis], demfile.RasterYSize, axis=1)
         Longitude=Longitude.transpose()
     except:
@@ -157,7 +189,8 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, proj, arrshape=None, workdir
 
     return demfilename, demfile, Latitude, Longitude
 
-def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_thresh=None, arrshape=None, workdir='./', outputFormat='ENVI', num_threads='2'):
+def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_thresh=None, arrshape=None, workdir='./', outputFormat='ENVI', \
+              num_threads='2'):
     '''
         Function to load and export mask file.
         If "Download" flag is specified, GSHHS water mask will be donwloaded on the fly.
@@ -166,11 +199,18 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
     # Import functions
     from ARIAtools.vrtmanager import renderOGRVRT
 
-    _world_watermask = [' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L1.shp',' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L2.shp',' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L3.shp', ' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L4.shp',' /vsizip/vsicurl/https://osmdata.openstreetmap.de/download/land-polygons-complete-4326.zip/land-polygons-complete-4326/land_polygons.shp']
+    _world_watermask = [' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L1.shp', \
+                       ' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L2.shp', \
+                       ' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L3.shp', \
+                       ' /vsizip/vsicurl/http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip/GSHHS_shp/f/GSHHS_f_L4.shp', \
+                       ' /vsizip/vsicurl/https://osmdata.openstreetmap.de/download/land-polygons-complete-4326.zip/land-polygons-complete' \
+                       '-4326/land_polygons.shp']
 
     # If specified DEM subdirectory exists, delete contents
     workdir=os.path.join(workdir,'mask')
-    if os.path.exists(workdir) and os.path.abspath(maskfilename)!=os.path.abspath(os.path.join(workdir,os.path.basename(maskfilename).split('.')[0].split('uncropped')[0]+'.msk')) and os.path.abspath(maskfilename)!=os.path.abspath(os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'.msk')) or maskfilename.lower()=='download':
+    if os.path.exists(workdir) and os.path.abspath(maskfilename)!=os.path.abspath(os.path.join(workdir,os.path.basename(maskfilename).split('.')[0] \
+        .split('uncropped')[0]+'.msk')) and os.path.abspath(maskfilename)!=os.path.abspath(os.path.join(workdir,os.path.basename(maskfilename) \
+        .split('.')[0]+'.msk')) or maskfilename.lower()=='download':
         for i in glob.glob(os.path.join(workdir,'*.*')): os.remove(i)
     if not os.path.exists(workdir):
         os.mkdir(workdir)
@@ -194,17 +234,21 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
 
         ###Initiate water-mask with coastlines/islands union VRT
         # save uncropped mask
-        gdal.Rasterize(os.path.join(workdir,'watermask_uncropped.msk'), os.path.join(workdir,'watermsk_shorelines.vrt'), options=gdal.RasterizeOptions(format=outputFormat, outputBounds=bounds, outputType=gdal.GDT_Byte, width=arrshape[1], height=arrshape[0], burnValues=[1], layers='merged'))
-        gdal.Translate(os.path.join(workdir,'watermask_uncropped.msk.vrt'), os.path.join(workdir,'watermask_uncropped.msk'), options=gdal.TranslateOptions(format="VRT"))
+        gdal.Rasterize(os.path.join(workdir,'watermask_uncropped.msk'), os.path.join(workdir,'watermsk_shorelines.vrt'), options=gdal.RasterizeOptions \
+            (format=outputFormat, outputBounds=bounds, outputType=gdal.GDT_Byte, width=arrshape[1], height=arrshape[0], burnValues=[1], layers='merged'))
+        gdal.Translate(os.path.join(workdir,'watermask_uncropped.msk.vrt'), os.path.join(workdir,'watermask_uncropped.msk'), \
+            options=gdal.TranslateOptions(format="VRT"))
         # save cropped mask
-        gdal.Warp(maskfilename, os.path.join(workdir,'watermask_uncropped.msk.vrt'), options=gdal.WarpOptions(format=outputFormat, outputBounds=bounds, outputType=gdal.GDT_Byte, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+        gdal.Warp(maskfilename, os.path.join(workdir,'watermask_uncropped.msk.vrt'), options=gdal.WarpOptions(format=outputFormat, outputBounds=bounds, \
+            outputType=gdal.GDT_Byte, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
         update_file=gdal.Open(maskfilename,gdal.GA_Update)
         update_file.SetProjection(proj)
         update_file.GetRasterBand(1).SetNoDataValue(0.) ; del update_file
         gdal.Translate(maskfilename+'.vrt', maskfilename, options=gdal.TranslateOptions(format="VRT"))
 
         ###Must take inverse of lakes/ponds union because of opposite designation (1 for water, 0 for land) as desired (0 for water, 1 for land)
-        lake_masks=gdal.Rasterize('', os.path.join(workdir,'watermsk_lakes.vrt'), options=gdal.RasterizeOptions(format='MEM', outputBounds=bounds, outputType=gdal.GDT_Byte, width=arrshape[1], height=arrshape[0], burnValues=[1], layers='merged', inverse=True))
+        lake_masks=gdal.Rasterize('', os.path.join(workdir,'watermsk_lakes.vrt'), options=gdal.RasterizeOptions(format='MEM', outputBounds=bounds, \
+            outputType=gdal.GDT_Byte, width=arrshape[1], height=arrshape[0], burnValues=[1], layers='merged', inverse=True))
         lake_masks.SetProjection(proj)
         lake_masks=lake_masks.ReadAsArray()
 
@@ -214,9 +258,12 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
             for i in glob.glob(os.path.join(workdir,'avgamplitude*')): os.remove(i)
 
             # building the VRT
-            gdal.BuildVRT(os.path.join(workdir,'avgamplitude') +'.vrt', product_dict[0], options=gdal.BuildVRTOptions(resolution='highest', resampleAlg='average'))
+            gdal.BuildVRT(os.path.join(workdir,'avgamplitude') +'.vrt', product_dict[0], options=gdal.BuildVRTOptions(resolution='highest', \
+                resampleAlg='average'))
             # taking average of all scenes and generating raster
-            gdal.Warp(os.path.join(workdir,'avgamplitude'), os.path.join(workdir,'avgamplitude')+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, resampleAlg='average', width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+            gdal.Warp(os.path.join(workdir,'avgamplitude'), os.path.join(workdir,'avgamplitude')+'.vrt', options=gdal.WarpOptions(format=outputFormat, \
+                cutlineDSName=prods_TOTbbox, outputBounds=bounds, resampleAlg='average', width=arrshape[1], height=arrshape[0], multithread=True, \
+                options=['NUM_THREADS=%s'%(num_threads)]))
             # Update VRT
             gdal.Translate(os.path.join(workdir,'avgamplitude')+'.vrt', os.path.join(workdir,'avgamplitude'), options=gdal.TranslateOptions(format="VRT"))
             print('Saved average amplitude here: '+ os.path.join(workdir,'avgamplitude'))
@@ -239,16 +286,20 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
         # Check if uncropped/cropped maskfiles exist in 'mask' subdirectory
         if not os.path.exists(os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'.msk')):
             # save uncropped masfile
-            gdal.BuildVRT(os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'_uncropped.msk.vrt'), maskfilename, options=gdal.BuildVRTOptions(outputBounds=bounds))
+            gdal.BuildVRT(os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'_uncropped.msk.vrt'), maskfilename, \
+                options=gdal.BuildVRTOptions(outputBounds=bounds))
             # update maskfilename
             maskfilename=os.path.join(workdir,os.path.basename(maskfilename).split('.')[0].split('uncropped')[0]+'.msk')
             # save cropped maskfile
-            gdal.Warp(maskfilename, os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'_uncropped.msk.vrt'), options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+            gdal.Warp(maskfilename, os.path.join(workdir,os.path.basename(maskfilename).split('.')[0]+'_uncropped.msk.vrt'), options=gdal.WarpOptions \
+                (format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], multithread=True, \
+                options=['NUM_THREADS=%s'%(num_threads)]))
             mask_file = gdal.Open(maskfilename,gdal.GA_Update)
             mask_file.SetProjection(proj) ; del mask_file
             gdal.Translate(maskfilename+'.vrt', maskfilename, options=gdal.TranslateOptions(format="VRT"))
         #pass cropped DEM
-        mask=gdal.Warp('', maskfilename, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+        mask=gdal.Warp('', maskfilename, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], \
+            height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
         mask.SetProjection(proj)
         mask.SetDescription(maskfilename)
     except:
@@ -258,7 +309,8 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj, amp_th
 
 def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None, croptounion=False, num_threads='2', minimumOverlap=0.0081):
     '''
-        Extract/merge productBoundingBox layers for each pair and update dict, report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
+        Extract/merge productBoundingBox layers for each pair and update dict, report common track bbox (default is to take common intersection, 
+        but user may specify union), and expected shape for DEM.
     '''
 
     # Import functions
@@ -332,7 +384,8 @@ def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None
         bbox_file=prods_TOTbbox
 
     # Warp the first scene with the output-bounds defined above
-    ds=gdal.Warp('', gdal.BuildVRT('', product_dict[0]['unwrappedPhase'][0]), options=gdal.WarpOptions(format="MEM", outputBounds=open_shapefile(bbox_file, 0, 0).bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+    ds=gdal.Warp('', gdal.BuildVRT('', product_dict[0]['unwrappedPhase'][0]), options=gdal.WarpOptions(format="MEM", outputBounds= \
+        open_shapefile(bbox_file, 0, 0).bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
     # Get shape of full res layers
     arrshape=[ds.RasterYSize, ds.RasterXSize]
     # Get projection of full res layers
@@ -341,8 +394,8 @@ def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None
 
     return metadata_dict, product_dict, bbox_file, prods_TOTbbox, arrshape, proj
 
-
-def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedResampling=False, dem=None, lat=None, lon=None, mask=None, outDir='./',outputFormat='VRT', stitchMethodType='overlap', verbose=None, num_threads='2', multilooking=None):
+def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedResampling=False, dem=None, lat=None, lon=None, mask=None, \
+                    outDir='./',outputFormat='VRT', stitchMethodType='overlap', verbose=None, num_threads='2', multilooking=None):
     """
         Export layer and 2D meta-data layers (at the product resolution).
         The function finalize_metadata is called to derive the 2D metadata layer. Dem/lat/lon arrays must be passed for this process.
@@ -390,7 +443,8 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedR
                 if len(set([gdal.Open(i).GetMetadataItem('NETCDF_DIM_heightsMeta_VALUES') for i in [i[1]][0]]))==1:
                     gdal.Open(outname+'.vrt').SetMetadataItem('NETCDF_DIM_heightsMeta_VALUES',gdal.Open([i[1]][0][0]).GetMetadataItem('NETCDF_DIM_heightsMeta_VALUES'))
                 else:
-                    raise Exception('Inconsistent heights for metadata layer(s) ', [i[1]][0], ' corresponding heights: ', [gdal.Open(i).GetMetadataItem('NETCDF_DIM_heightsMeta_VALUES') for i in [i[1]][0]])
+                    raise Exception('Inconsistent heights for metadata layer(s) ', [i[1]][0], ' corresponding heights: ', \
+                        [gdal.Open(i).GetMetadataItem('NETCDF_DIM_heightsMeta_VALUES') for i in [i[1]][0]])
 
                 # Pass metadata layer VRT, with DEM filename and output name to interpolate/intersect with DEM before cropping
                 finalize_metadata(outname, open_shapefile(bbox_file, 0, 0).bounds, prods_TOTbbox, dem, lat, lon, mask, outputFormat, verbose=verbose)
@@ -401,11 +455,13 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedR
                     # building the virtual vrt
                     gdal.BuildVRT(outname+ "_uncropped" +'.vrt', [i[1]][0])
                     # building the cropped vrt
-                    gdal.Warp(outname+'.vrt', outname+"_uncropped"+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+                    gdal.Warp(outname+'.vrt', outname+"_uncropped"+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, \
+                        outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
                 else:
                     # building the VRT
                     gdal.BuildVRT(outname +'.vrt', [i[1]][0])
-                    gdal.Warp(outname, outname+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+                    gdal.Warp(outname, outname+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, \
+                        outputBounds=bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
 
                     # Update VRT
                     gdal.Translate(outname+'.vrt', outname, options=gdal.TranslateOptions(format="VRT"))
@@ -419,7 +475,8 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedR
             # Extract/crop "unw" and "conn_comp" layers leveraging the two stage unwrapper
             else:
                 # Check if unw phase and connected components are already generated
-                if not os.path.exists(os.path.join(outDir,'unwrappedPhase',product_dict[1][i[0]][0])) or not os.path.exists(os.path.join(outDir,'connectedComponents',product_dict[1][i[0]][0])):
+                if not os.path.exists(os.path.join(outDir,'unwrappedPhase',product_dict[1][i[0]][0])) \
+                    or not os.path.exists(os.path.join(outDir,'connectedComponents',product_dict[1][i[0]][0])):
                     # extract the inputs required for stitching of unwrapped and connected component files
                     unw_files = full_product_dict[i[0]]['unwrappedPhase']
                     conn_files = full_product_dict[i[0]]['connectedComponents']
@@ -430,9 +487,11 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedR
 
                     # calling the stitching methods
                     if stitchMethodType == 'overlap':
-                        product_stitch_overlap(unw_files,conn_files,prod_bbox_files,bounds,prods_TOTbbox, outFileUnw=outFileUnw,outFileConnComp= outFileConnComp, mask=mask,outputFormat = outputFormat,verbose=verbose)
+                        product_stitch_overlap(unw_files,conn_files,prod_bbox_files,bounds,prods_TOTbbox, outFileUnw=outFileUnw, \
+                            outFileConnComp= outFileConnComp, mask=mask,outputFormat = outputFormat,verbose=verbose)
                     elif stitchMethodType == '2stage':
-                        product_stitch_2stage(unw_files,conn_files,bounds,prods_TOTbbox,outFileUnw=outFileUnw,outFileConnComp= outFileConnComp, mask=mask,outputFormat = outputFormat,verbose=verbose)
+                        product_stitch_2stage(unw_files,conn_files,bounds,prods_TOTbbox,outFileUnw=outFileUnw,outFileConnComp=outFileConnComp, \
+                            mask=mask,outputFormat = outputFormat,verbose=verbose)
 
                     #If necessary, resample both unw/conn_comp files
                     if multilooking is not None:
@@ -465,13 +524,16 @@ def finalize_metadata(outname, bbox_bounds, prods_TOTbbox, dem, lat, lon, mask=N
     if round((max(bbox_bounds[0::2])-min(bbox_bounds[0::2])),2)<round((abs(geotrans[1])*4),2) or round((max(bbox_bounds[1::2])-min(bbox_bounds[1::2])),2)<round((abs(geotrans[-1])*4),2):
         data_array=gdal.Warp('', outname+'.vrt', options=gdal.WarpOptions(format="MEM", multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
     else:
-        data_array=gdal.Warp('', outname+'.vrt', options=gdal.WarpOptions(format="MEM", outputBounds=bbox_bounds, multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+        data_array=gdal.Warp('', outname+'.vrt', options=gdal.WarpOptions(format="MEM", outputBounds=bbox_bounds, multithread=True, \
+            options=['NUM_THREADS=%s'%(num_threads)]))
 
     # Define lat/lon/height arrays for metadata layers
     heightsMeta=np.array(gdal.Open(outname+'.vrt').GetMetadataItem('NETCDF_DIM_heightsMeta_VALUES')[1:-1].split(','), dtype='float32')
     ##SS Do we need lon lat if we would be doing gdal reproject using projection and transformation? See our earlier discussions.
-    latitudeMeta=np.linspace(data_array.GetGeoTransform()[3],data_array.GetGeoTransform()[3]+(data_array.GetGeoTransform()[5]*data_array.RasterYSize),data_array.RasterYSize)
-    longitudeMeta=np.linspace(data_array.GetGeoTransform()[0],data_array.GetGeoTransform()[0]+(data_array.GetGeoTransform()[1]*data_array.RasterXSize),data_array.RasterXSize)
+    latitudeMeta=np.linspace(data_array.GetGeoTransform()[3],data_array.GetGeoTransform()[3]+ \
+        (data_array.GetGeoTransform()[5]*data_array.RasterYSize),data_array.RasterYSize)
+    longitudeMeta=np.linspace(data_array.GetGeoTransform()[0],data_array.GetGeoTransform()[0]+ \
+        (data_array.GetGeoTransform()[1]*data_array.RasterXSize),data_array.RasterXSize)
 
     # First, using the height/latitude/longitude arrays corresponding to the metadata layer, set-up spatial 2D interpolator. Using this, perform vertical 1D interpolation on cube, and then use result to set-up a regular-grid-interpolator. Using this, pass DEM and full-res lat/lon arrays in order to get intersection with DEM.
 
@@ -486,15 +548,18 @@ def finalize_metadata(outname, bbox_bounds, prods_TOTbbox, dem, lat, lon, mask=N
                 out_interpolated[hgt[0], line[0], pixel[0]] = interp_2d(line[1], pixel[1], hgt[1])
     out_interpolated=np.flip(out_interpolated, axis=0)
     # interpolate to interferometric grid
-    interpolator = scipy.interpolate.RegularGridInterpolator((heightsMeta,np.flip(latitudeMeta, axis=0),longitudeMeta), out_interpolated, method='linear', fill_value=data_array.GetRasterBand(1).GetNoDataValue())
+    interpolator = scipy.interpolate.RegularGridInterpolator((heightsMeta,np.flip(latitudeMeta, axis=0),longitudeMeta), out_interpolated, \
+        method='linear', fill_value=data_array.GetRasterBand(1).GetNoDataValue())
     out_interpolated = interpolator(np.stack((np.flip(dem.ReadAsArray(), axis=0), lat, lon), axis=-1))
 
     # Save file
-    renderVRT(outname, out_interpolated, geotrans=dem.GetGeoTransform(), drivername=outputFormat, gdal_fmt=data_array.ReadAsArray().dtype.name, proj=dem.GetProjection(), nodata=data_array.GetRasterBand(1).GetNoDataValue())
+    renderVRT(outname, out_interpolated, geotrans=dem.GetGeoTransform(), drivername=outputFormat, gdal_fmt=data_array.ReadAsArray().dtype.name, \
+        proj=dem.GetProjection(), nodata=data_array.GetRasterBand(1).GetNoDataValue())
 
     # Since metadata layer extends at least one grid node outside of the expected track bounds, it must be cut to conform with these bounds.
     # Crop to track extents
-    out_interpolated=gdal.Warp('', outname, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, dstNodata=data_array.GetRasterBand(1).GetNoDataValue(), multithread=True, options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
+    out_interpolated=gdal.Warp('', outname, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, \
+        dstNodata=data_array.GetRasterBand(1).GetNoDataValue(), multithread=True, options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
 
     # Apply mask (if specified).
     if mask is not None:
@@ -525,8 +590,10 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
     user_bbox=open_shapefile(bbox_file, 0, 0)
     bounds=user_bbox.bounds
 
-    product_dict=[[j['unwrappedPhase'] for j in full_product_dict[1]], [j['lookAngle'] for j in full_product_dict[1]], [j["pair_name"] for j in full_product_dict[1]]]
-    metadata_dict=[[j['azimuthZeroDopplerStartTime'] for j in full_product_dict[0]], [j['azimuthZeroDopplerEndTime'] for j in full_product_dict[0]], [j['wavelength'] for j in full_product_dict[0]]]
+    product_dict=[[j['unwrappedPhase'] for j in full_product_dict[1]], [j['lookAngle'] for j in full_product_dict[1]], \
+        [j["pair_name"] for j in full_product_dict[1]]]
+    metadata_dict=[[j['azimuthZeroDopplerStartTime'] for j in full_product_dict[0]], [j['azimuthZeroDopplerEndTime'] for j in full_product_dict[0]], \
+        [j['wavelength'] for j in full_product_dict[0]]]
     workdir=os.path.join(outDir,'tropocorrected_products')
 
     # If specified workdir doesn't exist, create it
@@ -545,7 +612,8 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
     if len([str(val) for val in tropo_products.split(',')])>1:
         tropo_products=[str(i) for i in tropo_products.split(',')]
         # If wildcard
-        tropo_products=[os.path.abspath(item) for sublist in [glob.glob(os.path.expanduser(os.path.expandvars(i))) if '*' in i else [i] for i in tropo_products] for item in sublist]
+        tropo_products=[os.path.abspath(item) for sublist in [glob.glob(os.path.expanduser(os.path.expandvars(i))) if '*' in i else [i] \
+            for i in tropo_products] for item in sublist]
     # If single file or wildcard
     else:
         # If single file
@@ -576,14 +644,17 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             # Only check files corresponding to standard product dates
             if os.path.basename(k)[:-4] in date_list:
                 tropo_date_dict[os.path.basename(k)[:-4]].append(k)
-                tropo_date_dict[os.path.basename(k)[:-4]+"_UTC"].append(os.path.basename(k)[:4]+'-'+os.path.basename(k)[4:6]+'-'+os.path.basename(k)[6:8]+'-'+open(k+'.rsc', 'r').readlines()[-1].split()[1])
+                tropo_date_dict[os.path.basename(k)[:-4]+"_UTC"].append(os.path.basename(k)[:4]+'-'+os.path.basename(k)[4:6]+'-'+ \
+                    os.path.basename(k)[6:8]+'-'+open(k+'.rsc', 'r').readlines()[-1].split()[1])
                 # make corresponding VRT file, if it doesn't exist
                 if not os.path.exists(k+'.vrt'):
                     tropo_rsc_dict={}
                     for line in open(k+'.rsc', 'r').readlines(): tropo_rsc_dict[line.split()[0]]=line.split()[1]
                     gacos_prod=np.fromfile(k, dtype='float32').reshape(int(tropo_rsc_dict['FILE_LENGTH']),int(tropo_rsc_dict['WIDTH']))
                     # Save as GDAL file, using proj from first unwrappedPhase file
-                    renderVRT(k, gacos_prod, geotrans=(float(tropo_rsc_dict['X_FIRST']), float(tropo_rsc_dict['X_STEP']), 0.0, float(tropo_rsc_dict['Y_FIRST']), 0.0, float(tropo_rsc_dict['Y_STEP'])), drivername=outputFormat, gdal_fmt='float32', proj=gdal.Open(os.path.join(outDir,'unwrappedPhase',product_dict[2][0][0])).GetProjection(), nodata=0.)
+                    renderVRT(k, gacos_prod, geotrans=(float(tropo_rsc_dict['X_FIRST']), float(tropo_rsc_dict['X_STEP']), 0.0, \
+                        float(tropo_rsc_dict['Y_FIRST']), 0.0, float(tropo_rsc_dict['Y_STEP'])), drivername=outputFormat, gdal_fmt='float32', \
+                         proj=gdal.Open(os.path.join(outDir,'unwrappedPhase',product_dict[2][0][0])).GetProjection(), nodata=0.)
                     gacos_prod = None
                     if verbose:
                         print("GACOS product %s successfully converted to GDAL-readable raster"%(k))
@@ -605,7 +676,8 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
                 geotrans=gdal.Open(outname).GetGeoTransform()
                 # Create merge rsc file
                 with open(outname[:-4]+'.rsc','w') as merged_rsc:
-                    merged_rsc.write('WIDTH %s\n'%(gdal.Open(outname).ReadAsArray().shape[1])) ; merged_rsc.write('FILE_LENGTH %s\n'%(gdal.Open(outname).ReadAsArray().shape[0]))
+                    merged_rsc.write('WIDTH %s\n'%(gdal.Open(outname).ReadAsArray().shape[1]))
+                    merged_rsc.write('FILE_LENGTH %s\n'%(gdal.Open(outname).ReadAsArray().shape[0]))
                     merged_rsc.write('XMIN %s\n'%(0)) ; merged_rsc.write('XMAX %s\n'%(gdal.Open(outname).ReadAsArray().shape[1]))
                     merged_rsc.write('YMIN %s\n'%(0)) ; merged_rsc.write('YMAX %s\n'%(gdal.Open(outname).ReadAsArray().shape[0]))
                     merged_rsc.write('X_FIRST %f\n'%(geotrans[0])) ; merged_rsc.write('Y_FIRST %f\n'%(geotrans[3]))
@@ -621,8 +693,9 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
     for i in glob.glob(os.path.join(tropo_products,'*.ztd.vrt')):
         # create shapefile
         geotrans=gdal.Open(i).GetGeoTransform()
-        bbox=[geotrans[3]+(gdal.Open(i).ReadAsArray().shape[0]*geotrans[-1]),geotrans[3],geotrans[0],geotrans[0]+(gdal.Open(i).ReadAsArray().shape[1]*geotrans[1])]
-        bbox=Polygon(np.column_stack((np.array([bbox[2],bbox[3],bbox[3],bbox[2],bbox[2]]),
+        bbox=[geotrans[3]+(gdal.Open(i).ReadAsArray().shape[0]*geotrans[-1]),geotrans[3],geotrans[0],geotrans[0]+ \
+            (gdal.Open(i).ReadAsArray().shape[1]*geotrans[1])]
+        bbox=Polygon(np.column_stack((np.array([bbox[2],bbox[3],bbox[3],bbox[2],bbox[2]]), \
                             np.array([bbox[0],bbox[0],bbox[1],bbox[1],bbox[0]]))))
         save_shapefile(i+'.shp', bbox, 'GeoJSON')
         per_overlap=((user_bbox.intersection(open_shapefile(i+'.shp', 0, 0)).area)/(user_bbox.area))*100
@@ -642,23 +715,29 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             for j in [tropo_reference, tropo_secondary]:
                 # Get ARIA product times
                 aria_rsc_dict={}
-                aria_rsc_dict['azimuthZeroDopplerStartTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S.%fZ") for m in metadata_dict[0][0]]
-                aria_rsc_dict['azimuthZeroDopplerEndTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S.%fZ") for m in metadata_dict[1][0]]
+                aria_rsc_dict['azimuthZeroDopplerStartTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+ \
+                    os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S.%fZ") for m in metadata_dict[0][0]]
+                aria_rsc_dict['azimuthZeroDopplerEndTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+ \
+                    os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S.%fZ") for m in metadata_dict[1][0]]
                 # Get tropo product UTC times
                 tropo_rsc_dict={}
                 tropo_rsc_dict['TIME_OF_DAY']=open(j[:-4]+'.rsc', 'r').readlines()[-1].split()[1].split('UTC')[:-1]
                 # If stitched tropo product, must account for date change (if applicable)
                 if '-' in tropo_rsc_dict['TIME_OF_DAY'][0]:
-                    tropo_rsc_dict['TIME_OF_DAY']=[datetime.strptime(m[:10]+'-'+m[11:].split('.')[0]+'-'+str(round(float('0.'+m[11:].split('.')[1])*60)), "%Y-%m-%d-%H-%M") for m in tropo_rsc_dict['TIME_OF_DAY']]
+                    tropo_rsc_dict['TIME_OF_DAY']=[datetime.strptime(m[:10]+'-'+m[11:].split('.')[0]+'-'+ \
+                        str(round(float('0.'+m[11:].split('.')[1])*60)), "%Y-%m-%d-%H-%M") for m in tropo_rsc_dict['TIME_OF_DAY']]
                 else:
-                    tropo_rsc_dict['TIME_OF_DAY']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[0]+'-'+str(round(float('0.'+tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[-1])*60)), "%Y-%m-%d-%H-%M")]
+                    tropo_rsc_dict['TIME_OF_DAY']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+ \
+                        os.path.basename(j)[6:8]+'-'+tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[0]+'-'+ \
+                        str(round(float('0.'+tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[-1])*60)), "%Y-%m-%d-%H-%M")]
 
                 # Check and report if tropospheric product falls outside of standard product range
                 latest_start = max(aria_rsc_dict['azimuthZeroDopplerStartTime']+[min(tropo_rsc_dict['TIME_OF_DAY'])])
                 earliest_end = min(aria_rsc_dict['azimuthZeroDopplerEndTime']+[max(tropo_rsc_dict['TIME_OF_DAY'])])
                 delta = (earliest_end - latest_start).total_seconds() + 1
                 if delta<0:
-                    print("WARNING: tropospheric product was generated %f secs outside of acquisition interval for scene %s in IFG %s"%(abs(delta), os.path.basename(j)[:8], product_dict[2][i][0]))
+                    print("WARNING: tropospheric product was generated %f secs outside of acquisition interval for scene %s in IFG %s" \
+                        %(abs(delta), os.path.basename(j)[:8], product_dict[2][i][0]))
 
             # Open unwrappedPhase and mask nodata
             unwphase=gdal.Open(unwname)
@@ -668,9 +747,13 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             unwphase=np.ma.masked_where(unwphase == unwnodata, unwphase)
 
             # Open corresponding tropo products and pass the difference
-            tropo_product=gdal.Warp('', tropo_reference, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], resampleAlg='lanczos', dstNodata=0., multithread=True, options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
+            tropo_product=gdal.Warp('', tropo_reference, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, \
+                width=arrshape[1], height=arrshape[0], resampleAlg='lanczos', dstNodata=0., multithread=True, \
+                options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
             tropo_product=np.ma.masked_where(tropo_product == 0., tropo_product)
-            tropo_secondary=gdal.Warp('', tropo_secondary, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, width=arrshape[1], height=arrshape[0], resampleAlg='lanczos', dstNodata=0., multithread=True, options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
+            tropo_secondary=gdal.Warp('', tropo_secondary, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds, \
+                width=arrshape[1], height=arrshape[0], resampleAlg='lanczos', dstNodata=0., multithread=True, \
+                options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
             tropo_secondary=np.ma.masked_where(tropo_secondary == 0., tropo_secondary)
             tropo_product=np.subtract(tropo_secondary,tropo_product)
 
@@ -694,8 +777,159 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             del unwphase, tropo_product, tropo_reference, tropo_secondary, lookfile
 
         else:
-            print("WARNING: Must skip IFG %s, because the tropospheric products corresponding to the reference and/or secondary products are not found in the specified folder %s"%(product_dict[2][i][0],tropo_products))
+            print("WARNING: Must skip IFG %s, because the tropospheric products corresponding to the reference and/or secondary products are not" \
+                "found in the specified folder %s"%(product_dict[2][i][0],tropo_products))
 
+def solidtide_correction(full_product_dict, bbox_file, prods_TOTbbox, inDir='unwrappedPhase', outDir='./',outputFormat='VRT', verbose=None, \
+    num_threads='2'):
+    """
+        Perform solid earth tide corrections. Source of code= Dennis Milbert: http://geodesyworld.github.io/SOFTS/solid.htm
+        All products are cropped by the bounds from the input bbox_file, and clipped to the track extent denoted by the input prods_TOTbbox.
+    """
+
+    # Import functions
+    from ARIAtools.vrtmanager import renderVRT
+    from datetime import datetime, timedelta
+    import shutil
+    import pandas as pd
+    from solid_grid import solidwrapped
+
+    # File must be physically extracted, cannot proceed with VRT format. Defaulting to ENVI format.
+    if outputFormat=='VRT':
+        outputFormat='ENVI'
+
+    user_bbox=open_shapefile(bbox_file, 0, 0)
+    bounds=user_bbox.bounds
+
+    product_dict=[[j['unwrappedPhase'] for j in full_product_dict[1] if os.path.exists(os.path.join(outDir,inDir,j["pair_name"][0]))], \
+        [j['lookAngle'] for j in full_product_dict[1] if os.path.exists(os.path.join(outDir,inDir,j["pair_name"][0]))], \
+        [j["pair_name"] for j in full_product_dict[1] if os.path.exists(os.path.join(outDir,inDir,j["pair_name"][0]))]]
+    metadata_dict=[[j['azimuthZeroDopplerStartTime'] for j in full_product_dict[0] if os.path.exists(os.path.join(outDir,inDir,j["pair_name"][0]))], \
+        [j['azimuthZeroDopplerEndTime'] for j in full_product_dict[0] if os.path.exists(os.path.join(outDir,inDir,j["pair_name"][0]))], \
+        [j['wavelength'] for j in full_product_dict[0] if os.path.exists(os.path.join(outDir,inDir,j["pair_name"][0]))]]
+    workdir=os.path.join(outDir,'earthtidecorrected_products')
+
+    # If specified workdir doesn't exist, create it
+    if not os.path.exists(workdir):
+        os.mkdir(workdir)
+        print('Created directory: {}'.format(workdir))
+
+    # Get list of all dates for which standard products exist
+    date_list=[]
+    aria_rsc_dict={}
+    # Estimate time range of standard product
+    earliest_start=max([datetime.strptime('2020-01-25-'+m[0][11:], "%Y-%m-%d-%H:%M:%S.%fZ") for m in metadata_dict[0]])
+    latest_end=min([datetime.strptime('2020-01-25-'+m[0][11:], "%Y-%m-%d-%H:%M:%S.%fZ") for m in metadata_dict[1]])
+    delta = ((latest_end - earliest_start).total_seconds())/2
+    mid_time = earliest_start + timedelta(seconds=delta)
+    mid_time = mid_time.strftime("%Y-%m-%d-%H:%M:%S.%f")
+    for i in product_dict[2]:
+        date_list.append(i[0][:8]); date_list.append(i[0][9:])
+    date_list=list(set(date_list)) # trim to unique dates only
+    for i in date_list:
+        aria_rsc_dict[i]=datetime.strptime(i[:4]+'-'+i[4:6]+'-'+i[6:8]+'-'+mid_time[11:], "%Y-%m-%d-%H:%M:%S.%f")
+
+    # Get azimuth/incidence angle filenames
+    incfilename=sorted(os.listdir(os.path.join(outDir,'incidenceAngle')), key=lambda filename: \
+        os.path.getsize(os.path.join(outDir,'incidenceAngle', filename)))[-1]
+    azfilename=os.path.join(outDir,'azimuthAngle',incfilename)
+    incfilename=os.path.join(outDir,'incidenceAngle',incfilename)
+    geotrans=gdal.Open(azfilename).GetGeoTransform();  proj=gdal.Open(azfilename).GetProjection()
+    #sampling increment of full-res layer, hardcoded to reflect metadata-layer resolution
+    samp_inc=100
+    #get subsampled dataset geotrans/bbox
+    ds_geotrans=[geotrans[0],geotrans[1]*samp_inc,0.,geotrans[3],0.,geotrans[-1]*samp_inc]
+    ds_bounds=list(bounds[:])
+    #add buffer, if necessary
+    #in x-dim
+    dim_buffer=np.arange(ds_bounds[0],ds_bounds[2],abs(ds_geotrans[1]))
+    ds_bounds[2]=(2*abs(ds_geotrans[1]))+dim_buffer[-1]
+    #in y-dim
+    dim_buffer=np.arange(ds_bounds[1],ds_bounds[-1],abs(ds_geotrans[-1]))
+    ds_bounds[-1]=(2*abs(ds_geotrans[-1]))+dim_buffer[-1]
+   
+    # Run solid_grid program
+    for i in date_list:
+        #arguments=yyyy, mm, dd, hh, mm, ss, latmin, lonmin, latmax, lonmax, spacingx, spacingy, increment, path to output file
+        solidwrapped(aria_rsc_dict[i].year,aria_rsc_dict[i].month,aria_rsc_dict[i].day,aria_rsc_dict[i].hour,aria_rsc_dict[i].minute, \
+            aria_rsc_dict[i].second,ds_bounds[1],ds_bounds[0],ds_bounds[-1],ds_bounds[2],geotrans[1],abs(geotrans[-1]),samp_inc, \
+            os.path.join(workdir,i+'.txt'))
+    #create temp file to circumvent fortran bug which cuts off last file in loop
+    solidwrapped(aria_rsc_dict[i].year,aria_rsc_dict[i].month,aria_rsc_dict[i].day,aria_rsc_dict[i].hour,aria_rsc_dict[i].minute, \
+        aria_rsc_dict[i].second,ds_bounds[1],ds_bounds[0],ds_bounds[-1],ds_bounds[2],geotrans[1],abs(geotrans[-1]),samp_inc, \
+        os.path.join(workdir,i+'TMP.txt'))
+    os.remove(os.path.join(workdir,i+'TMP.txt'))
+
+    # Iterate through all IFGs and apply corrections
+    for i in range(len(product_dict[0])):
+        unwname=os.path.join(outDir,inDir,product_dict[2][i][0])
+        outname=os.path.join(workdir,product_dict[2][i][0])
+        setide_reference=os.path.join(workdir,product_dict[2][i][0][:8]+'.txt')
+        setide_secondary=os.path.join(workdir,product_dict[2][i][0][9:]+'.txt' )
+        # Load text-file data-frames
+        df_reference = pd.read_csv(setide_reference, skiprows=3)
+        df_secondary = pd.read_csv(setide_secondary, skiprows=3)
+        # Get LOS look-up table
+        if 'incfile_lookup' not in locals() or 'azfile_lookup' not in locals():
+            ds_bounds=[min(df_reference['lon'].unique())-abs(samp_inc*geotrans[1]),min(df_reference['lat'].unique())-abs(samp_inc*geotrans[-1]), \
+                max(df_reference['lon'].unique())+abs(samp_inc*geotrans[1]),max(df_reference['lat'].unique())+abs(samp_inc*geotrans[-1])]
+            #oversample to full-res azimuth/incidence angle files
+            azfile=gdal.Warp('', azfilename, options=gdal.WarpOptions(format="MEM", outputBounds=ds_bounds, xRes=abs(geotrans[1]), \
+                yRes=abs(geotrans[-1]), resampleAlg='bilinear',multithread=True, options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
+            incfile=gdal.Warp('', incfilename, options=gdal.WarpOptions(format="MEM", outputBounds=ds_bounds, xRes=abs(geotrans[1]), \
+                yRes=abs(geotrans[-1]), resampleAlg='bilinear',multithread=True, options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
+            #append fields and mask nodata values
+            pixel=((df_reference['lon'] - round(ds_bounds[0],9)) / geotrans[1]).astype(int)
+            line=((df_reference['lat'] - round(ds_bounds[3],9)) / geotrans[-1]).astype(int)
+            incfile_lookup=np.deg2rad(pd.DataFrame({'INCvalue': incfile[line,pixel]}).astype(float))
+            azfile_lookup=np.deg2rad(pd.DataFrame({'AZvalue': azfile[line,pixel]}).astype(float))
+            incfile_lookup['INCvalue']=incfile_lookup.where(incfile_lookup!=0.)
+            azfile_lookup['AZvalue']=azfile_lookup.where(azfile_lookup!=0.)
+            del incfile, azfile, pixel, line
+        df_reference['INCvalue'] = df_reference.index.map(incfile_lookup['INCvalue'])
+        df_reference['AZvalue'] = df_reference.index.map(azfile_lookup['AZvalue'])
+        df_secondary['INCvalue'] = df_secondary.index.map(incfile_lookup['INCvalue'])
+        df_secondary['AZvalue'] = df_secondary.index.map(azfile_lookup['AZvalue'])
+        #project to LOS, formula=-(x(k)*cos(dlos)+y(k)*sin(dlos))*sin(inc)-z(k)*cos(inc) 
+        df_reference['PROJvalue'] = (-((df_reference['ut']*np.cos(df_reference['AZvalue']))+(df_reference['vt']*np.sin(df_reference['AZvalue'])))* \
+            np.sin(df_reference['INCvalue']))-(df_reference['wt']*np.cos(df_reference['INCvalue']))
+        df_secondary['PROJvalue'] = (-((df_secondary['ut']*np.cos(df_secondary['AZvalue']))+(df_secondary['vt']*np.sin(df_secondary['AZvalue'])))* \
+            np.sin(df_secondary['INCvalue']))-(df_secondary['wt']*np.cos(df_secondary['INCvalue']))
+        #get differential
+        se_product=np.flipud(df_secondary['PROJvalue'].to_numpy().reshape(len(df_secondary['lat'].unique()),len(df_secondary['lon'].unique()))- \
+            df_reference['PROJvalue'].to_numpy().reshape(len(df_reference['lat'].unique()),len(df_reference['lon'].unique())))
+        se_product=np.nan_to_num(se_product)
+        #update output geotrans to reflect dataframe bounds
+        ds_geotrans[0]=min(df_reference['lon']) ; ds_geotrans[3]=max(df_reference['lat'])
+        ds_geotrans[1]=(max(df_reference['lon'])-min(df_reference['lon']))/se_product.shape[1]
+        ds_geotrans[-1]=(min(df_reference['lat'])-max(df_reference['lat']))/se_product.shape[0]
+        renderVRT(outname+'_sediff', se_product, geotrans=ds_geotrans, drivername=outputFormat, gdal_fmt='float32', proj=proj, nodata=0.)
+        #extrapolate through nodata
+        src_ds = gdal.Open(outname+'_sediff', gdal.GA_Update) 
+        srcband=src_ds.GetRasterBand(1)
+        result = gdal.FillNodata(targetBand=srcband,maskBand=None, maxSearchDist=100, smoothingIterations=1)
+        src_ds = None
+        #oversample to full-res
+        gdal.Warp(outname+'_sediff', outname+'_sediff', options=gdal.WarpOptions(format=outputFormat, outputBounds=bounds, xRes=abs(geotrans[1]), \
+            yRes=abs(geotrans[-1]), resampleAlg='bilinear',multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
+        gdal.Warp(outname+'_sediff', outname+'_sediff', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, \
+            dstNodata=0.,multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
+        # update VRT
+        gdal.BuildVRT(outname+'_sediff.vrt', outname+'_sediff', options=gdal.BuildVRTOptions(options=['-overwrite']))
+        #correct phase and save to file
+        unwphase=gdal.Open(unwname)
+        unwnodata=unwphase.GetRasterBand(1).GetNoDataValue()
+        unwphase=unwphase.ReadAsArray()
+        unwphase=np.ma.masked_where(unwphase == unwnodata, unwphase)
+        se_product=gdal.Open(outname+'_sediff').ReadAsArray()
+        unwphase=np.subtract(unwphase,se_product)
+        np.ma.set_fill_value(unwphase, unwnodata)
+        renderVRT(outname, unwphase.filled(), geotrans=geotrans, drivername=outputFormat, gdal_fmt='float32', proj=proj, nodata=unwnodata)
+        del se_product, srcband, unwphase, df_reference, df_secondary
+    #remove .txt files
+    sefiles=glob.glob(os.path.expanduser(os.path.expandvars(os.path.join(workdir,'*.txt'))))
+    for i in sefiles:
+        os.remove(i)
 
 def main(inps=None):
     '''
@@ -710,17 +944,27 @@ def main(inps=None):
     # In addition, path to bbox file ['standardproduct_info.bbox_file'] (if bbox specified)
     standardproduct_info = ARIA_standardproduct(inps.imgfile, bbox=inps.bbox, workdir=inps.workdir, verbose=inps.verbose)
 
-    if not inps.layers and not inps.tropo_products:
+    if not inps.layers and not inps.tropo_products and not inps.solid_tide:
         print('No layers specified; only creating bounding box shapes')
 
     elif inps.tropo_products:
-        print('Tropospheric corrections will be applied, making sure at least unwrappedPhase and lookAngle are extracted.')
+        print('Corrections involving unwrappedPhase and lookAngle will be applied, making sure at least these layers are extracted.')
         # If no input layers specified, initialize list
         if not inps.layers: inps.layers=[]
         # If valid argument for input layers passed, parse to list
         if isinstance(inps.layers,str): inps.layers=list(inps.layers.split(',')) ; inps.layers=[i.replace(' ','') for i in inps.layers]
         if 'lookAngle' not in inps.layers: inps.layers.append('lookAngle')
         if 'unwrappedPhase' not in inps.layers: inps.layers.append('unwrappedPhase')
+
+    elif inps.solid_tide:
+        print('Corrections involving unwrappedPhase, incidenceAngle, and azimuthAngle will be applied, making sure at least these layers are extracted.')
+        # If no input layers specified, initialize list
+        if not inps.layers: inps.layers=[]
+        # If valid argument for input layers passed, parse to list
+        if isinstance(inps.layers,str): inps.layers=list(inps.layers.split(',')) ; inps.layers=[i.replace(' ','') for i in inps.layers]
+        if 'unwrappedPhase' not in inps.layers: inps.layers.append('unwrappedPhase')
+        if 'incidenceAngle' not in inps.layers: inps.layers.append('incidenceAngle')
+        if 'azimuthAngle' not in inps.layers: inps.layers.append('azimuthAngle')
 
     elif inps.layers.lower()=='all':
         print('All layers are to be extracted, pass all keys.')
@@ -741,21 +985,28 @@ def main(inps=None):
 
     # extract/merge productBoundingBox layers for each pair and update dict,
     # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-    standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap)
+    standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj =  \
+        merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), \
+        standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap)
     # Load or download mask (if specified).
     if inps.mask is not None:
-        inps.mask = prep_mask([[item for sublist in [list(set(d['amplitude'])) for d in standardproduct_info.products[1] if 'amplitude' in d] for item in sublist], [item for sublist in [list(set(d['pair_name'])) for d in standardproduct_info.products[1] if 'pair_name' in d] for item in sublist]], inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
-
+        inps.mask = prep_mask([[item for sublist in [list(set(d['amplitude'])) for d in standardproduct_info.products[1] if 'amplitude' in d] \
+            for item in sublist], [item for sublist in [list(set(d['pair_name'])) for d in standardproduct_info.products[1] if 'pair_name' in d] \
+            for item in sublist]], inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, \
+            workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Download/Load DEM & Lat/Lon arrays, providing bbox, expected DEM shape, and output dir as input.
     if inps.demfile is not None:
         # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, \
+            arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
     else:
         demfile=None ; Latitude=None ; Longitude=None
 
     # Extract user expected layers
-    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, inps.layers, inps.rankedResampling, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
+    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, inps.layers, inps.rankedResampling, dem=demfile, \
+        lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', \
+        verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
 
     # If necessary, resample DEM/mask AFTER they have been used to extract metadata layers and mask output layers, respectively
     if inps.multilooking is not None:
@@ -764,11 +1015,24 @@ def main(inps=None):
         bounds=open_shapefile(standardproduct_info.bbox_file, 0, 0).bounds
         # Resample mask
         if inps.mask is not None:
-            resampleRaster(inps.mask.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, inps.rankedResampling, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+            resampleRaster(inps.mask.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, inps.rankedResampling, \
+                outputFormat=inps.outputFormat, num_threads=inps.num_threads)
         # Resample DEM
         if demfile is not None:
-            resampleRaster(demfile.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, inps.rankedResampling, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+            resampleRaster(demfile.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, inps.rankedResampling, \
+                outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+
+    # Track reference IFG directory, so corrections are sequentially performed
+    ref_IFGdir='unwrappedPhase'
 
     # Perform GACOS-based tropospheric corrections (if specified).
     if inps.tropo_products:
-        tropo_correction(standardproduct_info.products, inps.tropo_products, standardproduct_info.bbox_file, prods_TOTbbox, outDir=inps.workdir, outputFormat=inps.outputFormat, verbose=inps.verbose, num_threads=inps.num_threads)
+        tropo_correction(standardproduct_info.products, inps.tropo_products, standardproduct_info.bbox_file, prods_TOTbbox, \
+            outDir=inps.workdir, outputFormat=inps.outputFormat, verbose=inps.verbose, num_threads=inps.num_threads)
+        ref_IFGdir='tropocorrected_products'
+
+    # Perform solid Earth tide corrections (if specified).
+    if inps.solid_tide:
+        solidtide_correction(standardproduct_info.products, standardproduct_info.bbox_file, prods_TOTbbox, inDir=ref_IFGdir, \
+            outDir=inps.workdir, outputFormat=inps.outputFormat, verbose=inps.verbose, num_threads=inps.num_threads)
+        ref_IFGdir='earthtidecorrected_products'

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -17,7 +17,7 @@ gdal.PushErrorHandler('CPLQuietErrorHandler')
 
 # Import functions
 from ARIAtools.ARIAProduct import ARIA_standardproduct
-from ARIAtools.extractProduct import merged_productbbox, prep_dem, prep_mask, export_products, tropo_correction
+from ARIAtools.extractProduct import merged_productbbox, prep_dem, prep_mask, export_products, tropo_correction, solidtide_correction
 
 
 def createParser():
@@ -28,22 +28,43 @@ def createParser():
     import argparse
     parser = argparse.ArgumentParser(description='Get DEM')
     parser.add_argument('-f', '--file', dest='imgfile', type=str, required=True, help='ARIA file')
-    parser.add_argument('-w', '--workdir', dest='workdir', default='./', help='Specify directory to deposit all outputs. Default is local directory where script is launched.')
-    parser.add_argument('-tp', '--tropo_products', dest='tropo_products', type=str, default=None, help='Path to director(ies) or tar file(s) containing GACOS products.')
-    parser.add_argument('-l', '--layers', dest='layers', default=None, help='Specify layers to extract as a comma deliminated list bounded by single quotes. Allowed keys are: "unwrappedPhase", "coherence", "amplitude", "bPerpendicular", "bParallel", "incidenceAngle", "lookAngle","azimuthAngle". If "all" is specified, then all layers are extracted. If blank, will only extract bounding box.')
+    parser.add_argument('-w', '--workdir', dest='workdir', default='./', help='Specify directory to deposit all outputs.'\
+                        'Default is local directory where script is launched.')
+    parser.add_argument('-tp', '--tropo_products', dest='tropo_products', type=str, default=None, help='Path to director(ies)'\
+                        'or tar file(s) containing GACOS products.')
+    parser.add_argument('-st', '--solid_tide', action='store_true', dest='solid_tide', help='If turned, solid Earth tide corrections will be applied.')
+    parser.add_argument('-l', '--layers', dest='layers', default=None, help='Specify layers to extract as a comma deliminated list'\
+                        'bounded by single quotes. Allowed keys are: "unwrappedPhase", "coherence", "amplitude", "bPerpendicular",'\
+                        '"bParallel", "incidenceAngle", "lookAngle","azimuthAngle". If "all" is specified, then all layers are extracted.'\
+                        'If blank, will only extract bounding box,"incidenceAngle","lookAngle","azimuthAngle","unwrappedPhase", and "coherence".')
     parser.add_argument('-d', '--demfile', dest='demfile', type=str, default='download', help='DEM file. Default is to download new DEM.')
     parser.add_argument('-p', '--projection', dest='projection', default='WGS84', type=str, help='projection for DEM. By default WGS84.')
-    parser.add_argument('-b', '--bbox', dest='bbox', type=str, default=None, help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
-    parser.add_argument('-m', '--mask', dest='mask', type=str, default=None, help="Path to mask file or 'Download'. File needs to be GDAL compatabile, contain spatial reference information, and have invalid/valid data represented by 0/1, respectively. If 'Download', will use GSHHS water mask")
-    parser.add_argument('-at', '--amp_thresh', dest='amp_thresh', default=None, type=str, help='Amplitude threshold below which to mask. Specify "None" to not use amplitude mask. By default "None".')
-    parser.add_argument('-nt', '--num_threads', dest='num_threads', default='2', type=str, help='Specify number of threads for multiprocessing operation in gdal. By default "2". Can also specify "All" to use all available threads.')
+    parser.add_argument('-b', '--bbox', dest='bbox', type=str, default=None, help="Provide either valid shapefile or Lat/Lon Bounding SNWE."\
+                        "-- Example : '19 20 -99.5 -98.5'")
+    parser.add_argument('-m', '--mask', dest='mask', type=str, default=None, help="Path to mask file or 'Download'. File needs to be GDAL"\
+                        "compatabile, contain spatial reference information, and have invalid/valid data represented by 0/1, respectively."\
+                        "If 'Download', will use GSHHS water mask")
+    parser.add_argument('-at', '--amp_thresh', dest='amp_thresh', default=None, type=str, help='Amplitude threshold below which to mask.'\
+                        'Specify "None" to not use amplitude mask. By default "None".')
+    parser.add_argument('-nt', '--num_threads', dest='num_threads', default='2', type=str, help='Specify number of threads for'\
+                        'multiprocessing operation in gdal. By default "2". Can also specify "All" to use all available threads.')
 #    parser.add_argument('-sm', '--stitchMethod', dest='stitchMethodType',  type=str, default='overlap', help="Method applied to stitch the unwrapped data. Either 'overlap', where product overlap is minimized, or '2stage', where minimization is done on connected components, are allowed methods. Default is 'overlap'.")
-    parser.add_argument('-of', '--outputFormat', dest='outputFormat', type=str, default='VRT', help='GDAL compatible output format (e.g., "ENVI", "GTiff"). By default files are generated virtually except for "bPerpendicular", "bParallel", "incidenceAngle", "lookAngle","azimuthAngle", "unwrappedPhase" as these are require either DEM intersection or corrections to be applied')
-    parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection and bbox (if specified).")
-    parser.add_argument('-bp', '--bperp', action='store_true', dest='bperp', help="If turned on, extracts perpendicular baseline grids. Default: A single perpendicular baseline value is calculated and included in the metadata of stack cubes for each pair.")
-    parser.add_argument('-ml', '--multilooking', dest='multilooking', type=int, default=None, help='Multilooking factor is an integer multiple of standard resolution. E.g. 2 = 90m*2 = 180m')
-    parser.add_argument('-rr', '--rankedResampling', action='store_true', dest='rankedResampling', help="If turned on, IFGs resampled based off of the average of pixels in a given resampling window corresponding to the connected component mode (if multilooking specified). Program defaults to lanczos resampling algorithm through gdal (if multilooking specified).")
-    parser.add_argument('-mo', '--minimumOverlap', dest='minimumOverlap', type=float, default=0.0081, help='Minimum km\u00b2 area of overlap of scenes wrt specified bounding box. Default 0.0081 = 0.0081km\u00b2 = area of single pixel at standard 90m resolution"')
+    parser.add_argument('-of', '--outputFormat', dest='outputFormat', type=str, default='VRT', help='GDAL compatible output format'\
+                        '(e.g., "ENVI", "GTiff"). By default files are generated virtually except for "bPerpendicular", "bParallel",'\
+                        '"incidenceAngle", "lookAngle","azimuthAngle", "unwrappedPhase" as these are require either DEM intersection'\
+                        'or corrections to be applied.')
+    parser.add_argument('-croptounion', '--croptounion', action='store_true', dest='croptounion', help="If turned on, IFGs cropped to bounds"\
+                        "based off of union and bbox (if specified). Program defaults to crop all IFGs to bounds based off of common intersection"\
+                        "and bbox (if specified).")
+    parser.add_argument('-bp', '--bperp', action='store_true', dest='bperp', help="If turned on, extracts perpendicular baseline grids."\
+                        "Default: A single perpendicular baseline value is calculated and included in the metadata of stack cubes for each pair.")
+    parser.add_argument('-ml', '--multilooking', dest='multilooking', type=int, default=None, help='Multilooking factor is an integer multiple of'\
+                        'standard resolution. E.g. 2 = 90m*2 = 180m')
+    parser.add_argument('-rr', '--rankedResampling', action='store_true', dest='rankedResampling', help="If turned on, IFGs resampled"\
+                        "based off of the average of pixels in a given resampling window corresponding to the connected component mode"\
+                        "(if multilooking specified). Program defaults to lanczos resampling algorithm through gdal (if multilooking specified).")
+    parser.add_argument('-mo', '--minimumOverlap', dest='minimumOverlap', type=float, default=0.0081, help='Minimum km\u00b2 area of overlap of scenes'\
+                        'wrt specified bounding box. Default 0.0081 = 0.0081km\u00b2 = area of single pixel at standard 90m resolution"')
     parser.add_argument('-verbose', '--verbose', action='store_true', dest='verbose', help="Toggle verbose mode on.")
 
     return parser
@@ -124,7 +145,13 @@ def generateStack(aria_prod,inputFiles,outputFileName,workdir='./'):
         domainName = 'unwrappedPhase'
         intList = glob.glob(os.path.join(workdir,'tropocorrected_products','[0-9]*[0-9].vrt'))
         dataType = "Float32"
-        print('Number of tropocorrected unwrapped interferograms discovered: ', len(intList))
+        print('Number of tropo corrected unwrapped interferograms discovered: ', len(intList))
+        Dlist = intList
+    elif inputFiles in ['earthtidecorrected_products', 'earthtidecorrected', 'earthtide']:
+        domainName = 'unwrappedPhase'
+        intList = glob.glob(os.path.join(workdir,'earthtidecorrected_products','[0-9]*[0-9].vrt'))
+        dataType = "Float32"
+        print('Number of earth-tide corrected unwrapped interferograms discovered: ', len(intList))
         Dlist = intList
     elif inputFiles in ['coherence', 'Coherence', 'coh']:
         domainName = 'Coherence'
@@ -255,38 +282,53 @@ def main(inps=None):
 
     # extract/merge productBoundingBox layers for each pair and update dict,
     # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-    standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap)
+    standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = \
+        merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), \
+        standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap)
 
     # Load or download mask (if specified).
     if inps.mask is not None:
-        inps.mask = prep_mask([[item for sublist in [list(set(d['amplitude'])) for d in standardproduct_info.products[1] if 'amplitude' in d] for item in sublist], [item for sublist in [list(set(d['pair_name'])) for d in standardproduct_info.products[1] if 'pair_name' in d] for item in sublist]],inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+        inps.mask = prep_mask([[item for sublist in [list(set(d['amplitude'])) for d in standardproduct_info.products[1] if 'amplitude' in d] \
+            for item in sublist], [item for sublist in [list(set(d['pair_name'])) for d in standardproduct_info.products[1] if 'pair_name' in d] \
+            for item in sublist]],inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, \
+            workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Download/Load DEM & Lat/Lon arrays, providing bbox, expected DEM shape, and output dir as input.
     if inps.demfile is not None:
         print('Download/cropping DEM')
         # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, \
+            arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Extract
     layers=['unwrappedPhase','coherence']
     print('\nExtracting unwrapped phase, coherence, and connected components for each interferogram pair')
-    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
+    export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, \
+        lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, \
+        num_threads=inps.num_threads, multilooking=inps.multilooking)
 
     layers=['incidenceAngle','lookAngle','azimuthAngle']
     print('\nExtracting single incidence angle, look angle and azimuth angle files valid over common interferometric grid')
-    export_products([dict(zip([k for k in set(k for d in standardproduct_info.products[1] for k in d)], [[item for sublist in [list(set(d[k])) for d in standardproduct_info.products[1] if k in d] for item in sublist] for k in set(k for d in standardproduct_info.products[1] for k in d)]))], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
+    export_products([dict(zip([k for k in set(k for d in standardproduct_info.products[1] for k in d)], [[item for sublist in [list(set(d[k])) \
+        for d in standardproduct_info.products[1] if k in d] for item in sublist] for k in set(k for d in standardproduct_info.products[1] \
+        for k in d)]))], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, \
+        outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, \
+        multilooking=inps.multilooking)
 
     if inps.bperp==True:
         layers=['bPerpendicular']
         print('\nExtracting perpendicular baseline grids for each interferogram pair')
-        export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
+        export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, \
+            lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, \
+            num_threads=inps.num_threads, multilooking=inps.multilooking)
 
     # Extracting other layers, if specified
     if inps.layers:
         if inps.layers.lower()=='all':
             inps.layers=list(standardproduct_info.products[1][0].keys())
             # Must also remove productBoundingBoxes & pair-names because they are not raster layers
-            layers=[i for i in inps.layers if i not in ['unwrappedPhase','coherence','incidenceAngle','lookAngle','azimuthAngle','bPerpendicular','productBoundingBox','productBoundingBoxFrames','pair_name']]
+            layers=[i for i in inps.layers if i not in ['unwrappedPhase','coherence','incidenceAngle','lookAngle','azimuthAngle', \
+                'bPerpendicular','productBoundingBox','productBoundingBoxFrames','pair_name']]
         else:
             inps.layers=list(inps.layers.split(','))
             layers=[i for i in inps.layers if i not in ['unwrappedPhase','coherence','incidenceAngle','lookAngle','azimuthAngle','bPerpendicular']]
@@ -294,7 +336,9 @@ def main(inps=None):
 
         if layers!=[]:
             print('\nExtracting optional, user-specified layers %s for each interferogram pair'%(layers))
-            export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, num_threads=inps.num_threads, multilooking=inps.multilooking)
+            export_products(standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, layers, dem=demfile, lat=Latitude, \
+                lon=Longitude, mask=inps.mask, outDir=inps.workdir, outputFormat=inps.outputFormat, stitchMethodType='overlap', verbose=inps.verbose, \
+                num_threads=inps.num_threads, multilooking=inps.multilooking)
 
     # If necessary, resample DEM/mask AFTER they have been used to extract metadata layers and mask output layers, respectively
     if inps.multilooking is not None:
@@ -304,19 +348,29 @@ def main(inps=None):
         bounds=open_shapefile(standardproduct_info.bbox_file, 0, 0).bounds
         # Resample mask
         if inps.mask is not None:
-            resampleRaster(inps.mask.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, inps.rankedResampling, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+            resampleRaster(inps.mask.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, inps.rankedResampling, \
+                outputFormat=inps.outputFormat, num_threads=inps.num_threads)
         # Resample DEM
         if demfile is not None:
-            resampleRaster(demfile.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, inps.rankedResampling, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+            resampleRaster(demfile.GetDescription(), inps.multilooking, bounds, prods_TOTbbox, inps.rankedResampling, \
+                outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+
+    # Track reference IFG directory, so corrections are sequentially performed
+    ref_IFGdir='unwrappedPhase'
 
     # Perform GACOS-based tropospheric corrections (if specified).
     if inps.tropo_products:
-        tropo_correction(standardproduct_info.products, inps.tropo_products, standardproduct_info.bbox_file, prods_TOTbbox, outDir=inps.workdir, outputFormat=inps.outputFormat, verbose=inps.verbose, num_threads=inps.num_threads)
+        tropo_correction(standardproduct_info.products, inps.tropo_products, standardproduct_info.bbox_file, prods_TOTbbox, outDir=inps.workdir, \
+            outputFormat=inps.outputFormat, verbose=inps.verbose, num_threads=inps.num_threads)
+        ref_IFGdir='tropocorrected_products'
+
+    # Perform solid Earth tide corrections (if specified).
+    if inps.solid_tide:
+        solidtide_correction(standardproduct_info.products, standardproduct_info.bbox_file, prods_TOTbbox, inDir=ref_IFGdir, outDir=inps.workdir, \
+            outputFormat=inps.outputFormat, verbose=inps.verbose, num_threads=inps.num_threads)
+        ref_IFGdir='earthtidecorrected_products'
 
     # Generate Stack
     generateStack(standardproduct_info,'coherence','cohStack',workdir=inps.workdir)
     generateStack(standardproduct_info,'connectedComponents','connCompStack',workdir=inps.workdir)
-    if inps.tropo_products:
-        generateStack(standardproduct_info,'tropocorrected_products','unwrapStack',workdir=inps.workdir)
-    else:
-        generateStack(standardproduct_info,'unwrappedPhase','unwrapStack',workdir=inps.workdir)
+    generateStack(standardproduct_info,ref_IFGdir,'unwrapStack',workdir=inps.workdir)


### PR DESCRIPTION
Solid Earth tide corrections implemented from Dennis Milbert's source code (found on http://geodesyworld.github.io/SOFTS/solid.htm, and also leveraged by GMT's earthtide function).

To utilize, simply specify the "-st" flag when running either ariaExtract.py or ariaTSsetup.py, and the solid earth differential tides + corrected phase fields will be deposited under the "earthtidecorrected_products" subdirectory.

To install prerequiste fortran bindings, follow these steps:
1. Enter "solidearth_code" subdirectory under cloned ARIA-tools repo.
2. Generate python bindings: 'f2py -c -m solid_grid solid_grid.f'
3. Move generated "solid_grid.cpython*" bindings into your python site packages. To get site package location, enter 'python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"'

A slew of codacy suggested fixes also implemented, mainly breaking up long lines.

@rzinke, when you get back, it would be great for you to test this out over Tibet, where we have seen strong solid earth tide signal (relative to my tests over Afar). @bbuzz31, this may be of interest for you as well.