### PR TITLE
Minor bug fixes

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -263,7 +263,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             # Layer names for these versions
             sdskeys=['productBoundingBox','/science/grids/data/unwrappedPhase','/science/grids/data/coherence',
             '/science/grids/data/connectedComponents','/science/grids/data/amplitude','/science/grids/imagingGeometry/perpendicularBaseline',
-            '/science/grids/imagingGeometry/parallelBaseline','/science/grids/imagingGeometry/incidenceAngle','/science/grids/imagingGeometry/lookAngle','/science/grids/imagingGeometry/azimuthAngle','/science/grids/imagingGeometry/ionosphere']
+            '/science/grids/imagingGeometry/parallelBaseline','/science/grids/imagingGeometry/incidenceAngle','/science/grids/imagingGeometry/lookAngle','/science/grids/imagingGeometry/azimuthAngle']
 
         return rdrmetadata_dict, sdskeys
 
@@ -278,7 +278,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         layerkeys=['productBoundingBox','unwrappedPhase',
         'coherence','connectedComponents','amplitude','bPerpendicular',
         'bParallel','incidenceAngle','lookAngle',
-        'azimuthAngle','ionosphere']
+        'azimuthAngle']
 
         # Setup datalyr_dict
         datalyr_dict={}

--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -326,10 +326,10 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         # If multiple pairs in list, cycle through and evaluate temporal connectivity.
         for i in enumerate(self.products[:-1]):
             # Get this reference product's times
-            scene_start=datetime.strptime(i[1][0]['azimuthZeroDopplerMidTime'], "%Y-%m-%dT%H:%M:%S")
+            scene_start=datetime.strptime(i[1][0]['azimuthZeroDopplerMidTime'], "%Y-%m-%dT%H:%M:%S.%f")
             scene_end=scene_start+timedelta(seconds=27)
             master=datetime.strptime(i[1][0]['pair_name'][9:], "%Y%m%d")
-            new_scene_start=datetime.strptime(self.products[i[0]+1][0]['azimuthZeroDopplerMidTime'], "%Y-%m-%dT%H:%M:%S")
+            new_scene_start=datetime.strptime(self.products[i[0]+1][0]['azimuthZeroDopplerMidTime'], "%Y-%m-%dT%H:%M:%S.%f")
             new_scene_end=new_scene_start+timedelta(seconds=27)
             slave=datetime.strptime(self.products[i[0]+1][0]['pair_name'][9:], "%Y%m%d")
 

--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -248,7 +248,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             # Radarmetadata names for these versions
             rdrmetadata_dict['pair_name']=self.pairname
             rdrmetadata_dict['azimuthZeroDopplerMidTime']=basename[21:25]+'-'+basename[25:27]+'-' \
-                +basename[27:29]+'T'+basename[39:41]+':'+basename[41:43]+':'+basename[43:45]
+                +basename[27:29]+'T'+basename[39:41]+':'+basename[41:43]+':'+basename[43:45] + '.0'
 
             #hardcoded keys
             rdrmetadata_dict['missionID']='Sentinel-1'

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -642,7 +642,7 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             for j in [tropo_reference, tropo_secondary]:
                 # Get ARIA product times
                 aria_rsc_dict={}
-                aria_rsc_dict['azimuthZeroDopplerMidTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S") for m in metadata_dict[0][0]]
+                aria_rsc_dict['azimuthZeroDopplerMidTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S.%f") for m in metadata_dict[0][0]]
                 # Get tropo product UTC times
                 tropo_rsc_dict={}
                 tropo_rsc_dict['TIME_OF_DAY']=open(j[:-4]+'.rsc', 'r').readlines()[-1].split()[1].split('UTC')[:-1]

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -85,7 +85,7 @@ def extractUTCtime(aria_prod):
         #Write calculated UTC time into a dictionary with associated pair names as keys
         timeDelta = (maxMidTime - minMidTime)/2
         utcTime = (minMidTime+timeDelta).time()
-        utcDict[pairName[0]] = utcTime
+        utcDict[pairName[0]] = utcTime.strftime("%H:%M:%S.%f")
     return utcDict
 
 def generateStack(aria_prod,inputFiles,outputFileName,workdir='./'):

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -77,7 +77,7 @@ def extractUTCtime(aria_prod):
         midTimeList = aria_prod.products[0][i]['azimuthZeroDopplerMidTime']
         midTime=[]
         for j in midTimeList:
-            midTime.append(datetime.strptime(j,'%Y-%m-%dT%H:%M:%S'))
+            midTime.append(datetime.strptime(j,'%Y-%m-%dT%H:%M:%S.%f'))
         minMidTime = min(midTime)
         maxMidTime = max(midTime)
 

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -166,12 +166,12 @@ class Downloader(object):
         return ','.join([W,S,E,N])
 
     def _fmt_dst(self):
-        dst_base = op.join(self.inps.wd, 'download_products')
+        dst = op.join(self.inps.wd, 'download_products')
         ext      = '.kmz' if self.inps.output == 'Kmz' else '.txt'
         if self.inps.track:
-            dst = '{}_{}'.format(dst_base, self.inps.track).replace(',', '-')
+            dst = '{}_{}track'.format(dst, self.inps.track).replace(',', '-')
 
-        elif self.inps.bbox:
+        if self.inps.bbox:
             WSEN     = self._get_bbox().split(',')
             WSEN_fmt = []
             for i, coord in enumerate(WSEN):
@@ -179,11 +179,11 @@ class Downloader(object):
                     WSEN_fmt.append(math.floor(float(coord)))
                 else:
                     WSEN_fmt.append(math.ceil(float(coord)))
-            dst = '{}_bbox'.format(dst_base)
-        dst  += '0{}'.format(ext)
+            dst = '{}_{}W{}S{}E{}Nbbox'.format(dst, str(WSEN_fmt[0]), str(WSEN_fmt[1]), str(WSEN_fmt[2]), str(WSEN_fmt[3]))
+        dst  += '_0{}'.format(ext)
         count = 1 # don't overwrite if already exists
         while op.exists(dst):
-            basen  = '{}{}{}'.format(re.split('\d', op.basename(dst))[0], count, ext)
+            basen  = '{}{}{}'.format(re.split(str(count-1)+ext, op.basename(dst))[0], count, ext)
             dst    = op.join(op.dirname(dst), basen)
             count += 1
         return dst


### PR DESCRIPTION
Fixed bug in ariaDownload that crashes when bbox specified. Filename of text file containing URLs updated so track name separated from index.

Removed hardcoded ionosphere layer key in ARIAProduct.py. The program would crash if the user specified an extraction of all layers (i.e. -l 'all') because the ionosphere layer doesn't exist. Checking for the existence of this layer would potentially re-introduce some overhead in the ARIAProduct script as 'gdalinfo' would have to be run on each product. For now, I proceed with the working assumption that future products containing this layer would have a distinct product version, with which we will associate the existence of this layer (i.e. update "__mappingVersion__" and "__mappingData__" in ARIAProduct.py accordingly)".