### PR TITLE
Adjust bbox to IFG grid, handle multipolygons

### DIFF
--- a/tools/ARIAtools/shapefile_util.py
+++ b/tools/ARIAtools/shapefile_util.py
@@ -73,14 +73,19 @@ def shapefile_area(file_bbox):
     from pyproj import Proj
     from shapely.geometry import shape
 
-    #get coords
-    lon, lat=file_bbox.exterior.coords.xy
+    # loop through polygons
+    shape_area = 0
+    # pass single polygon as list
+    if file_bbox.type == 'Polygon': file_bbox = [file_bbox]
+    for polyobj in file_bbox:
+        # get coords
+        lon, lat=polyobj.exterior.coords.xy
 
-    #use equal area projection centered on/bracketing AOI
-    pa = Proj("+proj=aea +lat_1=%f +lat_2=%f +lat_0=%f +lon_0=%f"%(min(lat),max(lat), (max(lat)+min(lat))/2, (max(lon)+min(lon))/2))
-    x, y = pa(lon, lat)
-    cop = {"type": "Polygon", "coordinates": [zip(x, y)]}
-    shape_area=shape(cop).area/1e6  # area in km^2
+        # use equal area projection centered on/bracketing AOI
+        pa = Proj("+proj=aea +lat_1={} +lat_2={} +lat_0={} +lon_0={}".format(min(lat), max(lat), (max(lat)+min(lat))/2, (max(lon)+min(lon))/2))
+        x, y = pa(lon, lat)
+        cop = {"type": "Polygon", "coordinates": [zip(x, y)]}
+        shape_area+=shape(cop).area/1e6  # area in km^2
 
     return shape_area
 


### PR DESCRIPTION
Addressed the following two issues:
1. Under the ```merged_productbbox``` function of the ```extractProduct.py``` script, bounding box shapefiles and bounds are now adjusted to ensure they are integer multiples of the standard interferometric grid increment. This is done by passing the 'target aligned pixels' option to the first call to gdalWarp in order to access the master bounds. These bounds are then inherited by all future warping calls. Addresses discussion in Issue #185 
2. Handle area calculations for fringe cases where intersection of products and bounding boxes produces multipolygons (see Issue #188 for illustrations). Changes made to```shapefile_area``` function under the ```shapefile_util.py``` script. 