### PR TITLE
GACOS and DEM bug-fixes

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -346,7 +346,7 @@ def dl_dem(path_dem, path_prod_union, num_threads):
     WSEN      = prod_shapefile.bounds
     # If area > 225000 km2, must split requests into chunks to successfully access data
     chunk = False
-    if shapefile_area(prod_shapefile) > 450000:
+    if shapefile_area(prod_shapefile) > 300000:
         chunk = True
         # Increase chunking size to discretize box into smaller grids
         log.warning('User-defined bounds results in an area of %d km which exceeds the maximum download area of 450000; downloading in chunks', shapefile_area(prod_shapefile))
@@ -429,7 +429,12 @@ def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None
         total_bbox_metadatalyr=open_shapefile(prods_TOTbbox_metadatalyr, 0, 0)
         # Generate footprint for the union of all products
         if croptounion:
-            prods_bbox=prods_bbox.union(total_bbox)
+            # Get union
+            total_bbox=total_bbox.union(prods_bbox)
+            total_bbox_metadatalyr=total_bbox_metadatalyr.union(prods_bbox)
+            # Save to file
+            save_shapefile(prods_TOTbbox, total_bbox, 'GeoJSON')
+            save_shapefile(prods_TOTbbox_metadatalyr, total_bbox_metadatalyr, 'GeoJSON')
         # Generate footprint for the common intersection of all products
         else:
             # Now pass track intersection for cutline
@@ -658,6 +663,9 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, lat,
     except:
         #chunk data to conserve memory
         out_interpolated = []
+        # need to mask nodata
+        dem_array = dem.ReadAsArray()
+        dem_array = np.ma.masked_where(dem_array == dem.GetRasterBand(1).GetNoDataValue(), dem_array)
         dem_array=np.array_split(dem.ReadAsArray(), 100) ; dem_array=[x for x in dem_array if x.size > 0]
         lat=np.array_split(lat, 100) ; dem_array=[x for x in lat if x.size > 0]
         lon=np.array_split(lon, 100) ; dem_array=[x for x in lon if x.size > 0]
@@ -745,15 +753,21 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
     tropo_date_dict={}
     for i in date_list: tropo_date_dict[i]=[] ; tropo_date_dict[i+"_UTC"]=[]
     for i in enumerate(tropo_products):
-        if not os.path.isdir(i[1]):
+        if not os.path.isdir(i[1]) and not i[1].endswith('.ztd') and not i[1].endswith('.tif'):
             untar_dir=os.path.join(os.path.abspath(os.path.join(i[1], os.pardir)),os.path.basename(i[1]).split('.')[0]+'_extracted')
             if not tarfile.is_tarfile(i[1]):
                 raise Exception('Cannot extract %s because it is not a valid tarfile. Resolve this and relaunch'%(i[1]))
             log.info('Extracting GACOS tarfile %s to %s.', os.path.basename(i[1]), untar_dir)
             tarfile.open(i[1]).extractall(path=untar_dir)
             tropo_products[i[0]]=untar_dir
-        # Loop through each GACOS product file
-        for k in glob.glob(os.path.join(tropo_products[i[0]],'*.ztd')):
+        # Loop through each GACOS product file, differentiating between direct input list of GACOS products vs parent directory
+        if i[1].endswith('.ztd') or i[1].endswith('.tif'):
+            ztd_list = [i[1]]
+        else:
+            ztd_list = glob.glob(os.path.join(tropo_products[i[0]],'*.ztd')) + glob.glob(os.path.join(tropo_products[i[0]],'*.tif'))
+            # prioritize .ztd over .tif duplicates if the former exists
+            ztd_list = [i for i in ztd_list if not (i.endswith('.tif') and i.split('.tif')[0] in ztd_list)]
+        for k in ztd_list:
             # Only check files corresponding to standard product dates
             if os.path.basename(k)[:-4] in date_list:
                 tropo_date_dict[os.path.basename(k)[:-4]].append(k)
@@ -769,6 +783,7 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
                     log.debug("GACOS product %s successfully converted to GDAL-readable raster", k)
 
     # If multiple GACOS directories, merge products.
+    tropo_products = list(set([os.path.dirname(i) if (i.endswith('.ztd') or i.endswith('.tif')) else i for i in tropo_products]))
     if len(tropo_products)>1:
         tropo_products=os.path.join(outDir,'merged_GACOS')
         log.info('Stitching/storing GACOS products in %s.', tropo_products)
@@ -798,7 +813,7 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
         tropo_products=tropo_products[0]
 
     # Estimate percentage of overlap with tropospheric product
-    for i in glob.glob(os.path.join(tropo_products,'*.ztd.vrt')):
+    for i in glob.glob(os.path.join(tropo_products,'*.vrt')):
         # create shapefile
         geotrans=gdal.Open(i).GetGeoTransform()
         bbox=[geotrans[3]+(gdal.Open(i).ReadAsArray().shape[0]*geotrans[-1]),geotrans[3],geotrans[0],geotrans[0]+(gdal.Open(i).ReadAsArray().shape[1]*geotrans[1])]
