### PR TITLE
Fixed bug in finalize_metadata function. VRT now updated

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -526,7 +526,10 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, lat,
 
     # Since metadata layer extends at least one grid node outside of the expected track bounds, it must be cut to conform with these bounds.
     # Crop to track extents
-    gdal.Warp(outname, outname, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, dstNodata=data_array.GetRasterBand(1).GetNoDataValue(), width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite'])).ReadAsArray()
+    gdal.Warp(outname, outname, options=gdal.WarpOptios(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, dstNodata=data_array.GetRasterBand(1).GetNoDataValue(), width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite'])).ReadAsArray()
+
+    # Update VRT
+    gdal.Translate(outname+'.vrt', outname, options=gdal.TranslateOptions(format="VRT"))
 
     # Apply mask (if specified)
     if mask is not None:

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -526,7 +526,7 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, lat,
 
     # Since metadata layer extends at least one grid node outside of the expected track bounds, it must be cut to conform with these bounds.
     # Crop to track extents
-    gdal.Warp(outname, outname, options=gdal.WarpOptios(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, dstNodata=data_array.GetRasterBand(1).GetNoDataValue(), width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite'])).ReadAsArray()
+    gdal.Warp(outname, outname, options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bbox_bounds, dstNodata=data_array.GetRasterBand(1).GetNoDataValue(), width=arrshape[1], height=arrshape[0], multithread=True, options=['NUM_THREADS=%s'%(num_threads)+' -overwrite'])).ReadAsArray()
 
     # Update VRT
     gdal.Translate(outname+'.vrt', outname, options=gdal.TranslateOptions(format="VRT"))


### PR DESCRIPTION
Extracted/interpolated metadata field VRT file now updated to reflect cropping of metadata field raster. Not updating the VRT files could potentially lead to failures later on when trying to load the raster from the VRT file (e.g. because of inconsistent dimensions, nodata values, etc). 

For example, see note the inconsistency in reported dimensions before the bug-fix: 
<img width="614" alt="Screen Shot 2020-05-11 at 1 51 32 AM" src="https://user-images.githubusercontent.com/13227405/81543240-a6870f00-932a-11ea-8604-cd9a60f4a360.png">
<img width="645" alt="Screen Shot 2020-05-11 at 1 51 43 AM" src="https://user-images.githubusercontent.com/13227405/81543254-aa1a9600-932a-11ea-89ec-e7c320d604bc.png">


Which is eliminated after the bug-fix:
<img width="618" alt="Screen Shot 2020-05-11 at 1 52 57 AM" src="https://user-images.githubusercontent.com/13227405/81543272-aedf4a00-932a-11ea-84ac-42a094f64709.png">
<img width="658" alt="Screen Shot 2020-05-11 at 1 53 05 AM" src="https://user-images.githubusercontent.com/13227405/81543277-b141a400-932a-11ea-8d1c-a4ea85b47112.png">
