### PR TITLE
Update S1 sceneLength to 35

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -263,7 +263,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
                 rdrmetadata_dict['slantRangeStart']=798980.125
                 rdrmetadata_dict['slantRangeEnd']=956307.125
                 #hardcoded key meant to gauge temporal connectivity of scenes (i.e. seconds between start and end)
-                rdrmetadata_dict['sceneLength']=27
+                rdrmetadata_dict['sceneLength']=35
             elif basename.split('-')[0]=='ALOS2':
                 rdrmetadata_dict['missionID']='ALOS-2'
                 rdrmetadata_dict['productType']='UNW GEO IFG'


### PR DESCRIPTION
SceneLength key was originally hardcoded to 27 seconds for S1 products. This value was leveraged to compare adjacent frames and determine whether or not they temporally overlap.

However, upon closer inspection I saw that this value varies between 27-35 seconds. Thus when comparing adjacent frames with a sceneLength of 27 vs 35 seconds, the program would flag a gap even though the products were actually continuous. This issue is resolved by simply setting the ```sceneLength``` key to 35 seconds, which would avoid such positives but still flag legitimate gaps.

As tests, please run the following examples:
1. False positive gap (now circumvented)
ariaDownload.py -t 144 -i 20181117_20181018
ariaExtract.py -f "products/*20181117_20181018*.nc" -v -w falsepositivegap_20181117_20181018

Using python, take a closer look at product "S1-GUNW-D-R-144-tops-20181117_20181018-135957-35740N_33435N-PP-763f-v2_0_2.nc'" to see the upper end sceneLength of 35 seconds:
```
import netCDF4
first='products/S1-GUNW-D-R-144-tops-20181117_20181018-135957-35740N_33435N-PP-763f-v2_0_2.nc'
#first='products/S1-GUNW-D-R-144-tops-20181117_20181018-135928-37232N_35260N-PP-b467-v2_0_2.nc'
rdrmetadata = netCDF4.Dataset(first, keepweakref=True,diskless=True).groups['science'].groups['radarMetaData']
rdrmetadata
KeyboardInterrupt
rdrmetakeys = list(rdrmetadata.variables.keys())
rdrmetakeys
['missionID', 'wavelength', 'centerFrequency', 'productType', 'ISCEversion', 'unwrapMethod', 'DEM', 'ESDthreshold', 'azimuthZeroDopplerStartTime', 'azimuthZeroDopplerEndTime', 'azimuthTimeInterval', 'slantRangeSpacing', 'slantRangeEnd', 'slantRangeStart']
rdrmetadata['azimuthZeroDopplerStartTime'][0]
#'2018-11-17T13:59:15.420122Z'
rdrmetadata['azimuthZeroDopplerEndTime'][0]
#'2018-11-17T13:59:42.366409Z'
```
Uncomment line 3 to take a look at the adjacent product  to see the lower end sceneLength of 27 seconds

2. Legitimate gap (still correctly flagged)
ariaDownload.py -t 144 -i 20160606_20150519
ariaExtract.py -f "products/*20160606_20150519*.nc" -v -w legitimategap_20160606_20150519