### PR TITLE
Circumvent bPerp grid artifacts

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -136,16 +136,15 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
 
         # Open standard product bbox
         if self.bbox is not None:
-            file_bbox = open_shapefile(fname + '":'+sdskeys[0], 'productBoundingBox', 1)                    ##SS => We should track the projection of the shapefile. i.e. in case this changes in the product
-            # file_bbox = open_shapefile(fname, 'productBoundingBox', 1)                    ##SS => We should track the projection of the shapefile. i.e. in case this changes in the product
+            file_bbox = open_shapefile(fname + '":'+sdskeys[0], 'productBoundingBox', 1)
             # Only generate dictionaries if there is spatial overlap with user bbox
             if file_bbox.intersects(self.bbox):
-                product_dicts = [self.__mappingData__(fname, rmdkeys, sdskeys)]
+                product_dicts = [self.__mappingData__(fname, rmdkeys, sdskeys, version)]
             else:
                 product_dicts = []
         # If no bbox specified, just pass dictionaries
         else:
-            product_dicts = [self.__mappingData__(fname, rmdkeys, sdskeys)]
+            product_dicts = [self.__mappingData__(fname, rmdkeys, sdskeys, version)]
 
         return product_dicts
 
@@ -239,36 +238,57 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         '''
 
         # ARIA standard product version 1a and 1b have same mapping
+        # ARIA standard product version 1c differs with inclusion of ionosphere layer
         rdrmetadata_dict={}
-        if version.lower() in ['1a', '1b']:
+        if version.lower() in ['1a', '1b', '1c']:
             #Pass pair name
             basename     = os.path.basename(fname)
-            self.pairname=basename[21:29] +'_'+ basename[30:38]
+            self.pairname=basename.split('-')[6]
 
             # Radarmetadata names for these versions
             rdrmetadata_dict['pair_name']=self.pairname
             rdrmetadata_dict['azimuthZeroDopplerMidTime']=basename[21:25]+'-'+basename[25:27]+'-' \
                 +basename[27:29]+'T'+basename[39:41]+':'+basename[41:43]+':'+basename[43:45] + '.0'
 
-            #hardcoded keys
-            rdrmetadata_dict['missionID']='Sentinel-1'
-            rdrmetadata_dict['productType']='UNW GEO IFG'
-            rdrmetadata_dict['wavelength']=0.05546576
-            rdrmetadata_dict['slantRangeSpacing']=2.329562187194824
-            rdrmetadata_dict['slantRangeStart']=798980.125
-            rdrmetadata_dict['slantRangeEnd']=956307.125
-            #hardcoded key meant to gauge temporal connectivity of scenes
-            rdrmetadata_dict['sceneLength']=27
+            rdrmetadata_dict['azimuthZeroDopplerMidTime']=self.pairname[:4]+'-'+self.pairname[4:6]+'-'+self.pairname[6:8]+'T' \
+                +basename.split('-')[7][:2]+':'+basename.split('-')[7][2:4]+':'+basename.split('-')[7][4:]+'.0'
+
+            #hardcoded keys for a given sensor
+            if basename.split('-')[0]=='S1':
+                rdrmetadata_dict['missionID']='Sentinel-1'
+                rdrmetadata_dict['productType']='UNW GEO IFG'
+                rdrmetadata_dict['wavelength']=0.05546576
+                rdrmetadata_dict['centerFrequency']=5.4050007e+09
+                rdrmetadata_dict['slantRangeSpacing']=2.329562187194824
+                rdrmetadata_dict['slantRangeStart']=798980.125
+                rdrmetadata_dict['slantRangeEnd']=956307.125
+                #hardcoded key meant to gauge temporal connectivity of scenes (i.e. seconds between start and end)
+                rdrmetadata_dict['sceneLength']=27
+            elif basename.split('-')[0]=='ALOS2':
+                rdrmetadata_dict['missionID']='ALOS-2'
+                rdrmetadata_dict['productType']='UNW GEO IFG'
+                rdrmetadata_dict['wavelength']=0.229
+                rdrmetadata_dict['centerFrequency']=1.2364997e+09
+                rdrmetadata_dict['slantRangeSpacing']=8.582534
+                rdrmetadata_dict['slantRangeStart']=695397.
+                rdrmetadata_dict['slantRangeEnd']=913840.2
+                #hardcoded key meant to gauge temporal connectivity of scenes (i.e. seconds between start and end)
+                rdrmetadata_dict['sceneLength']=52
+            else:
+                raise Exception('Sensor %s for file %s not supported.'%(basename.split('-')[0],fname))
 
             # Layer names for these versions
             sdskeys=['productBoundingBox','/science/grids/data/unwrappedPhase','/science/grids/data/coherence',
             '/science/grids/data/connectedComponents','/science/grids/data/amplitude','/science/grids/imagingGeometry/perpendicularBaseline',
-            '/science/grids/imagingGeometry/parallelBaseline','/science/grids/imagingGeometry/incidenceAngle','/science/grids/imagingGeometry/lookAngle','/science/grids/imagingGeometry/azimuthAngle']
+            '/science/grids/imagingGeometry/parallelBaseline','/science/grids/imagingGeometry/incidenceAngle',
+            '/science/grids/imagingGeometry/lookAngle','/science/grids/imagingGeometry/azimuthAngle']
+            if version.lower()=='1c':
+                sdskeys.append('/science/grids/corrections/derived/ionosphere')
 
         return rdrmetadata_dict, sdskeys
 
 
-    def __mappingData__(self, fname, rdrmetadata_dict, sdskeys):
+    def __mappingData__(self, fname, rdrmetadata_dict, sdskeys, version):
         '''
             Output and group together 2 dictionaries containing the “radarmetadata info” and “data layer keys+paths”, respectively
             The order of the dictionary keys below needs to be consistent with the keys in the __mappingVersion__ function of the ARIA_standardproduct class (see instructions on how to appropriately add new keys there).
