### PR TITLE
Circumvent netcdf4 driver to parse metadata

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -32,7 +32,6 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
     '''
 
     # import dependencies
-    import netCDF4
     import glob
 
     def __init__(self, filearg, bbox=None, workdir='./', verbose=False):
@@ -134,6 +133,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             E.g. a new expected radar-metadata key can be added as XXX to the end of the list "rmdkeys" below, and correspondingly to the end of the list "radarkeys" inside the mappingData function. Same protocol for new expected layer keys in the list "sdskeys" below, and correspondingly in "layerkeys" inside the mappingData function.
         '''
 
+        import netCDF4
         # ARIA standard product version 1a and 1b have same mapping
         if version=='1a' or version=='1b':
             # Radarmetadata names for these versions
@@ -147,7 +147,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             'parallelBaseline','incidenceAngle','lookAngle','azimuthAngle','ionosphere']
 
             #Pass pair name
-            read_file=self.netCDF4.Dataset(fname, keepweakref=True).groups['science'].groups['radarMetaData'].groups['inputSLC']
+            read_file=netCDF4.Dataset(fname, keepweakref=True).groups['science'].groups['radarMetaData'].groups['inputSLC']
             self.pairname=read_file.groups['reference']['L1InputGranules'][:][0][17:25] +'_'+ read_file.groups['secondary']['L1InputGranules'][:][0][17:25]
             del read_file
 
