### PR TITLE
Implemented handling of large DEM downloads

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -375,7 +375,7 @@ def dl_dem(path_dem, path_prod_union, num_threads):
         dst       = f'{root}_uncropped.tif'
         gdal.Warp(dst, chunked_files, options=gdal.WarpOptions(multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
         # remove temp files
-        for i in glob.glob(f'{root}_*_uncropped.tif'): os.remove(i)    
+        for i in glob.glob(f'{root}_*_uncropped.tif'): os.remove(i)
     return dst
 
 def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None, croptounion=False, num_threads='2', minimumOverlap=0.0081, verbose=None):

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -355,7 +355,6 @@ def dl_dem(path_dem, path_prod_union, num_threads):
     bottomLeft = (min(WESN[1::2]), min(WESN[::2]))
     bottomRight = (min(WESN[1::2]), max(WESN[::2]))
     topLeft = (max(WESN[1::2]), min(WESN[::2]))
-    topRight = (max(WESN[1::2]), max(WESN[::2]))
     cols = np.linspace(bottomLeft[1], bottomRight[1], num=chunking_size)
     rows = [bottomLeft[0], topLeft[0]]
     # Download in chunks (if necessary)

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -296,7 +296,7 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr, p
     outputFormat = 'ENVI' if outputFormat == 'VRT' else outputFormat
 
     if demfilename.lower()=='download':
-        demfilename = dl_dem(aria_dem, prods_TOTbbox_metadatalyr)
+        demfilename = dl_dem(aria_dem, prods_TOTbbox_metadatalyr, num_threads)
 
     else: # checks for user specified DEM, ensure it's georeferenced
         demfilename = os.path.abspath(demfilename)
@@ -335,15 +335,48 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr, p
 
     return aria_dem, ds_aria, Latitude, Longitude
 
-def dl_dem(path_dem, path_prod_union):
+def dl_dem(path_dem, path_prod_union, num_threads):
     """Download the DEM over product bbox union."""
-    WESN      = open_shapefile(path_prod_union, 0, 0).bounds
+
+    # Import functions
+    from ARIAtools.shapefile_util import shapefile_area
+
     root      = os.path.splitext(path_dem)[0]
-    dst       = f'{root}_uncropped.tif'
-    r         = requests.get(_world_dem.format(*WESN), allow_redirects=True)
-    with open(dst, 'wb') as fh:
-        fh.write(r.content)
-    del r
+    prod_shapefile = open_shapefile(path_prod_union, 0, 0)
+    WESN      = prod_shapefile.bounds
+    chunking_size = 2
+    # If area > 225000 km2, must split requests into chunks to successfully access data
+    if shapefile_area(prod_shapefile) > 225000:
+        # Increase chunking size to discretize box into smaller grids
+        log.warning("User-defined bounds %dkm\u00b2 supersedes DEM maximum download area of 225000km\u00b2, must download in chunks", shapefile_area(prod_shapefile))
+        chunking_size = int(np.ceil(shapefile_area(prod_shapefile)/225000)) + 1
+
+    # Determine number of iterations to download DEM
+    bottomLeft = (min(WESN[1::2]), min(WESN[::2]))
+    bottomRight = (min(WESN[1::2]), max(WESN[::2]))
+    topLeft = (max(WESN[1::2]), min(WESN[::2]))
+    topRight = (max(WESN[1::2]), max(WESN[::2]))
+    cols = np.linspace(bottomLeft[1], bottomRight[1], num=chunking_size)
+    rows = [bottomLeft[0], topLeft[0]]
+    # Download in chunks (if necessary)
+    chunked_files = []
+    for i in enumerate (cols[:-1]):
+        dst       = f'{root}_{i[0]}_uncropped.tif'
+        # Do not create temp file if chunking not necessary
+        if len(cols) == 2:
+            dst       = f'{root}_uncropped.tif'
+        chunked_files.append(dst)
+        WESN = [cols[i[0]], rows[0], cols[i[0]+1], rows[1]]
+        r         = requests.get(_world_dem.format(*WESN), allow_redirects=True)
+        with open(dst, 'wb') as fh:
+            fh.write(r.content)
+        del r
+    # Tile chunked products together after last iteration (if necessary)
+    if len(cols) != 2:
+        dst       = f'{root}_uncropped.tif'
+        gdal.Warp(dst, chunked_files, options=gdal.WarpOptions(multithread=True, options=['NUM_THREADS=%s'%(num_threads)]))
+        # remove temp files
+        for i in glob.glob(f'{root}_*_uncropped.tif'): os.remove(i)    
     return dst
 
 def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None, croptounion=False, num_threads='2', minimumOverlap=0.0081, verbose=None):


### PR DESCRIPTION
If the requested area is too large, DEM download fails because of bandwidth restrictions from the parent server. This PR circumvents this issue by downloading DEM is smaller tiles -- where necessary -- and then merging the tiles.

These changes build off of the commits which address issue #237 , and should not conflict with commits made to address #238 .

Listed below are the commands I used to test these changes:
```
ariaDownload.py -t 79 -o "Download" -s 20141023 -e 20141210 -b "6.39 16.07 38.066 42.21"

ariaExtract.py -f 'products/*.nc' -l amplitude -d Download -of ISCE -w test -b "6.39 16.07 38.066 42.21"
``` 