@@ -812,11 +827,29 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             raise Exception('No spatial overlap between tropospheric product %s and defined bounding box. Resolve conflict and relaunch', i)
 
     # Iterate through all IFGs and apply corrections
+    missing_products = []
     for i in range(len(product_dict[0])):
         outname=os.path.join(workdir,product_dict[2][i][0])
         unwname=os.path.join(outDir,'unwrappedPhase',product_dict[2][i][0])
         tropo_reference=os.path.join(tropo_products,product_dict[2][i][0][:8]+'.ztd.vrt')
         tropo_secondary=os.path.join(tropo_products,product_dict[2][i][0][9:]+'.ztd.vrt')
+        # if .ztd products don't exist, check if .tif exists
+        if not os.path.exists(tropo_reference):
+            tropo_reference=os.path.join(tropo_products,product_dict[2][i][0][:8]+'.ztd.tif.vrt')
+        if not os.path.exists(tropo_secondary):
+            tropo_secondary=os.path.join(tropo_products,product_dict[2][i][0][9:]+'.ztd.tif.vrt')
+        # skip if corrected already generated and does not need to be updated
+        if os.path.exists(outname):
+            # get unwrappedPhase geotrans and productbounding box
+            unw_prodcheck = gdal.Open(unwname)
+            unw_geotrans = unw_prodcheck.GetGeoTransform()
+            unw_prodcheck = np.isfinite(unw_prodcheck.ReadAsArray())
+            tropo_prodcheck = gdal.Open(outname)
+            output_geotrans = tropo_prodcheck.GetGeoTransform()
+            tropo_prodcheck = np.isfinite(tropo_prodcheck.ReadAsArray())
+            if unw_geotrans == output_geotrans and np.array_equal(unw_prodcheck, tropo_prodcheck):
+                continue
+            del unw_prodcheck, tropo_prodcheck
         if os.path.exists(tropo_reference) and os.path.exists(tropo_secondary):
             # Check if tropo products are temporally consistent with IFG
             for j in [tropo_reference, tropo_secondary]:
@@ -882,6 +915,14 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
 
         else:
             log.warning("Must skip IFG %s, because the tropospheric products corresponding to the reference and/or secondary products are not found in the specified folder %s", product_dict[2][i][0], tropo_products)
+            for j in [tropo_reference, tropo_secondary]:
+                if not os.path.exists(j) and j not in missing_products:
+                    missing_products.append(j)
+    # Print list of dates missing tropospheric corrections
+    if len(missing_products) > 0:
+        missing_products = [os.path.basename(i)[:8] for i in missing_products]
+        log.debug("Tropo products for the following dates are missing:")
+        log.debug(missing_products)
 
 def main(inps=None):
     '''

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -150,7 +150,7 @@ def generateStack(aria_prod,inputFiles,outputFileName,workdir='./', refDlist=Non
         tropoDlist = glob.glob(os.path.join(workdir,'tropocorrected_products','[0-9]*[0-9].vrt'))
         tropoDlist = sorted([os.path.basename(i).split('.vrt')[0] for i in tropoDlist])
         if os.path.exists(os.path.join(workdir,'tropocorrected_products')) and tropoDlist == refDlist:
-            log.warning("Discrepancy between 'tropocorrected_products' products ({} files) and {} products ({} files)," 
+            log.warning("Discrepancy between 'tropocorrected_products' products ({} files) and {} products ({} files),"
                         "rejecting scenes not common between both".format(len(refDlist), domainName, len(newDlist)))
         else:
             log.warning("Discrepancy between 'unwrappedPhase' products ({} files) and {} products ({} files),"

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -10,6 +10,7 @@ import os
 import glob
 from datetime import datetime
 from osgeo import gdal
+import logging
 
 gdal.UseExceptions()
 #Suppress warnings
@@ -20,6 +21,7 @@ from ARIAtools.ARIAProduct import ARIA_standardproduct
 from ARIAtools.mask_util import prep_mask
 from ARIAtools.extractProduct import merged_productbbox, prep_dem, export_products, tropo_correction
 
+log = logging.getLogger(__name__)
 
 def createParser():
     '''