@@ -159,7 +159,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             Output and group together 2 dictionaries containing the “radarmetadata info” and “data layer keys+paths”, respectively
             The order of the dictionary keys below needs to be consistent with the keys in the __mappingVersion__ function of the ARIA_standardproduct class (see instructions on how to appropriately add new keys there).
         '''
-
+        import netCDF4
         # Expected radarmetadata
         radarkeys=['missionID', 'wavelength', 'centerFrequency', 'productType',
         'ISCEversion', 'unwrapMethod', 'DEM', 'ESDthreshold', 'azimuthZeroDopplerStartTime', 'azimuthZeroDopplerEndTime',
@@ -172,7 +172,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         'azimuthAngle','ionosphere']
 
         # Parse radarmetadata
-        rdrmetadata = self.netCDF4.Dataset(fname, keepweakref=True, diskless=True).groups['science'].groups['radarMetaData']
+        rdrmetadata = netCDF4.Dataset(fname, keepweakref=True, diskless=True).groups['science'].groups['radarMetaData']
         rdrmetakeys = list(rdrmetadata.variables.keys())
         rdrmetadata_dict={}
 

--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -221,16 +221,19 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             self.pairname=os.path.basename(file)[21:29] +'_'+ os.path.basename(file)[30:38]
 
             # Radarmetadata names for these versions
-            rdrmetadata_dict['missionID']='Sentinel-1'
-            rdrmetadata_dict['productType']='UNW GEO IFG'
+            rdrmetadata_dict['pair_name']=self.pairname
             rdrmetadata_dict['azimuthZeroDopplerMidTime']=os.path.basename(file)[21:25]+'-'+os.path.basename(file)[25:27]+'-' \
                 +os.path.basename(file)[27:29]+'T'+os.path.basename(file)[39:41]+':'+os.path.basename(file)[41:43]+':' \
                 +os.path.basename(file)[43:45]
+            #hardcoded keys
+            rdrmetadata_dict['missionID']='Sentinel-1'
+            rdrmetadata_dict['productType']='UNW GEO IFG'
+            rdrmetadata_dict['wavelength']=0.05546576
+            rdrmetadata_dict['slantRangeSpacing']=2.329562187194824
+            rdrmetadata_dict['slantRangeStart']=798980.125
+            rdrmetadata_dict['slantRangeEnd']=956307.125
             #hardcoded key meant to gauge temporal connectivity of scenes
             rdrmetadata_dict['sceneLength']=27
-            rdrmetadata_dict['wavelength']=0.05546576
-            rdrmetadata_dict['pair_name']=self.pairname
-            test=self.netCDF4.Dataset(file, keepweakref=True, diskless=True).groups['science'].groups['radarMetaData']
 
             # Layer names for these versions
             sdskeys=['productBoundingBox','unwrappedPhase','coherence',

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -526,7 +526,7 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
     bounds=user_bbox.bounds
 
     product_dict=[[j['unwrappedPhase'] for j in full_product_dict[1]], [j['lookAngle'] for j in full_product_dict[1]], [j["pair_name"] for j in full_product_dict[1]]]
-    metadata_dict=[[j['azimuthZeroDopplerStartTime'] for j in full_product_dict[0]], [j['azimuthZeroDopplerEndTime'] for j in full_product_dict[0]], [j['wavelength'] for j in full_product_dict[0]]]
+    metadata_dict=[[j['azimuthZeroDopplerMidTime'] for j in full_product_dict[0]], [j['wavelength'] for j in full_product_dict[0]]]
     workdir=os.path.join(outDir,'tropocorrected_products')
 
     # If specified workdir doesn't exist, create it
@@ -642,8 +642,7 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             for j in [tropo_reference, tropo_secondary]:
                 # Get ARIA product times
                 aria_rsc_dict={}
-                aria_rsc_dict['azimuthZeroDopplerStartTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S.%fZ") for m in metadata_dict[0][0]]
-                aria_rsc_dict['azimuthZeroDopplerEndTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S.%fZ") for m in metadata_dict[1][0]]
+                aria_rsc_dict['azimuthZeroDopplerMidTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S") for m in metadata_dict[0][0]]
                 # Get tropo product UTC times
                 tropo_rsc_dict={}
                 tropo_rsc_dict['TIME_OF_DAY']=open(j[:-4]+'.rsc', 'r').readlines()[-1].split()[1].split('UTC')[:-1]
@@ -654,8 +653,8 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
                     tropo_rsc_dict['TIME_OF_DAY']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[0]+'-'+str(round(float('0.'+tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[-1])*60)), "%Y-%m-%d-%H-%M")]
 
                 # Check and report if tropospheric product falls outside of standard product range
-                latest_start = max(aria_rsc_dict['azimuthZeroDopplerStartTime']+[min(tropo_rsc_dict['TIME_OF_DAY'])])
-                earliest_end = min(aria_rsc_dict['azimuthZeroDopplerEndTime']+[max(tropo_rsc_dict['TIME_OF_DAY'])])
+                latest_start = max(aria_rsc_dict['azimuthZeroDopplerMidTime']+[min(tropo_rsc_dict['TIME_OF_DAY'])])
+                earliest_end = min(aria_rsc_dict['azimuthZeroDopplerMidTime']+[max(tropo_rsc_dict['TIME_OF_DAY'])])
                 delta = (earliest_end - latest_start).total_seconds() + 1
                 if delta<0:
                     print("WARNING: tropospheric product was generated %f secs outside of acquisition interval for scene %s in IFG %s"%(abs(delta), os.path.basename(j)[:8], product_dict[2][i][0]))
@@ -675,7 +674,7 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             tropo_product=np.subtract(tropo_secondary,tropo_product)
 
             # Convert troposphere to rad
-            tropo_product=np.divide(tropo_product,float(metadata_dict[2][i][0])/(4*np.pi))
+            tropo_product=np.divide(tropo_product,float(metadata_dict[1][i][0])/(4*np.pi))
             # Account for lookAngle
             # if in TS mode, only 1 lookfile would be generated, so check for this
             if os.path.exists(os.path.join(outDir,'lookAngle',product_dict[2][i][0])):

--- a/tools/ARIAtools/shapefile_util.py
+++ b/tools/ARIAtools/shapefile_util.py
@@ -31,6 +31,7 @@ def open_shapefile(fname, lyrind, ftind):
     #If layer name provided
     if isinstance(lyrind, str):
         file_bbox = file_bbox.GetLayerByName(lyrind).GetFeature(ftind)
+
     #If layer index provided
     else:
         file_bbox = file_bbox.GetLayerByIndex(lyrind).GetFeature(ftind)

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -73,24 +73,18 @@ def extractUTCtime(aria_prod):
         #Grab pair name of the product
         pairName = aria_prod.products[1][i]['pair_name']
 
-        #Grab start times, append to a list and find minimum start time
-        startTimeList = aria_prod.products[0][i]['azimuthZeroDopplerStartTime']
-        startTime=[]
-        for j in startTimeList:
-            startTime.append(datetime.strptime(j,'%Y-%m-%dT%H:%M:%S.%fZ'))
-        minStartTime = min(startTime)
-
-        #Grab end times, append to a list and find maximum end time
-        endTimeList = aria_prod.products[0][i]['azimuthZeroDopplerEndTime']
-        endTime=[]
-        for k in endTimeList:
-            endTime.append(datetime.strptime(k,'%Y-%m-%dT%H:%M:%S.%fZ'))
-        maxEndTime = max(endTime)
+        #Grab mid-times, append to a list and find minimum and maximum mid-times
+        midTimeList = aria_prod.products[0][i]['azimuthZeroDopplerMidTime']
+        midTime=[]
+        for j in midTimeList:
+            midTime.append(datetime.strptime(j,'%Y-%m-%dT%H:%M:%S'))
+        minMidTime = min(midTime)
+        maxMidTime = max(midTime)
 
         #Calculate time difference between minimum start and maximum end time, and add it to mean start time
         #Write calculated UTC time into a dictionary with associated pair names as keys
-        timeDelta = (maxEndTime - minStartTime)/2
-        utcTime = (minStartTime+timeDelta).time()
+        timeDelta = (maxMidTime - minMidTime)/2
+        utcTime = (minMidTime+timeDelta).time()
         utcDict[pairName[0]] = utcTime
     return utcDict
 

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -86,7 +86,7 @@ class Downloader(object):
             os.chdir(self.inps.wd)
             os.sys.argv = []
             fileName = os.path.abspath(os.path.join(self.inps.wd,'ASFDataDload.py'))
-            with open(fileName, 'w') as fh:
+            with open(fileName, 'w') as f:
                 f.write(script)
 
             os.sys.path.append(os.path.abspath(self.inps.wd))

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -49,7 +49,7 @@ def cmdLineParse(iargs=None):
         raise Exception('Must specify either a bbox or track')
 
     if not inps.output.lower() in ['count', 'kml', 'kmz', 'url', 'download']:
-        raise Exception ('Incorrect output keyword. Choose "count", "kmz", or "download"')
+        raise Exception ('Incorrect output keyword. Choose "count", "kmz", "url", or "download"')
 
     inps.output = 'Kml' if inps.output.lower() == 'kmz' else inps.output.title()
     return inps


### PR DESCRIPTION
netCDF4 driver no longer used to open standard products in standard sorting class. However, devs may experiment with original, vestigial functions leveraging netCDF4 for now (i.e. "__OGmappingVersion__" and "__OGmappingData__")

Radar-metadata field "azimuthZeroDopplerMidTime" now parsed directly from filename, and also replaces references to "azimuthZeroDopplerStartTime" and "azimuthZeroDopplerEndTime" in the "extractProduct" and "tsSetup", since the latter two can only be accessed with the netCDF4 driver. 

This PR directly addresses suggestions made in issue #138 