### PR TITLE
Improved reliability of metadata layer interpolation

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -498,9 +498,9 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, lat,
 
     #chunk data to conserve memory
     out_interpolated = []
-    dem_array=np.array_split(dem.ReadAsArray(), 12) ; dem_array=[x for x in dem_array if x.size > 0]
-    lat=np.array_split(lat, 12) ; dem_array=[x for x in lat if x.size > 0]
-    lon=np.array_split(lon, 12) ; dem_array=[x for x in lon if x.size > 0]
+    dem_array=np.array_split(dem.ReadAsArray(), 100) ; dem_array=[x for x in dem_array if x.size > 0]
+    lat=np.array_split(lat, 100) ; dem_array=[x for x in lat if x.size > 0]
+    lon=np.array_split(lon, 100) ; dem_array=[x for x in lon if x.size > 0]
     for i in enumerate(dem_array):
         out_interpolated.append(interpolator(np.stack((np.flip(i[1], axis=0), lat[i[0]], lon[i[0]]), axis=-1)))
     out_interpolated=np.concatenate(out_interpolated, axis=0)

--- a/tools/ARIAtools/productPlot.py
+++ b/tools/ARIAtools/productPlot.py
@@ -559,9 +559,10 @@ def main(inps=None):
 
         # extract/merge productBoundingBox layers for each pair and update dict,
         # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-        standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj \
-            = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), \
-            standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap)
+        standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, \
+            prods_TOTbbox_metadatalyr, arrshape, proj = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], \
+            os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, \
+            minimumOverlap=inps.minimumOverlap)
 
         # Load or download mask (if specified).
         if inps.mask is not None:

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -249,7 +249,7 @@ def main(inps=None):
 
     # extract/merge productBoundingBox layers for each pair and update dict,
     # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-    standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, arrshape, proj = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap)
+    standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr, arrshape, proj = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap)
 
     # Load or download mask (if specified).
     if inps.mask is not None:
@@ -259,7 +259,8 @@ def main(inps=None):
     if inps.demfile is not None:
         print('Download/cropping DEM')
         # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile, standardproduct_info.bbox_file, prods_TOTbbox, \
+            prods_TOTbbox_metadatalyr, proj, arrshape=arrshape, workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Extract
     layers=['unwrappedPhase','coherence']


### PR DESCRIPTION
In certain cases, cropping may translate to mild/moderate artifacts in the extracted, interpolated metadata fields. E.g. see incidence angle field below:
<img width="1328" alt="Screen Shot 2020-05-07 at 3 00 16 AM" src="https://user-images.githubusercontent.com/13227405/81386801-79d4bc80-90ca-11ea-82a3-535a814540d3.png">

 
To resolve this, a DEM cropped to the union of product bounding boxes is now passed. Passing this field once through "prep_dem" is much more efficient then simply warping the DEM and updated lat/lon arrays each time a metadata field is extracted in a loop. The "merged_prodductbbox" function has now been updated to always produce a shapefile recording the union of product bounding boxes (named "productBoundingBox_croptounion_formetadatalyr.shp"), which is then meant to be passed to the "prep_dem" function.

Below is the incidence angle field after running this same command after implementing these changes. The artifact has been eliminated:
<img width="1329" alt="Screen Shot 2020-05-07 at 3 00 00 AM" src="https://user-images.githubusercontent.com/13227405/81385886-f6ff3200-90c8-11ea-9539-117b28e3fc54.png">


To duplicate my tests, run the following commands:
ariaDownload.py --track 144 -i 20150612_20150519 -b '39.3 39.8 -119.5 118'
ariaExtract.py -nt 30 -b track_144_CA.shp -f "products/S1-GUNW-D-R-144-tops-20150612_20150519-135847-40882N_38909N-PP-e3e6-v2_0_2.nc" -d download -l 'incidenceAngle' -of ISCE -w test_output

Shapefile passed as argument for '-b' is attached below in a zipfile:
[track_144_CA.zip](https://github.com/aria-tools/ARIA-tools/files/4597805/track_144_CA.zip)