@@ -277,8 +297,9 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         # Expected layers
         layerkeys=['productBoundingBox','unwrappedPhase',
         'coherence','connectedComponents','amplitude','bPerpendicular',
-        'bParallel','incidenceAngle','lookAngle',
-        'azimuthAngle']
+        'bParallel','incidenceAngle','lookAngle','azimuthAngle']
+        if version.lower()=='1c':
+            layerkeys.append('ionosphere')
 
         # Setup datalyr_dict
         datalyr_dict={}
@@ -333,10 +354,10 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         for i in enumerate(self.products[:-1]):
             # Get this reference product's times
             scene_start=datetime.strptime(i[1][0]['azimuthZeroDopplerMidTime'], "%Y-%m-%dT%H:%M:%S.%f")
-            scene_end=scene_start+timedelta(seconds=27)
+            scene_end=scene_start+timedelta(seconds=i[1][0]['sceneLength'])
             master=datetime.strptime(i[1][0]['pair_name'][9:], "%Y%m%d")
             new_scene_start=datetime.strptime(self.products[i[0]+1][0]['azimuthZeroDopplerMidTime'], "%Y-%m-%dT%H:%M:%S.%f")
-            new_scene_end=new_scene_start+timedelta(seconds=27)
+            new_scene_end=new_scene_start+timedelta(seconds=i[1][0]['sceneLength'])
             slave=datetime.strptime(self.products[i[0]+1][0]['pair_name'][9:], "%Y%m%d")
 
             # Determine if next product in time is in same orbit AND overlaps AND corresponds to same pair
@@ -413,6 +434,10 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         # Sort by pair and start time.
         self.products = sorted(self.products, key=lambda k: (k[0]['pair_name'], k[0]['azimuthZeroDopplerMidTime']))
         self.products=list(self.products)
