### PR TITLE
Specified download of compatible GDAL version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   - python>=3.6
   - cartopy
-  - gdal>=3.0
+  - gdal=3.0.4
   - hdf5
   - joblib
   - jupyterlab

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   - python>=3.6
   - cartopy
-  - gdal=3.0.4
+  - gdal >=3.0,<=3.0.4
   - hdf5
   - joblib
   - jupyterlab


### PR DESCRIPTION
GDAL versions > 3.0.4 may generate empty outputs (refer to #232). Until this bug is addressed by GDAL, we will fix the install to point to the most recent working version.