@@ -145,8 +147,18 @@ def generateStack(aria_prod,inputFiles,outputFileName,workdir='./', refDlist=Non
     # Confirm 1-to-1 match between UNW and other derived products
     newDlist = [os.path.basename(i).split('.vrt')[0] for i in Dlist]
     if refDlist and newDlist != refDlist:
-        raise Exception('Discrepancy between {} number of UNW products and {} number of {} products'.format(
-            len(refDlist), len(newDlist), domainName))
+        tropoDlist = glob.glob(os.path.join(workdir,'tropocorrected_products','[0-9]*[0-9].vrt'))
+        tropoDlist = sorted([os.path.basename(i).split('.vrt')[0] for i in tropoDlist])
+        if os.path.exists(os.path.join(workdir,'tropocorrected_products')) and tropoDlist == refDlist:
+            log.warning("Discrepancy between 'tropocorrected_products' products ({} files) and {} products ({} files)," 
+                        "rejecting scenes not common between both".format(len(refDlist), domainName, len(newDlist)))
+        else:
+            log.warning("Discrepancy between 'unwrappedPhase' products ({} files) and {} products ({} files),"
+                        "rejecting scenes not common between both".format(len(refDlist), domainName, len(newDlist)))
+        # subset to match other datasets
+        subset_ind = [i[0] for i in enumerate(newDlist) if i[1] in refDlist]
+        newDlist = [newDlist[i] for i in subset_ind]
+        Dlist = [Dlist[i] for i in subset_ind]
 
     for data in Dlist:
         width = None
@@ -328,12 +340,12 @@ def main(inps=None):
         tropo_correction(standardproduct_info.products, inps.tropo_products, standardproduct_info.bbox_file, prods_TOTbbox, outDir=inps.workdir, outputFormat=inps.outputFormat, verbose=inps.verbose, num_threads=inps.num_threads)
 
     # Generate Stack
-    refDlist = generateStack(standardproduct_info,'coherence','cohStack',workdir=inps.workdir)
-    refDlist = generateStack(standardproduct_info,'connectedComponents','connCompStack',workdir=inps.workdir, refDlist=refDlist)
     if inps.tropo_products:
-        refDlist = generateStack(standardproduct_info,'tropocorrected_products','unwrapStack',workdir=inps.workdir, refDlist=refDlist)
+        refDlist = generateStack(standardproduct_info,'tropocorrected_products','unwrapStack',workdir=inps.workdir)
     else:
-        refDlist = generateStack(standardproduct_info,'unwrappedPhase','unwrapStack',workdir=inps.workdir, refDlist=refDlist)
+        refDlist = generateStack(standardproduct_info,'unwrappedPhase','unwrapStack',workdir=inps.workdir)
+    refDlist = generateStack(standardproduct_info,'coherence','cohStack',workdir=inps.workdir, refDlist=refDlist)
+    refDlist = generateStack(standardproduct_info,'connectedComponents','connCompStack',workdir=inps.workdir, refDlist=refDlist)
     # If amplitude files extracted
     if 'amplitude' in inps.layers:
-        refDlist = generateStack(standardproduct_info,'amplitude','ampStack',workdir=inps.workdir)
+        refDlist = generateStack(standardproduct_info,'amplitude','ampStack',workdir=inps.workdir, refDlist=refDlist)

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -221,7 +221,7 @@ def generateStack(aria_prod,inputFiles,outputFileName,workdir='./', refDlist=Non
                 print('Orbit direction not recognized')
                 metadata['orbit_direction'] = 'UNKNOWN'
 
-            path = os.path.relpath(os.path.abspath(data[1]), start=stack_dir)
+            path = os.path.abspath(data[1])
             outstr = '''    <VRTRasterBand dataType="{dataType}" band="{index}">
         <SimpleSource>
             <SourceFilename relativeToVRT="1">{path}</SourceFilename>


### PR DESCRIPTION
GACOS-correction associated bug-fixes:

- Update other stacks accordingly (i.e. coherence/connComp) to reflect troop-corrected products if GACOS corrections aren’t available for some pairs. Before, the program would crash when attempting to generate the ‘Stack.vrt’ as there would be a discrepancy between the number of GACOS corrected-products and coherence/connComp files.

- List all of the acquisitions for which GACOS products are not available in the warning log.

- Check if existing GACOS-corrected products share the same geotrans/bounding box and skip duplicate work if they do in a successive run.

- Finally, GACOS products appear to be distributed as ‘TIF’ files now by default, while ARIA-tools had still expected products with the original ‘.ztd’ extension. Now a check for both has been integrated. This was addressed in a recent MintPy PR: https://github.com/insarlab/MintPy/pull/519


DEM-associated bug-fixes:

- Mask default DEM nodata value (-32768) when loading as numpy array, otherwise it will be may treated as a real value during 3d metadata cube intersection.

- croptounion option bug where unions of shape files were taken, but not saved to file.

- Chunking threshold needed to be adjusted, as download of large DEMs not captured by the area check failed.



Note, to test these bug fixes you may run the following commands and refer to Slack to obtain the test GACOS products (couldn't upload here because they were too big for github!). Before my fixes, the following commands would encounter the problems outlined above:

```
ariaDownload.py -t 79 -o "Download" -b "5.4 16.3 37.6 42.4" -nt 4 --end 20141210

unzip D079_test_gacos.zip

ariaTSsetup.py -f 'products/*.nc' -d "Download" -m "Download" -of ISCE -w aria_gacos -tp 'D079_test_gacos/*ztd' -b "5.4 16.3 37.6 42.4" -nt 4 -croptounion
```

@rzinke, perhaps these changes would be relevant to your work?