+
+        # Exit if products from different sensors were mixed
+        if not all(i[0]['missionID'] == 'Sentinel-1' for i in self.products) and not all(i[0]['missionID'] == 'ALOS-2' for i in self.products):
+            raise Exception('Specified input contains standard products from different sensors, please proceed with homogeneous products.')
 
         # Check if any pairs meet criteria
         if self.products==[]:

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -524,9 +524,6 @@ class metadata_qualitycheck:
                 slope, bias, rsquared, p_value, std_err = linregress(xarr_chunk,chunk)
                 rsquaredarr.append(abs(rsquared)**2)
                 std_errarr.append(std_err)
-                #!#slope_n, bias_n, rsquared_n, p_value_n, std_err_n = linregress(mid_line.tolist(),(xarr*slope)+bias)
-                #!#rsquaredarr.append(min(abs(rsquared), abs(rsquared_n))**2)
-                #!#std_errarr.append(min(abs(std_err), abs(std_err_n)))
                 #terminate early if last iteration would have small chunk size
                 if len(chunk)>chunk_size:
                     break
@@ -602,7 +599,6 @@ class metadata_qualitycheck:
                     # best-fit linear plane: for very large artifacts, must mask array for outliers to get best fit
                     if min(rsquaredarr) < 0.85 and max(std_errarr) > 0.001:
                         maj_percent=((self.data_array_band < self.data_array_band.mean()).sum()/self.data_array_band.size)*100
-                        print("maj_percent",maj_percent)
                         #mask all values above mean
                         if maj_percent>50:
                             self.data_array_band = np.ma.masked_where(self.data_array_band > self.data_array_band.mean(), self.data_array_band)


### PR DESCRIPTION
In some cases, there is an abrupt sign-change in the perpendicular baseline grids (see ISCE issue ticket #137).    
<img width="503" alt="Screen Shot 2020-05-27 at 1 31 35 AM" src="https://user-images.githubusercontent.com/13227405/82997068-bfdebb00-9fba-11ea-8044-9d043732031e.png">


As a post-processing fix, I have implemented a strategy to first capture this artifact by plotting a best fit line to values along the mid-range and mid-azimuth, respectively. These plots are saved in verbose mode and organized as so in the specified working directory, respectively: 'metadatalyr_plots/bPerpendicular/20181210_20171203_midrange.eps' and 'metadatalyr_plots/bPerpendicular/20181210_20171203_midazimuth.eps'.    
<img width="1421" alt="Screen Shot 2020-05-27 at 1 34 14 AM" src="https://user-images.githubusercontent.com/13227405/82997087-c4a36f00-9fba-11ea-8e38-f3fd35d2f5a8.png">

The covariance of the polynomial coefficient estimates between both plots are then passed and if either is larger than a hardcoded value of 0.001, then the correction is applied. Note that generally smoothly varying fields with no artifacts are associated with covariances on the order of 10-5, so this hardcoded value of 0.001 is appropriate. In regards to the correction procedure, a uniform sign is set to the entire field based off of whatever the majority sign is (e.g. if >50% of the pixels are negative, than the whole field is set to negative, and vice-versa), so it is assumed that whatever is in the majority is accurate. The logic behind this strategy is to not capture false positives for which a transition from positive to negative values is expected in a smoothly varying field (e.g. range of 0.1 m to -0.1 m), as opposed to fields with legitimate artifacts (e.g. range of 8 m to -8 m). Below is the corrected field:
<img width="496" alt="Screen Shot 2020-05-27 at 1 33 25 AM" src="https://user-images.githubusercontent.com/13227405/82997107-ccfbaa00-9fba-11ea-9b6a-a2cd41d61686.png">


To replicate this test, run the following commands:
ariaDownload.py --track 121 -o download -i '20181210_20171203' -b '38.6 38.7 88.8 88.9'

ariaExtract.py -f "products/S1-GUNW-D-R-121-tops-20181210_20171203-000743-39338N_38026N-PP-eb7f-v2_0_2.nc" -l 'bPerpendicular' -d download -w testbugfix -verbose