### PR TITLE
Bb l cmask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if os.path.isdir(relaxPath):
            ext_modules = [module1],
            packages=['ARIAtools'],
            package_dir={'ARIAtools': 'tools/ARIAtools'},
-           scripts=['tools/bin/ariaPlot.py','tools/bin/ariaDownload.py','tools/bin/ariaExtract.py','tools/bin/ariaTSsetup.py','tools/bin/ariaAOIassist.py'])
+           scripts=['tools/bin/ariaPlot.py','tools/bin/ariaDownload.py','tools/bin/ariaExtract.py','tools/bin/ariaTSsetup.py','tools/bin/ariaAOIassist.py', 'tools/bin/ariaNLCDmask.py'])
 else:
     # Third party package RelaxIV not found
     print('Installing ARIA-tools without support for RelaxIV')
@@ -38,5 +38,5 @@ else:
            description = 'This is the ARIA tools package without RelaxIV support',
            packages=['ARIAtools'],
            package_dir={'ARIAtools': 'tools/ARIAtools'},
-           scripts=['tools/bin/ariaPlot.py','tools/bin/ariaDownload.py','tools/bin/ariaExtract.py','tools/bin/ariaTSsetup.py','tools/bin/ariaAOIassist.py'])
+           scripts=['tools/bin/ariaPlot.py','tools/bin/ariaDownload.py','tools/bin/ariaExtract.py','tools/bin/ariaTSsetup.py','tools/bin/ariaAOIassist.py', 'tools/bin/ariaNLCDmask.py'])
 

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -251,15 +251,16 @@ def main(inps=None):
     # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
     standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap)
 
