### PR TITLE
Fixed bug in average raster generation and reporting failed IFGs

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -283,7 +283,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             '/science/grids/imagingGeometry/parallelBaseline','/science/grids/imagingGeometry/incidenceAngle',
             '/science/grids/imagingGeometry/lookAngle','/science/grids/imagingGeometry/azimuthAngle']
             if version.lower()=='1c':
-                sdskeys.append('/science/grids/corrections/derived/ionosphere')
+                sdskeys.append('/science/grids/corrections/derived/ionosphere/ionosphere')
 
         return rdrmetadata_dict, sdskeys
 
@@ -395,7 +395,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         # Remove duplicate dates
         track_rejected_pairs=list(set(track_rejected_pairs))
         if len(track_rejected_pairs)>0:
-            print("%d out of %d interferograms rejected since stitched interferogram would have gaps"%(len(track_rejected_pairs),len(sorted_products)+len(track_rejected_pairs)))
+            print("%d out of %d interferograms rejected since stitched interferogram would have gaps"%(len(track_rejected_pairs),len([item[0] for item in sorted_products])))
             if self.verbose:
                 # Provide report of which files were kept vs. which were not.
                 print("Specifically, the following interferograms were rejected:")


### PR DESCRIPTION
Average rasters through productPlot (coherence) and mask_util (amplitude, when amplitude threshold is specified) were inaccurately being generated. Specifically, ```gdalWarp``` was called on a VRT containing relevant product layers across all pairs, which just results in the first raster being passed. Now each IFG is iterated on in a loop, and a nan-mean is taken after the end of the for-loop. I.e. if at least one IFG has nodata for a given pixel, no value is reported in the final averaged raster.

Since this is executed multiple times through the code depending on the argument, a separate function ```rasterAverage``` is added under ```vrtmanager.py``` to simplify the code. 

Furthermore, now if specified, the average amplitude raster is used to mask the NLCD mask. Before this argument was ignored if a user specified a download of the NLCD mask.

Finally, a minor bug was resolved under ```ARIAproducts.py``` to ensure the appropriate number of total interferograms is reported in the print statements.

