### PR TITLE
Improve handling of duplicate products

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   - python>=3.6
   - cartopy
-  - gdal>=3.0
+  - gdal=3.0.4
   - hdf5
   - joblib
   - jupyterlab

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   - python>=3.6
   - cartopy
-  - gdal=3.0.4
+  - gdal>3.0|<=3.0.4
   - hdf5
   - joblib
   - jupyterlab

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   - python>=3.6
   - cartopy
-  - gdal>3.0|<=3.0.4
+  - gdal >=3.0,<=3.0.4
   - hdf5
   - joblib
   - jupyterlab

--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -335,7 +335,19 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         num_dups=[]
         for i in enumerate(self.products[:-1]):
             # If scenes share >90% spatial overlap AND same dates, they MUST be duplicates. Reject the latter.
-            if (self.products[i[0]+1][0]['pair_name'][9:]==i[1][0]['pair_name'][9:]) and (self.products[i[0]+1][0]['pair_name'][:8]==i[1][0]['pair_name'][:8]) and (open_shapefile(self.products[i[0]+1][1]['productBoundingBox'], 'productBoundingBox', 1).intersection(open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1)).area)/(open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1).area)>0.9:
+            if (self.products[i[0]+1][0]['pair_name'][9:]==i[1][0]['pair_name'][9:]) and \
+                (self.products[i[0]+1][0]['pair_name'][:8]==i[1][0]['pair_name'][:8]) and \
+                (open_shapefile(self.products[i[0]+1][1]['productBoundingBox'], 'productBoundingBox', 1).intersection( \
+                open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1)).area) \
+                /(open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1).area)>0.9:
+                # If applicable, overwrite smaller scene with larger one
+                if (open_shapefile(self.products[i[0]+1][1]['productBoundingBox'], 'productBoundingBox', 1).intersection(
+                open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1)).area) \
+                /(open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1).area) \
+                >(open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1).intersection(
+                open_shapefile(self.products[i[0]+1][1]['productBoundingBox'], 'productBoundingBox', 1)).area) \
+                /(open_shapefile(self.products[i[0]+1][1]['productBoundingBox'], 'productBoundingBox', 1).area):
+                    i=(i[0]-1,self.products[i[0]+1])
                 log.debug("Duplicate product captured. Rejecting scene %s", os.path.basename(self.products[i[0]+1][1]['unwrappedPhase'].split('"')[1]))
                 # Overwrite latter scene with former
                 self.products[i[0]+1]=i[1]


### PR DESCRIPTION
As illustrated in #233, when duplicate products are flagged (i.e. produced with same reference frame) in some instances the longer of the two may be discarded, which introduces a gap in the path. The proposed improvements compare the duplicate files and pass the longer of the two.