-    # Load or download mask (if specified).
-    if inps.mask is not None:
-        inps.mask = prep_mask([[item for sublist in [list(set(d['amplitude'])) for d in standardproduct_info.products[1] if 'amplitude' in d] for item in sublist], [item for sublist in [list(set(d['pair_name'])) for d in standardproduct_info.products[1] if 'pair_name' in d] for item in sublist]],inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Download/Load DEM & Lat/Lon arrays, providing bbox, expected DEM shape, and output dir as input.
     if inps.demfile is not None:
         print('Download/cropping DEM')
         # Pass DEM-filename, loaded DEM array, and lat/lon arrays
         inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+
+    # Load or download mask (if specified).
+    if inps.mask is not None:
+        inps.mask = prep_mask([[item for sublist in [list(set(d['amplitude'])) for d in standardproduct_info.products[1] if 'amplitude' in d] for item in sublist], [item for sublist in [list(set(d['pair_name'])) for d in standardproduct_info.products[1] if 'pair_name' in d] for item in sublist]],inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Extract
     layers=['unwrappedPhase','coherence']

--- a/tools/bin/ariaNLCDmask.py
+++ b/tools/bin/ariaNLCDmask.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+import os
+import os.path as op
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+
+from osgeo import gdal, gdalconst
+
+def createParser():
+    """ Download a bulk download script and execute it """
+    parser = argparse.ArgumentParser(description='Command line interface to create a mask using the NLCD land cover dataset\nNLCD can be downloaded from: '\
+                                                 'https://www.mrlc.gov/data?f%5B0%5D=category%3Aland%20cover&f%5B1%5D=year%3A2016'\
+                                                 '\nMust specify the directory to ARIA results (e.g. from ariaTSsetup.py or ariaExtract.py) and NLCD product',
+                                     epilog='Examples of use:\n\t ariaNLCDmask.py ARIAresults ./NLCD_2016_Land_Cover_L48_20190424.img --view',
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('path_aria', type=str, help='Path to file to ARIA results (i.e., where DEM and productBoundingbox directories are located)')
+    parser.add_argument('path_nlcd', type=str, help='Path to file to NLCD product')
+    parser.add_argument('-t', '--test', dest='test', action='store_true', help='Run test on dummy data')
+    parser.add_argument('-v', '--view', dest='view', action='store_true', help='Show plots of steps; for debugging')
+    return parser
+
+def cmdLineParse(iargs=None):
+    parser = createParser()
+    # iargs  = 'test'
+    if len(os.sys.argv) < 3:
+        parser.print_help()
+        os.sys.exit(1)
+
+    inps = parser.parse_args(args=iargs)
+    # print(inps); quit()
+    return inps
+
+def crop_ds(path_raster, path_poly):
+    """ Crop to a raster (or path to one) using the a polygon stored on disk """
+    if isinstance(path_raster, str) and op.exists(path_raster):
+        ds  = gdal.Open(path_raster)
+    ds  = gdal.Warp('', ds, format='VRT', cutlineDSName=path_poly, cropToCutline=True, dstNodata=9999)
+    # dst = op.join(self.path_data, 'cropped_NLCD')
+    # ds  = gdal.Warp(dst, ds, format='ENVI', cutlineDSName=self.path_prod, cropToCutline=True, dstNodata=9999)
+    # ds_vrt = gdal.BuildVRT('{}.vrt'.format(dst), ds)
+    return ds
+
+def make_mask(ds_crop, lc):
+    # values outside crop; 0 is really just extra check
+    lc.extend([0,255])
+
+    arr = ds_crop.ReadAsArray()
+    for lclass in lc:
+        arr = np.where(arr == lclass, np.nan, arr)
+
+    arr = np.where(np.isnan(arr), np.nan, 1)
+    ds  = arr2ds(ds_crop, arr)
+    return ds
+
+def resamp(src, match, view=False):
+    """ Resample a dataset from src dimensions to match """
+    path = src.GetDescription()
+    path = path if op.exists(path) else ''
+    if isinstance(src, str) and op.exists(src):
+        src = gdal.Open(src, gdal.GA_ReadOnly)
+    if isinstance(match, str) and op.exists(match):
+        match = gdal.Open(match, gdal.GA_ReadOnly)
+
+    src_proj     = src.GetProjection()
+    src_geotrans = src.GetGeoTransform()
+    # match_nodata   = match.GetRasterBand(1).GetNoDataValue()
+
+    match_proj     = match.GetProjection()
+    match_geotrans = match.GetGeoTransform()
+    width  = match.RasterXSize
+    height = match.RasterYSize
+
+    if path:
+        dst = gdal.GetDriverByName('ENVI').Create(path, width, height, 1, gdalconst.GDT_Float32)
+    else:
+        dst = gdal.GetDriverByName('MEM').Create('', width, height, 1, gdalconst.GDT_Float32)
+
+    dst.SetGeoTransform(match_geotrans)
+    dst.SetProjection(match_proj)
+    gdal.ReprojectImage(src, dst, src_proj, match_proj, gdalconst.GRA_NearestNeighbour)
+    # gdal.ReprojectImage(src, dst, src_proj, match_proj, gdalconst.GRA_Bilinear)
+    del src, match
+
+    return dst
+
+def arr2ds(ds_orig, arr, noData=9999):
+    """
+    Create a new dataset identical to ds_orig except with values of 'arr'
+    Performed in memory
+    """
+    ds_orig = gdal.Open(ds_orig, gdal.GA_ReadOnly) if isinstance(ds_orig, str) else ds_orig
+    arr     = np.where(np.isnan(arr), noData, arr)
+
+    if arr.ndim == 3:
+        ds_out = gdal.GetDriverByName('MEM').Create('', ds_orig.RasterXSize,
+                        ds_orig.RasterYSize, arr.shape[0], gdal.GDT_Float32)
+
+        for i in range(arr.shape[0]):
+            ds_out.GetRasterBand(i+1).WriteArray(arr[i, :, :])
+            ds_out.GetRasterBand(i+1).SetNoDataValue(noData)
+    else:
+        ds_out = gdal.GetDriverByName('MEM').Create('', ds_orig.RasterXSize,
+                    ds_orig.RasterYSize, 1, gdal.GDT_Float32)
+        ds_out.GetRasterBand(1).WriteArray(arr)
+        ds_out.GetRasterBand(1).SetNoDataValue(noData)
+    ds_out.SetGeoTransform(ds_orig.GetGeoTransform())
+    ds_out.SetProjection(ds_orig.GetProjection())
+    del ds_orig
+    return ds_out
+
+class NLCDMasker(object):
+    def __init__(self, path_aria):
+        self.path_aria = path_aria
+        self.path_bbox = op.join(self.path_aria, 'productBoundingBox', 'productBoundingBox.shp')
+        self.path_dem  = op.join(self.path_aria, 'DEM', 'SRTM_3arcsec.dem')
+
+    def __call__(self, path_nlcd, lc=[11,12, 90, 95], view=False, test=False):
+        ## crop the raw nlcd in memory
+        ds_crop = crop_ds(path_nlcd, self.path_bbox)
+
+        ## mask the landcover classes in lc
+        ds_mask = make_mask(ds_crop, lc)
+
+        ## resample the mask to the size of the products (using the DEM)
+        ds_maskre = resamp(ds_mask, self.path_dem)
+
+        ## write mask to disk
+        path_mask = op.join(self.path_aria, 'mask')
+        os.mkdirs(path_mask) if not op.exists(path_mask) else ''
+        dst = op.join(path_mask, 'NLCD_crop.msk')
+        ds  = gdal.Translate(dst, ds_maskre, format='ENVI', outputType=gdal.GDT_UInt16, noData=0)
+        gdal.BuildVRT(dst + '.vrt' ,ds)
+
+        ## optionally view the mask
+        if view:
+            arr = ds.ReadAsArray()
+            plt.imshow(arr, cmap=plt.cm.Greys_r); plt.colorbar()
+            plt.title('Resampled mask\nDims: {}'.format(arr.shape)); plt.show()
+
+        if test: self.__test__(ds_maskre)
+
+        return dst
+
+    def __test__(self, ds_maskre):
+        ## apply mask to dummy data FOR TESTING
+        ds_dummy  = self._dummy_data(self.path_dem)
+        ds_masked = self._apply_mask(ds_maskre, ds_dummy)
+
+        arr = ds_masked.ReadAsArray()
+        arr = np.where(arr>9990, np.nan, arr)
+        plt.imshow(arr, cmap='jet_r'); plt.colorbar()
+        plt.title('Mask applied to dummy data'); plt.show()
+
+    def _dummy_data(self, ds2match):
+        """ Create a raster of dummy data using the dem (for sizing) """
+        if isinstance(ds2match, str) and op.exists(ds2match):
+            arr = gdal.Open(ds2match, gdal.GA_ReadOnly).ReadAsArray()
+        else:
+            arr = ds2match.ReadAsArray()
+
+        # arr = np.random.rand(*arr.shape)
+        arr = np.ones(arr.shape) * 10
+        ds  = arr2ds(ds2match, arr)
+        arr1 = ds.ReadAsArray()
+        return ds
+
+    def _apply_mask(self, ds_mask, ds_2mask):
+        arr = ds_mask.ReadAsArray()
+        arr = np.where(arr == 0, np.nan, 1)
+        masked = ds_2mask.ReadAsArray() * arr
+        ds_masked = arr2ds(ds_mask, masked)
+        return ds_masked
+
+if __name__ == '__main__':
+    inps = cmdLineParse()
+    path_aria = op.abspath(inps.path_aria)
+    path_nlcd = op.abspath(inps.path_nlcd)
+    # gdal.SetConfigOption('AWS_NO_SIGN_REQUEST', 'YES')
+    # gdal.SetConfigOption('AWS_SECRET_ACCESS_KEY', '')
+    # ds = gdal.Info('/vsizip/vsicurl/https://s3-us-west-2.amazonaws.com/mrlc/NLCD_2016_Land_Cover_L48_20190424.zip/NLCD_2016_Land_Cover_L48_20190424/NLCD_2016_Land_Cover_L48_20190424.img')
+    NLCDMasker(path_aria)(path_nlcd, view=inps.view, test=inps.test)


### PR DESCRIPTION
Create a mask using the [NLCD dataset](https://www.mrlc.gov/data?f%5B0%5D=category%3Aland%20cover&f%5B1%5D=year%3A2016). 
Currently masking classes: 11, 12, 90, 95 (water, perennial ice/snow, woody wetlands, herbaceous wetlands).

**You must have this downloaded.**

To create a mask using ARIA products you've already extracted (e.g. via `ariaExtract.py` or `ariaTSsetup.py`) run the `ariaNLCDmask.py` directly. See instructions with `ariaNLCDmask.py -h`

Alternatively, run ariaExtract.py` or ariaTSsetup.py` with `-m path/NLCD_2016_Land_Cover_L48_20190424.img` to create the mask on the fly. 

Finally, you can run `prep_aria.py --water-mask PATH` where PATH is the file produced by ariaNLCDmask.py 

Minimally tested, and takes a bit for large bounding boxes (~30 minutes for a whole track).