### PR TITLE
Automatic figure resize for productPlot.

### DIFF
--- a/tools/ARIAtools/productPlot.py
+++ b/tools/ARIAtools/productPlot.py
@@ -249,8 +249,11 @@ class plot_class:
             Make plot of track extents vs bounding bbox/common track extent.
         '''
 
-        ax=self.plt.figure().add_subplot(111)
-        #Iterate through all IFGs
+        # Figure size based on number of products
+        fig_xsize=0.17*len(self.product_dict[0])+4.8
+        ax=self.plt.figure(figsize=(fig_xsize,3.4)).add_subplot(111)
+
+        # Iterate through all IFGs
         S_extent=[]
         N_extent=[]
         for i in enumerate(self.product_dict[0]):


### PR DESCRIPTION
If ariaPlot.py -plottracks is run with more than a dozen or so pairs, the pair labels will overlap and become unreadable. This fix automatically scales the figure size so that the pair labels do not overlap.