### PR TITLE
Fixed interpolation bug in finalize_metadata

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -494,9 +494,9 @@ def finalize_metadata(outname, bbox_bounds, prods_TOTbbox, dem, lat, lon, mask=N
 
     # Since metadata layer extends at least one grid node outside of the expected track bounds, it must be cut to conform with these bounds.
     # Crop to track extents
-    out_interpolated=gdal.Warp('', outname, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, dstNodata=data_array.GetRasterBand(1).GetNoDataValue(), multithread=True, options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
+    out_interpolated=gdal.Warp('', outname, options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, dstNodata=data_array.GetRasterBand(1).GetNoDataValue(), width=dem.ReadAsArray().shape[1], height=dem.ReadAsArray().shape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)])).ReadAsArray()
 
-    # Apply mask (if specified).
+    # Apply mask (if specified)
     if mask is not None:
         out_interpolated = mask.ReadAsArray()*out_interpolated
 


### PR DESCRIPTION
After investigating the problem outlined in Issue #148, I found that in some instances when an interpolated metadata layer is saved to the file, but then warped to apply a track cutline, rounding errors involved with the cutline may translate to 1 pixel in width/length with respect to the expected output dimensions. The program then crashes when a mask (with the expected output dimensions) is applied to this warped metadata layer.

Output width/lengths are now enforced through gdal.Warp in the finalize_metadata function, which ensures expected output dimensions are set.