### PR TITLE
Patch download and area calculation

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -28,7 +28,9 @@ def unwrap_self_readproduct(arg):
     return ARIA_standardproduct.__readproduct__(arg[0], arg[1])[0]
 
 class ARIA_standardproduct: #Input file(s) and bbox as either list or physical shape file.
-    """Class which loads ARIA standard products and splits them into
+    """Load ARIA standard products
+
+    Load ARIA standard products and split them into
     spatiotemporally contigeous interferograms.
     """
     # import dependencies
@@ -93,11 +95,13 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             gdal.SetConfigOption('VSI_CACHE','YES')
 
             fmt=gdal.Open([s for s in self.files if 'https://' in s][0]).GetDriver().GetDescription()
-            if fmt != 'netCDF': raise Exception ('System update required to read requested virtual products: Linux kernel >=4.3 and libnetcdf >=4.5')
+            if fmt != 'netCDF': raise Exception ('System update required to ' \
+                'read requested virtual products: Linux kernel >=4.3 and libnetcdf >=4.5')
         #check if local file reader is being captured as netcdf
         if any("https://" not in i for i in self.files):
             fmt=gdal.Open([s for s in self.files if 'https://' not in s][0]).GetDriver().GetDescription()
-            if fmt != 'netCDF': raise Exception ('System update required to read requested local products: Linux kernel >=4.3 and libnetcdf >=4.5')
+            if fmt != 'netCDF': raise Exception ('System update required to' \
+                'read requested local products: Linux kernel >=4.3 and libnetcdf >=4.5')
 
         if len(self.files)==0:
             raise Exception('No file match found')
@@ -113,14 +117,17 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
                 try:
                     bbox = [float(val) for val in bbox.split()]
                 except:
-                    raise Exception('Cannot understand the --bbox argument. String input is incorrect or path does not exist.')
+                    raise Exception('Cannot understand the --bbox argument.' \
+                        'String input is incorrect or path does not exist.')
                 # Use shapely to make list
                 self.bbox = Polygon(np.column_stack((np.array([bbox[2],bbox[3],bbox[3],bbox[2],bbox[2]]),
                             np.array([bbox[0],bbox[0],bbox[1],bbox[1],bbox[0]])))) #Pass lons/lats to create polygon
                 # Save polygon in shapefile
-                save_shapefile(os.path.join(workdir,'user_bbox.json'), self.bbox, 'GeoJSON')
+                save_shapefile(os.path.join(workdir,'user_bbox.json'),
+                              self.bbox, 'GeoJSON')
                 self.bbox_file=os.path.join(workdir,'user_bbox.json')
-                log.info("Shapefile %s created for input user bounds.", os.path.join(workdir,'user_bbox.json'))
+                log.info("Shapefile %s created for input user bounds.",
+                         os.path.join(workdir,'user_bbox.json'))
             # If shapefile
             elif os.path.isfile(bbox):
                 self.bbox = open_shapefile(bbox, 0, 0)                       ##SS => We should track the projection of the shapefile. i.e. if user provides this in e.g. UTM etc.
@@ -135,7 +142,9 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
 
 
     def __readproduct__(self, fname):
-        """Read product, determine expected layer names based off of version
+        """Read products
+
+        Read product, determine expected layer names based off of version
         number, and populate corresponding product dictionary accordingly.
         """
         ### Get standard product version from file
@@ -152,22 +161,26 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
 
         # Open standard product bbox
         if self.bbox is not None:
-            file_bbox = open_shapefile(fname + '":'+sdskeys[0], 'productBoundingBox', 1)
+            file_bbox = open_shapefile(fname + '":'+sdskeys[0],
+                                       'productBoundingBox', 1)
             # Only generate dictionaries if there is spatial overlap with user bbox
             if file_bbox.intersects(self.bbox):
-                product_dicts = [self.__mappingData__(fname, rmdkeys, sdskeys, version)]
+                product_dicts = [self.__mappingData__( \
+                                 fname, rmdkeys, sdskeys, version)]
             else:
                 product_dicts = []
         # If no bbox specified, just pass dictionaries
         else:
-            product_dicts = [self.__mappingData__(fname, rmdkeys, sdskeys, version)]
+            product_dicts = [self.__mappingData__( \
+                             fname, rmdkeys, sdskeys, version)]
 
         return product_dicts
 
 
     def __OGmappingVersion__(self, fname, version):
         """Track the mapping of ARIA standard product versions.
-        The order of the keys needs to be consistent with the keys in the 
+
+        The order of the keys needs to be consistent with the keys in the
         mappingData function.
         E.g. a new expected radar-metadata key can be added as XXX to the end
         of the list "rmdkeys" below, and correspondingly to the end of the list
@@ -179,14 +192,17 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         # ARIA standard product version 1a and 1b have same mapping
         if version=='1a' or version=='1b':
             # Radarmetadata names for these versions
-            rmdkeys=['missionID', 'wavelength', 'centerFrequency', 'productType',
-            'ISCEversion', 'unwrapMethod', 'DEM', 'ESDthreshold', 'azimuthZeroDopplerStartTime', 'azimuthZeroDopplerEndTime',
-            'azimuthTimeInterval', 'slantRangeSpacing', 'slantRangeEnd', 'slantRangeStart']
+            rmdkeys = ['missionID', 'wavelength', 'centerFrequency',
+                'productType', 'ISCEversion', 'unwrapMethod', 'DEM',
+                'ESDthreshold', 'azimuthZeroDopplerStartTime',
+                'azimuthZeroDopplerEndTime', 'azimuthTimeInterval',
+                'slantRangeSpacing', 'slantRangeEnd', 'slantRangeStart']
 
             # Layer names for these versions
-            sdskeys=['productBoundingBox','unwrappedPhase','coherence',
-            'connectedComponents','amplitude','perpendicularBaseline',
-            'parallelBaseline','incidenceAngle','lookAngle','azimuthAngle','ionosphere']
+            sdskeys=['productBoundingBox', 'unwrappedPhase', 'coherence',
+                'connectedComponents', 'amplitude', 'perpendicularBaseline',
+                'parallelBaseline', 'incidenceAngle', 'lookAngle',
+                'azimuthAngle', 'ionosphere']
 
             #Pass pair name
             read_file=netCDF4.Dataset(fname, keepweakref=True).groups['science'].groups['radarMetaData'].groups['inputSLC']
@@ -253,6 +269,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
 
     def __mappingVersion__(self, fname, version):
         """Track the mapping of ARIA standard product versions.
+
         The order of the keys needs to be consistent with the keys in the
         mappingData function.
         E.g. a new expected radar-metadata key can be added as XXX to the end
@@ -270,36 +287,42 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
             self.pairname=basename.split('-')[6]
 
             # Radarmetadata names for these versions
-            rdrmetadata_dict['pair_name']=self.pairname
-            rdrmetadata_dict['azimuthZeroDopplerMidTime']=basename[21:25]+'-'+basename[25:27]+'-' \
-                +basename[27:29]+'T'+basename[39:41]+':'+basename[41:43]+':'+basename[43:45] + '.0'
+            rdrmetadata_dict['pair_name'] = self.pairname
+            rdrmetadata_dict['azimuthZeroDopplerMidTime'] = basename[21:25] \
+                + '-'+basename[25:27] + '-' + basename[27:29] + 'T' \
+                + basename[39:41] + ':' + basename[41:43] + ':' \
+                + basename[43:45] + '.0'
 
-            rdrmetadata_dict['azimuthZeroDopplerMidTime']=self.pairname[:4]+'-'+self.pairname[4:6]+'-'+self.pairname[6:8]+'T' \
-                +basename.split('-')[7][:2]+':'+basename.split('-')[7][2:4]+':'+basename.split('-')[7][4:]+'.0'
+            rdrmetadata_dict['azimuthZeroDopplerMidTime'] = self.pairname[:4] \
+                + '-' + self.pairname[4:6] + '-' + self.pairname[6:8] \
+                + 'T' + basename.split('-')[7][:2] + ':' \
+                + basename.split('-')[7][2:4] + ':' \
+                + basename.split('-')[7][4:] + '.0'
 
             #hardcoded keys for a given sensor
-            if basename.split('-')[0]=='S1':
-                rdrmetadata_dict['missionID']='Sentinel-1'
-                rdrmetadata_dict['productType']='UNW GEO IFG'
-                rdrmetadata_dict['wavelength']=0.05546576
-                rdrmetadata_dict['centerFrequency']=5.4050007e+09
-                rdrmetadata_dict['slantRangeSpacing']=2.329562187194824
-                rdrmetadata_dict['slantRangeStart']=798980.125
-                rdrmetadata_dict['slantRangeEnd']=956307.125
+            if basename.split('-')[0] == 'S1':
+                rdrmetadata_dict['missionID'] = 'Sentinel-1'
+                rdrmetadata_dict['productType'] = 'UNW GEO IFG'
+                rdrmetadata_dict['wavelength'] = 0.05546576
+                rdrmetadata_dict['centerFrequency'] = 5.4050007e+09
+                rdrmetadata_dict['slantRangeSpacing'] = 2.329562187194824
+                rdrmetadata_dict['slantRangeStart'] = 798980.125
+                rdrmetadata_dict['slantRangeEnd'] = 956307.125
                 #hardcoded key meant to gauge temporal connectivity of scenes (i.e. seconds between start and end)
-                rdrmetadata_dict['sceneLength']=35
-            elif basename.split('-')[0]=='ALOS2':
-                rdrmetadata_dict['missionID']='ALOS-2'
-                rdrmetadata_dict['productType']='UNW GEO IFG'
-                rdrmetadata_dict['wavelength']=0.229
-                rdrmetadata_dict['centerFrequency']=1.2364997e+09
-                rdrmetadata_dict['slantRangeSpacing']=8.582534
-                rdrmetadata_dict['slantRangeStart']=695397.
-                rdrmetadata_dict['slantRangeEnd']=913840.2
+                rdrmetadata_dict['sceneLength'] = 35
+            elif basename.split('-')[0] == 'ALOS2':
+                rdrmetadata_dict['missionID'] = 'ALOS-2'
+                rdrmetadata_dict['productType'] = 'UNW GEO IFG'
+                rdrmetadata_dict['wavelength'] = 0.229
+                rdrmetadata_dict['centerFrequency'] = 1.2364997e+09
+                rdrmetadata_dict['slantRangeSpacing'] = 8.582534
+                rdrmetadata_dict['slantRangeStart'] = 695397.
+                rdrmetadata_dict['slantRangeEnd'] = 913840.2
                 #hardcoded key meant to gauge temporal connectivity of scenes (i.e. seconds between start and end)
-                rdrmetadata_dict['sceneLength']=52
+                rdrmetadata_dict['sceneLength'] = 52
             else:
-                raise Exception('Sensor %s for file %s not supported.'%(basename.split('-')[0],fname))
+                raise Exception('Sensor %s for file %s not supported.' \
+                                %(basename.split('-')[0],fname))
 
             # Layer names for these versions
             sdskeys = [
@@ -315,13 +338,16 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
                 '/science/grids/imagingGeometry/azimuthAngle'
             ]
             if version.lower()=='1c':
-                sdskeys.append('/science/grids/corrections/derived/ionosphere/ionosphere')
+                sdskeys.append('/science/grids/corrections' \
+                               '/derived/ionosphere/ionosphere')
 
         return rdrmetadata_dict, sdskeys
 
 
     def __mappingData__(self, fname, rdrmetadata_dict, sdskeys, version):
-        """Output and group together 2 dictionaries containing the
+        """Pass product record of metadata and layers
+
+        Output and group together 2 dictionaries containing the
         “radarmetadata info” and “data layer keys+paths”, respectively
         The order of the dictionary keys below needs to be consistent with the
         keys in the __mappingVersion__ function of the ARIA_standardproduct
@@ -353,65 +379,98 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
 
     def __continuous_time__(self):
         """Split the products into spatiotemporally continuous groups
-        (i.e. by individual, continuous interferograms). Input must be already
-        sorted by pair and start-time to fit the logic scheme below.
+
+        Split products by individual, continuous interferograms.
+        Input must be already sorted by pair and start-time to fit
+        the logic scheme below.
         Using their time-tags, this function determines whether or not
-        successive products are in the same orbit. If in the same orbit, the
-        program determines whether or not they overlap in time and are
-        therefore spatially contiguous, and rejects/reports cases for which
-        there is no temporal overlap and therefore a spatial gap.
+        successive products are in the same orbit.
+        If in the same orbit, the program determines whether or not they
+        overlap in time and are therefore spatially contiguous,
+        and rejects/reports cases for which there is no temporal overlap
+        and therefore a spatial gap.
         """
         # import dependencies
         from datetime import datetime, timedelta
         import itertools
 
-        sorted_products=[]
-        track_rejected_pairs=[]
+        sorted_products = []
+        track_rejected_pairs = []
 
         # Check for (and remove) duplicate products
-        num_prods=len(self.products)
-        num_dups=[]
+        num_prods = len(self.products)
+        num_dups = []
         for i in enumerate(self.products[:-1]):
             # If scenes share >90% spatial overlap AND same dates, they MUST be duplicates. Reject the latter.
-            if (self.products[i[0]+1][0]['pair_name'][9:]==i[1][0]['pair_name'][9:]) and \
-                (self.products[i[0]+1][0]['pair_name'][:8]==i[1][0]['pair_name'][:8]) and \
-                (open_shapefile(self.products[i[0]+1][1]['productBoundingBox'], 'productBoundingBox', 1).intersection( \
-                open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1)).area) \
-                /(open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1).area)>0.9:
+            if (self.products[i[0]+1][0]['pair_name'][9:] \
+                 == i[1][0]['pair_name'][9:]) and \
+                 (self.products[i[0]+1][0]['pair_name'][:8] \
+                 == i[1][0]['pair_name'][:8]) and \
+                 (open_shapefile( \
+                 self.products[i[0]+1][1]['productBoundingBox'], \
+                 'productBoundingBox', 1).intersection( \
+                 open_shapefile(i[1][1]['productBoundingBox'], \
+                 'productBoundingBox', 1)).area) \
+                 / (open_shapefile(i[1][1]['productBoundingBox'], \
+                 'productBoundingBox', 1).area) > 0.9:
                 # If applicable, overwrite smaller scene with larger one
-                if (open_shapefile(self.products[i[0]+1][1]['productBoundingBox'], 'productBoundingBox', 1).intersection(
-                open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1)).area) \
-                /(open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1).area) \
-                >(open_shapefile(i[1][1]['productBoundingBox'], 'productBoundingBox', 1).intersection(
-                open_shapefile(self.products[i[0]+1][1]['productBoundingBox'], 'productBoundingBox', 1)).area) \
-                /(open_shapefile(self.products[i[0]+1][1]['productBoundingBox'], 'productBoundingBox', 1).area):
+                if (open_shapefile( \
+                     self.products[i[0]+1][1]['productBoundingBox'], \
+                     'productBoundingBox', 1).intersection( \
+                     open_shapefile(i[1][1]['productBoundingBox'], \
+                     'productBoundingBox', 1)).area) \
+                     / (open_shapefile(i[1][1]['productBoundingBox'], \
+                     'productBoundingBox', 1).area) \
+                     > (open_shapefile(i[1][1]['productBoundingBox'], \
+                     'productBoundingBox', 1).intersection( \
+                     open_shapefile( \
+                     self.products[i[0]+1][1]['productBoundingBox'], \
+                     'productBoundingBox', 1)).area) \
+                     / (open_shapefile( \
+                     self.products[i[0]+1][1]['productBoundingBox'], \
+                     'productBoundingBox', 1).area):
                     i=(i[0]-1,self.products[i[0]+1])
-                log.debug("Duplicate product captured. Rejecting scene %s", os.path.basename(self.products[i[0]+1][1]['unwrappedPhase'].split('"')[1]))
+                log.debug("Duplicate product captured. Rejecting scene %s",
+                    os.path.basename( \
+                     self.products[i[0]+1][1]['unwrappedPhase'].split('"')[1]))
                 # Overwrite latter scene with former
                 self.products[i[0]+1]=i[1]
                 num_dups.append(i[0])
         # Delete duplicate products
-        self.products=list(self.products for self.products,_ in itertools.groupby(self.products))
+        self.products=list(self.products for self.products,_ in \
+                           itertools.groupby(self.products))
         if num_dups:
-            log.warning("%d products rejected since they are duplicates", len(num_dups))
+            log.warning("%d products rejected since they are duplicates",
+                        len(num_dups))
 
         # If only one pair in list, add it to list.
         if len(self.products)==1:
-            sorted_products.extend([[dict(zip(self.products[0][0].keys(), [list(a) for a in zip(self.products[0][0].values())])), dict(zip(self.products[0][1].keys(), [list(a) for a in zip(self.products[0][1].values())]))]])
+            sorted_products.extend([[dict(zip(self.products[0][0].keys(),
+                [list(a) for a in zip(self.products[0][0].values())])),
+                dict(zip(self.products[0][1].keys(),
+                [list(a) for a in zip(self.products[0][1].values())]))]])
 
         # If multiple pairs in list, cycle through and evaluate temporal connectivity.
         for i in enumerate(self.products[:-1]):
             # Get this reference product's times
-            scene_start=datetime.strptime(i[1][0]['azimuthZeroDopplerMidTime'], "%Y-%m-%dT%H:%M:%S.%f")
-            scene_end=scene_start+timedelta(seconds=i[1][0]['sceneLength'])
-            master=datetime.strptime(i[1][0]['pair_name'][9:], "%Y%m%d")
-            new_scene_start=datetime.strptime(self.products[i[0]+1][0]['azimuthZeroDopplerMidTime'], "%Y-%m-%dT%H:%M:%S.%f")
-            new_scene_end=new_scene_start+timedelta(seconds=i[1][0]['sceneLength'])
-            slave=datetime.strptime(self.products[i[0]+1][0]['pair_name'][9:], "%Y%m%d")
+            scene_start = datetime.strptime(
+                i[1][0]['azimuthZeroDopplerMidTime'],
+                "%Y-%m-%dT%H:%M:%S.%f")
+            scene_end = scene_start + timedelta(seconds=i[1][0]['sceneLength'])
+            master = datetime.strptime(i[1][0]['pair_name'][9:],
+                "%Y%m%d")
+            new_scene_start = datetime.strptime(
+                self.products[i[0]+1][0]['azimuthZeroDopplerMidTime'],
+                "%Y-%m-%dT%H:%M:%S.%f")
+            new_scene_end = new_scene_start + timedelta(
+                seconds = i[1][0]['sceneLength'])
+            slave = datetime.strptime(self.products[i[0]+1][0]['pair_name'][9:],
+                "%Y%m%d")
 
             # Determine if next product in time is in same orbit AND overlaps AND corresponds to same pair
             # If it is within same orbit cycle, try to append scene. This accounts for day change.
-            if abs(new_scene_end-scene_end)<=timedelta(minutes=100) and abs(slave-master)<=timedelta(days=1):
+            if abs(new_scene_end-scene_end) <= timedelta(minutes=100) and \
+                 abs(slave-master) <= timedelta(days=1):
                 # Don't export product if it is already tracked as a rejected pair
                 if i[1][0]['pair_name'] in track_rejected_pairs or self.products[i[0]+1][0]['pair_name'] in track_rejected_pairs:
                     track_rejected_pairs.extend((i[1][0]['pair_name'],self.products[i[0]+1][0]['pair_name']))
@@ -492,7 +551,7 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
         # Exit if products from different sensors were mixed
         if not all(i[0]['missionID'] == 'Sentinel-1' for i in self.products) \
             and not all(i[0]['missionID'] == 'ALOS-2' for i in self.products):
-            raise Exception('Specified input contains standard products from '\
+            raise Exception('Specified input contains standard products from '
                 'different sensors, please proceed with homogeneous products.')
 
         # Check if any pairs meet criteria

--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -533,8 +533,10 @@ class ARIA_standardproduct: #Input file(s) and bbox as either list or physical s
                     self.products += Parallel(n_jobs= -1, max_nbytes=1e6)(
                                 delayed(unwrap_self_readproduct)(i) for i in
                                         zip([self]*len(self.files), self.files))
-                except Exception:
-                    log.info('Multi-core version failed, will try single loop')
+                except Exception as E:
+                    log.warning('Multi-core version failed with error: %s', E)
+                    log.info('Will try single loop')
+
                     for f in self.files:
                         self.products += self.__readproduct__(f)
             else:

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -27,9 +27,7 @@ log = logging.getLogger(__name__)
 _world_dem = "https://portal.opentopography.org/API/globaldem?demtype=SRTMGL1_E&west={}&south={}&east={}&north={}&outputFormat=GTiff"
 
 def createParser():
-    '''
-       Extract specified product layers. The default will export all layers.
-    '''
+    """Extract specified product layers. The default will export all layers."""
     import argparse
     parser = argparse.ArgumentParser(description= \
             'Program to extract data and meta-data layers from ARIA standard GUNW products.'\
@@ -76,14 +74,10 @@ def cmdLineParse(iargs = None):
     return parser.parse_args(args=iargs)
 
 class InterpCube(object):
-    '''
-        Class to interpolate intersection of cube with DEM
-    '''
+    """Class to interpolate intersection of cube with DEM."""
 
     def __init__(self, inobj, hgtobj, latobj, lonobj):
-        '''
-            Init with h5py dataset.
-        '''
+        """Init with h5py dataset."""
         self.data = inobj[:]
         self.hgts = hgtobj[:]
         self.offset = None
@@ -94,9 +88,7 @@ class InterpCube(object):
         self.createInterp()
 
     def createInterp(self):
-        '''
-            Create interpolators.
-        '''
+        """Create interpolators."""
         from scipy.interpolate import RectBivariateSpline
         self.offset = np.mean(self.data)
         for i in range(len(self.hgts)):
@@ -114,11 +106,10 @@ class InterpCube(object):
         return est(h) + self.offset
 
 class metadata_qualitycheck:
-    """ Metadata quality control function. Artifacts recognized based off of covariance of cross-profiles.
-
-    Bug-fix varies based off of layer of interest.
-    Verbose mode generates a series of quality control plots with these profiles.
-    """
+    """Metadata quality control function. Artifacts recognized based off of
+    covariance of cross-profiles. Bug-fix varies based off of layer of
+    interest. Verbose mode generates a series of quality control plots with
+    these profiles."""
 
     def __init__(self, data_array, prod_key, outname, verbose=None):
         # Pass inputs
@@ -326,9 +317,9 @@ class metadata_qualitycheck:
 def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
                         proj, arrshape=None, workdir='./',
                         outputFormat='ENVI', num_threads='2'):
-    """Function to load and export DEM, lat, lon arrays.
-
-    If "Download" flag is specified, DEM will be downloaded on the fly.
+    """
+        Function to load and export DEM, lat, lon arrays.
+        If "Download" flag is specified, DEM will be downloaded on the fly.
     """
     # If specified DEM subdirectory exists, delete contents
     workdir      = os.path.join(workdir,'DEM')
@@ -387,8 +378,9 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
     return aria_dem, ds_aria, Latitude, Longitude
 
 def dl_dem(path_dem, path_prod_union, num_threads):
-    """Download the DEM over product bbox union."""
-
+    """
+        Download the DEM over product bbox union.
+    """
     # Import functions
     from ARIAtools.shapefile_util import shapefile_area
 
@@ -432,10 +424,12 @@ def dl_dem(path_dem, path_prod_union, num_threads):
     return dst
 
 def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None, croptounion=False, num_threads='2', minimumOverlap=0.0081, verbose=None):
-    '''
-        Extract/merge productBoundingBox layers for each pair and update dict, report common track bbox (default is to take common intersection, but user may specify union), report common track union to accurately interpolate metadata fields, and expected shape for DEM.
-    '''
-
+    """
+        Extract/merge productBoundingBox layers for each pair and update dict,
+        report common track bbox (default is to take common intersection, but
+        user may specify union), report common track union to accurately
+        interpolate metadata fields, and expected shape for DEM.
+    """
     # Import functions
     from ARIAtools.shapefile_util import save_shapefile, shapefile_area
     from shapely.geometry import Polygon
@@ -563,12 +557,14 @@ def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None
 def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedResampling=False, dem=None, lat=None, lon=None, mask=None, outDir='./',outputFormat='VRT', stitchMethodType='overlap', verbose=None, num_threads='2', multilooking=None):
     """
         Export layer and 2D meta-data layers (at the product resolution).
-        The function finalize_metadata is called to derive the 2D metadata layer. Dem/lat/lon arrays must be passed for this process.
+        The function finalize_metadata is called to derive the
+        2D metadata layer.
+        Dem/lat/lon arrays must be passed for this process.
         The keys specify which layer to extract from the dictionary.
-        All products are cropped by the bounds from the input bbox_file, and clipped to the track extent denoted by the input prods_TOTbbox.
+        All products are cropped by the bounds from the input bbox_file,
+        and clipped to the track extent denoted by the input prods_TOTbbox.
         Optionally, a user may pass a mask-file.
     """
-
     ##Import functions
     from ARIAtools.vrtmanager import resampleRaster
 
@@ -673,10 +669,11 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedR
     return
 
 def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, lat, lon, mask=None, outputFormat='ENVI', verbose=None, num_threads='2'):
-    '''
-        2D metadata layer is derived by interpolating and then intersecting 3D layers with a DEM. Lat/lon arrays must also be passed for this process.
-    '''
-
+    """
+        2D metadata layer is derived by interpolating and then intersecting
+        3Dlayers with a DEM.
+        Lat/lon arrays must also be passed for this process.
+    """
     # import dependencies
     import scipy
 
@@ -759,10 +756,11 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, lat,
 
 def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox, outDir='./',outputFormat='VRT', verbose=None, num_threads='2'):
     """
-        Perform tropospheric corrections. Must provide valid path to GACOS products.
-        All products are cropped by the bounds from the input bbox_file, and clipped to the track extent denoted by the input prods_TOTbbox.
+        Perform tropospheric corrections. Must provide valid path to 
+        GACOS products.
+        All products are cropped by the bounds from the input bbox_file,
+        and clipped to the track extent denoted by the input prods_TOTbbox.
     """
-
     # Import functions
     from ARIAtools.vrtmanager import renderVRT
     import tarfile
@@ -985,9 +983,9 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
         log.debug(missing_products)
 
 def main(inps=None):
-    '''
-       Main workflow for extracting layers from ARIA products
-    '''
+    """
+       Main workflow for extracting layers from ARIA products.
+    """
     from ARIAtools.ARIAProduct import ARIA_standardproduct
     print ('*****************************************************************')
     print ('*** Extract Product Function ***')

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -956,11 +956,11 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file,
                       / (user_bbox.area))*100
         if per_overlap != 100. and per_overlap != 0.:
             log.warning('Common track extent only has %d overlap with' \
-                        'tropospheric product %d\n', per_overlap, i)
+                        'tropospheric product %d\n', per_overlap, i[0])
         if per_overlap == 0.:
             raise Exception('No spatial overlap between tropospheric ' \
                             'product %s and defined bounding box. ' \
-                            'Resolve conflict and relaunch', i)
+                            'Resolve conflict and relaunch', i[1])
 
     # Iterate through all IFGs and apply corrections
     missing_products = []

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -78,7 +78,6 @@ def cmdLineParse(iargs = None):
 
 class InterpCube(object):
     """Class to interpolate intersection of cube with DEM."""
-
     def __init__(self, inobj, hgtobj, latobj, lonobj):
         """Init with h5py dataset."""
         self.data = inobj[:]
@@ -99,9 +98,7 @@ class InterpCube(object):
                                                     self.data[i]-self.offset))
 
     def __call__(self, line, pix, h):
-        '''
-            Interpolate at a single point.
-        '''
+        """Interpolate at a single point."""
         from scipy.interpolate import interp1d
 
         vals  = np.array( [x(line,pix)[0,0] for x in self.interp])
@@ -109,10 +106,13 @@ class InterpCube(object):
         return est(h) + self.offset
 
 class metadata_qualitycheck:
-    """Metadata quality control function. Artifacts recognized based off of
-    covariance of cross-profiles. Bug-fix varies based off of layer of
-    interest. Verbose mode generates a series of quality control plots with
-    these profiles."""
+    """Metadata quality control function.
+    
+    Artifacts recognized based off of covariance of cross-profiles.
+    Bug-fix varies based off of layer of interest.
+    Verbose mode generates a series of quality control plots with
+    these profiles.
+    """
 
     def __init__(self, data_array, prod_key, outname, verbose=None):
         # Pass inputs
@@ -320,9 +320,9 @@ class metadata_qualitycheck:
 def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
                         proj, arrshape=None, workdir='./',
                         outputFormat='ENVI', num_threads='2'):
-    """
-        Function to load and export DEM, lat, lon arrays.
-        If "Download" flag is specified, DEM will be downloaded on the fly.
+    """Function to load and export DEM, lat, lon arrays.
+
+    If "Download" flag is specified, DEM will be downloaded on the fly.
     """
     # If specified DEM subdirectory exists, delete contents
     workdir      = os.path.join(workdir,'DEM')
@@ -381,9 +381,7 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
     return aria_dem, ds_aria, Latitude, Longitude
 
 def dl_dem(path_dem, path_prod_union, num_threads):
-    """
-        Download the DEM over product bbox union.
-    """
+    """Download the DEM over product bbox union."""
     # Import functions
     from ARIAtools.shapefile_util import shapefile_area
 
@@ -427,11 +425,12 @@ def dl_dem(path_dem, path_prod_union, num_threads):
     return dst
 
 def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None, croptounion=False, num_threads='2', minimumOverlap=0.0081, verbose=None):
-    """
-        Extract/merge productBoundingBox layers for each pair and update dict,
-        report common track bbox (default is to take common intersection, but
-        user may specify union), report common track union to accurately
-        interpolate metadata fields, and expected shape for DEM.
+    """Extract/merge productBoundingBox layers for each pair.
+
+    Also update dict, report common track bbox
+    (default is to take common intersection, but user may specify union),
+    report common track union to accurately interpolate metadata fields,
+    and expected shape for DEM.
     """
     # Import functions
     from ARIAtools.shapefile_util import save_shapefile, shapefile_area
@@ -558,15 +557,14 @@ def merged_productbbox(metadata_dict, product_dict, workdir='./', bbox_file=None
     return metadata_dict, product_dict, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr, arrshape, proj
 
 def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedResampling=False, dem=None, lat=None, lon=None, mask=None, outDir='./',outputFormat='VRT', stitchMethodType='overlap', verbose=None, num_threads='2', multilooking=None):
-    """
-        Export layer and 2D meta-data layers (at the product resolution).
-        The function finalize_metadata is called to derive the
-        2D metadata layer.
-        Dem/lat/lon arrays must be passed for this process.
-        The keys specify which layer to extract from the dictionary.
-        All products are cropped by the bounds from the input bbox_file,
-        and clipped to the track extent denoted by the input prods_TOTbbox.
-        Optionally, a user may pass a mask-file.
+    """Export layer and 2D meta-data layers (at the product resolution).
+
+    The function finalize_metadata is called to derive the 2D metadata layer.
+    Dem/lat/lon arrays must be passed for this process.
+    The keys specify which layer to extract from the dictionary.
+    All products are cropped by the bounds from the input bbox_file,
+    and clipped to the track extent denoted by the input prods_TOTbbox.
+    Optionally, a user may pass a mask-file.
     """
     ##Import functions
     from ARIAtools.vrtmanager import resampleRaster
@@ -672,10 +670,11 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers, rankedR
     return
 
 def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, lat, lon, mask=None, outputFormat='ENVI', verbose=None, num_threads='2'):
-    """
-        2D metadata layer is derived by interpolating and then intersecting
-        3Dlayers with a DEM.
-        Lat/lon arrays must also be passed for this process.
+    """Interpolate and extract 2D metadata layer.
+
+    2D metadata layer is derived by interpolating and then intersecting
+    3Dlayers with a DEM.
+    Lat/lon arrays must also be passed for this process.
     """
     # import dependencies
     import scipy
@@ -757,17 +756,19 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, lat,
 
     del out_interpolated, interpolator, interp_2d, data_array
 
-def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox, outDir='./',outputFormat='VRT', verbose=None, num_threads='2'):
-    """
-        Perform tropospheric corrections. Must provide valid path to
-        GACOS products.
-        All products are cropped by the bounds from the input bbox_file,
-        and clipped to the track extent denoted by the input prods_TOTbbox.
+def tropo_correction(full_product_dict, tropo_products, bbox_file,
+                     prods_TOTbbox, outDir='./', outputFormat='VRT',
+                     verbose=None, num_threads='2'):
+    """Perform tropospheric corrections.
+
+    Must provide valid path to GACOS products.
+    All products are cropped by the bounds from the input bbox_file,
+    and clipped to the track extent denoted by the input prods_TOTbbox.
     """
     # Import functions
-    from ARIAtools.vrtmanager import renderVRT
     import tarfile
     from datetime import datetime
+    from ARIAtools.vrtmanager import renderVRT, rscGacos, tifGacos
     from ARIAtools.shapefile_util import save_shapefile
     from shapely.geometry import Polygon
 
@@ -777,74 +778,145 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
     user_bbox    = open_shapefile(bbox_file, 0, 0)
     bounds       = user_bbox.bounds
 
-    product_dict=[[j['unwrappedPhase'] for j in full_product_dict[1]], [j['lookAngle'] for j in full_product_dict[1]], [j["pair_name"] for j in full_product_dict[1]]]
-    metadata_dict=[[j['azimuthZeroDopplerMidTime'] for j in full_product_dict[0]], [j['wavelength'] for j in full_product_dict[0]]]
-    workdir=os.path.join(outDir,'tropocorrected_products')
+    product_dict = [[j['unwrappedPhase'] for j in full_product_dict[1]],
+                  [j['lookAngle'] for j in full_product_dict[1]],
+                  [j["pair_name"] for j in full_product_dict[1]]]
+    metadata_dict = [[j['azimuthZeroDopplerMidTime'] for j in \
+                    full_product_dict[0]],
+                   [j['wavelength'] for j in full_product_dict[0]]]
+    workdir = os.path.join(outDir,'tropocorrected_products')
 
     # If specified workdir doesn't exist, create it
     os.makedirs(workdir, exist_ok=True)
 
     # Get list of all dates for which standard products exist
-    date_list=[]
+    date_list = []
     for i in product_dict[2]:
         date_list.append(i[0][:8]); date_list.append(i[0][9:])
-    date_list=list(set(date_list)) # trim to unique dates only
+    date_list = list(set(date_list)) # trim to unique dates only
 
     ### Determine if file input is single file, a list, or wildcard.
     # If list of files
-    if len([str(val) for val in tropo_products.split(',')])>1:
-        tropo_products=[str(i) for i in tropo_products.split(',')]
-        # If wildcard
-        tropo_products=[os.path.abspath(item) for sublist in [glob.glob(os.path.expanduser(os.path.expandvars(i))) if '*' in i else [i] for i in tropo_products] for item in sublist]
+    if len([str(val) for val in tropo_products.split(',')]) > 1:
+        tropo_products = [str(i) for i in tropo_products.split(',')]
+        #tropo_products=[os.path.abspath(item) for sublist in [glob.glob(os.path.expanduser(os.path.expandvars(i))) if '*' in i else [i] for i in tropo_products] for item in sublist]
+        # Sort and parse tropo products
+        tropo_sublist = []
+        for i in tropo_products:
+            # If wildcard
+            if '*' in i:
+                tropo_sublist.append( \
+                     glob.glob(os.path.expanduser(os.path.expandvars(i))))
+            else:
+                tropo_sublist.append([i])
+        # Finalize list of tropo products
+        tropo_products = []
+        for sublist in tropo_sublist:
+            for item in sublist:
+                tropo_products.append(os.path.abspath(item))
+
     # If single file or wildcard
     else:
         # If single file
         if os.path.isfile(tropo_products):
-            tropo_products=[tropo_products]
+            tropo_products = [tropo_products]
         # If wildcard
         else:
-            tropo_products=glob.glob(os.path.expanduser(os.path.expandvars(tropo_products)))
+            tropo_products = glob.glob(os.path.expanduser( \
+                                       os.path.expandvars(tropo_products)))
         # Convert relative paths to absolute paths
-        tropo_products=[os.path.abspath(i) for i in tropo_products]
-    if len(tropo_products)==0:
+        tropo_products = [os.path.abspath(i) for i in tropo_products]
+    if len(tropo_products) == 0:
         raise Exception('No file match found')
 
     ###Extract tarfiles
     # Setup dictionary to track for products that are to be merged
-    tropo_date_dict={}
-    for i in date_list: tropo_date_dict[i]=[] ; tropo_date_dict[i+"_UTC"]=[]
+    tropo_date_dict = {}
+    for i in date_list:
+        tropo_date_dict[i] = []
+        tropo_date_dict[i+"_UTC"] = []
     for i in enumerate(tropo_products):
-        if not os.path.isdir(i[1]) and not i[1].endswith('.ztd') and not i[1].endswith('.tif'):
-            untar_dir=os.path.join(os.path.abspath(os.path.join(i[1], os.pardir)),os.path.basename(i[1]).split('.')[0]+'_extracted')
+        if not os.path.isdir(i[1]) and not i[1].endswith('.ztd') \
+            and not i[1].endswith('.tif'):
+            untar_dir = os.path.join(os.path.abspath(os.path.join(i[1], \
+                         os.pardir)),
+                        os.path.basename(i[1]).split('.')[0] + '_extracted')
             if not tarfile.is_tarfile(i[1]):
-                raise Exception('Cannot extract %s because it is not a valid tarfile. Resolve this and relaunch'%(i[1]))
-            log.info('Extracting GACOS tarfile %s to %s.', os.path.basename(i[1]), untar_dir)
-            tarfile.open(i[1]).extractall(path=untar_dir)
-            tropo_products[i[0]]=untar_dir
+                raise Exception('Cannot extract %s because it is not a ' \
+                                'valid tarfile. Resolve this ' \
+                                'and relaunch'%(i[1]))
+            log.info('Extracting GACOS tarfile %s to %s.',
+                os.path.basename(i[1]), untar_dir)
+            tarfile.open(i[1]).extractall(path = untar_dir)
+            tropo_products[i[0]] = untar_dir
         # Loop through each GACOS product file, differentiating between direct input list of GACOS products vs parent directory
         if i[1].endswith('.ztd') or i[1].endswith('.tif'):
             ztd_list = [i[1]]
         else:
-            ztd_list = glob.glob(os.path.join(tropo_products[i[0]],'*.ztd')) + glob.glob(os.path.join(tropo_products[i[0]],'*.tif'))
-            # prioritize .ztd over .tif duplicates if the former exists
+            ztd_list = glob.glob(os.path.join(tropo_products[i[0]], '*.ztd')) \
+                + glob.glob(os.path.join(tropo_products[i[0]], '*.tif'))
+            # prioritize older .ztd over .tif duplicates if the former exists
+            # older .ztd files contain UTC time info
             ztd_list = [i for i in ztd_list if not (i.endswith('.tif') and i.split('.tif')[0] in ztd_list)]
         for k in ztd_list:
             # Only check files corresponding to standard product dates
-            if os.path.basename(k)[:-4] in date_list:
-                tropo_date_dict[os.path.basename(k)[:-4]].append(k)
-                tropo_date_dict[os.path.basename(k)[:-4]+"_UTC"].append(os.path.basename(k)[:4]+'-'+os.path.basename(k)[4:6]+'-'+os.path.basename(k)[6:8]+'-'+open(k+'.rsc', 'r').readlines()[-1].split()[1])
+            ztd_basename = os.path.basename(k)
+            ztd_basename = ztd_basename.split('.tif')[0].split('.ztd')[0]
+            print('date_list',date_list)
+            print('ztd_basename',ztd_basename)
+            if ztd_basename in date_list:
+                tropo_date_dict[ztd_basename].append(k)
+                if os.path.exists(k+'.rsc'):
+                    tropo_date_dict[ztd_basename+"_UTC"].append( \
+                         ztd_basename[:4] + '-' \
+                         + ztd_basename[4:6] \
+                         + '-' + ztd_basename[6:8] + '-' \
+                         + open(k+'.rsc', 'r').readlines()[-1].split()[1])
+                else:
+                    tropo_date_dict[ztd_basename+"_UTC"].append( \
+                         ztd_basename[:4] + '-' \
+                         + ztd_basename[4:6] \
+                         + '-' + ztd_basename[6:8] + '-' \
+                         + 'NoneUTC')
                 # make corresponding VRT file, if it doesn't exist
                 if not os.path.exists(k+'.vrt'):
-                    tropo_rsc_dict={}
-                    for line in open(k+'.rsc', 'r').readlines(): tropo_rsc_dict[line.split()[0]]=line.split()[1]
-                    gacos_prod=np.fromfile(k, dtype='float32').reshape(int(tropo_rsc_dict['FILE_LENGTH']),int(tropo_rsc_dict['WIDTH']))
+                    # parse metadata from RSC if it exists
+                    if os.path.exists(k+'.rsc'):
+                        tropo_rsc_dict={}
+                        for line in open(k+'.rsc', 'r').readlines():
+                            tropo_rsc_dict[line.split()[0]]=line.split()[1]
+                        gacos_prod = np.fromfile(k, dtype='float32').reshape( \
+                             int(tropo_rsc_dict['FILE_LENGTH']), \
+                             int(tropo_rsc_dict['WIDTH']))
+                    else:
+                        tropo_rsc_dict = tifGacos(k)
+                        gacos_prod = gdal.Open(k).ReadAsArray()
+                        print("tropo_rsc_dict",tropo_rsc_dict)
                     # Save as GDAL file, using proj from first unwrappedPhase file
-                    renderVRT(k, gacos_prod, geotrans=(float(tropo_rsc_dict['X_FIRST']), float(tropo_rsc_dict['X_STEP']), 0.0, float(tropo_rsc_dict['Y_FIRST']), 0.0, float(tropo_rsc_dict['Y_STEP'])), drivername=outputFormat, gdal_fmt='float32', proj=gdal.Open(os.path.join(outDir,'unwrappedPhase',product_dict[2][0][0])).GetProjection(), nodata=0.)
+                    renderVRT(k, gacos_prod,
+                        geotrans=(float(tropo_rsc_dict['X_FIRST']),
+                        float(tropo_rsc_dict['X_STEP']),
+                        0.0,
+                        float(tropo_rsc_dict['Y_FIRST']),
+                        0.0,
+                        float(tropo_rsc_dict['Y_STEP'])),
+                        drivername=outputFormat,
+                        gdal_fmt='float32',
+                        proj=gdal.Open(os.path.join(outDir,'unwrappedPhase', \
+                         product_dict[2][0][0])).GetProjection(),
+                        nodata=0.)
                     gacos_prod = None
-                    log.debug("GACOS product %s successfully converted to GDAL-readable raster", k)
+                    log.debug('GACOS product %s successfully converted to ' \
+                              'GDAL-readable raster', k)
+                # make corresponding RSC file, if it doesn't exist
+                if not os.path.exists(k+'.rsc'):
+                    rscGacos(os.path.join(k+'.vrt'), os.path.join(k+'.rsc'),
+                             tropo_date_dict)
 
     # If multiple GACOS directories, merge products.
-    tropo_products = list(set([os.path.dirname(i) if (i.endswith('.ztd') or i.endswith('.tif')) else i for i in tropo_products]))
+    tropo_products = list(set([os.path.dirname(i) \
+                          if (i.endswith('.ztd') or i.endswith('.tif')) \
+                          else i for i in tropo_products]))
     if len(tropo_products)>1:
         tropo_products=os.path.join(outDir,'merged_GACOS')
         log.info('Stitching/storing GACOS products in %s.', tropo_products)
@@ -859,46 +931,53 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
                 # building the VRT
                 gdal.BuildVRT(outname, tropo_date_dict[i])
                 geotrans=gdal.Open(outname).GetGeoTransform()
-                # Create merge rsc file
-                with open(outname[:-4]+'.rsc','w') as merged_rsc:
-                    merged_rsc.write('WIDTH %s\n'%(gdal.Open(outname).ReadAsArray().shape[1])) ; merged_rsc.write('FILE_LENGTH %s\n'%(gdal.Open(outname).ReadAsArray().shape[0]))
-                    merged_rsc.write('XMIN %s\n'%(0)) ; merged_rsc.write('XMAX %s\n'%(gdal.Open(outname).ReadAsArray().shape[1]))
-                    merged_rsc.write('YMIN %s\n'%(0)) ; merged_rsc.write('YMAX %s\n'%(gdal.Open(outname).ReadAsArray().shape[0]))
-                    merged_rsc.write('X_FIRST %f\n'%(geotrans[0])) ; merged_rsc.write('Y_FIRST %f\n'%(geotrans[3]))
-                    merged_rsc.write('X_STEP %f\n'%(geotrans[1])) ; merged_rsc.write('Y_STEP %f\n'%(geotrans[-1]))
-                    merged_rsc.write('X_UNIT %s\n'%('degres')) ; merged_rsc.write('Y_UNIT %s\n'%('degres'))
-                    merged_rsc.write('Z_OFFSET %s\n'%(0)) ; merged_rsc.write('Z_SCALE %s\n'%(1))
-                    merged_rsc.write('PROJECTION %s\n'%('LATLON')) ; merged_rsc.write('DATUM %s\n'%('WGS84'))
-                    merged_rsc.write('TIME_OF_DAY %s\n'%(''.join(tropo_date_dict[i+"_UTC"])))
+                # Create merged rsc file
+                rscGacos(outname, merged_rsc, tropo_date_dict)
     else:
-        tropo_products=tropo_products[0]
+        tropo_products = tropo_products[0]
 
     # Estimate percentage of overlap with tropospheric product
     for i in glob.glob(os.path.join(tropo_products,'*.vrt')):
         # create shapefile
-        geotrans=gdal.Open(i).GetGeoTransform()
-        bbox=[geotrans[3]+(gdal.Open(i).ReadAsArray().shape[0]*geotrans[-1]),geotrans[3],geotrans[0],geotrans[0]+(gdal.Open(i).ReadAsArray().shape[1]*geotrans[1])]
-        bbox=Polygon(np.column_stack((np.array([bbox[2],bbox[3],bbox[3],bbox[2],bbox[2]]),
-                            np.array([bbox[0],bbox[0],bbox[1],bbox[1],bbox[0]]))))
+        geotrans = gdal.Open(i).GetGeoTransform()
+        bbox = [geotrans[3] \
+                 + (gdal.Open(i).ReadAsArray().shape[0]*geotrans[-1]),
+                 geotrans[3],
+                 geotrans[0],
+                 geotrans[0] \
+                 + (gdal.Open(i).ReadAsArray().shape[1]*geotrans[1])
+        ]
+        bbox = Polygon(np.column_stack( \
+                       (np.array([bbox[2], bbox[3], bbox[3],bbox[2],bbox[2]]),
+                        np.array([bbox[0],bbox[0],bbox[1],bbox[1],bbox[0]]))))
         save_shapefile(i+'.json', bbox, 'GeoJSON')
-        per_overlap=((user_bbox.intersection(open_shapefile(i+'.json', 0, 0)).area)/(user_bbox.area))*100
-        if per_overlap!=100. and per_overlap!=0.:
-            log.warning("Common track extent only has %d overlap with tropospheric product %d\n", per_overlap, i)
-        if per_overlap==0.:
-            raise Exception('No spatial overlap between tropospheric product %s and defined bounding box. Resolve conflict and relaunch', i)
+        per_overlap = ((user_bbox.intersection( \
+                      open_shapefile(i+'.json', 0, 0)).area) \
+                      / (user_bbox.area))*100
+        if per_overlap != 100. and per_overlap != 0.:
+            log.warning('Common track extent only has %d overlap with' \
+                        'tropospheric product %d\n', per_overlap, i)
+        if per_overlap == 0.:
+            raise Exception('No spatial overlap between tropospheric ' \
+                            'product %s and defined bounding box. ' \
+                            'Resolve conflict and relaunch', i)
 
     # Iterate through all IFGs and apply corrections
     missing_products = []
     for i in range(len(product_dict[0])):
-        outname=os.path.join(workdir,product_dict[2][i][0])
-        unwname=os.path.join(outDir,'unwrappedPhase',product_dict[2][i][0])
-        tropo_reference=os.path.join(tropo_products,product_dict[2][i][0][:8]+'.ztd.vrt')
-        tropo_secondary=os.path.join(tropo_products,product_dict[2][i][0][9:]+'.ztd.vrt')
+        outname = os.path.join(workdir,product_dict[2][i][0])
+        unwname = os.path.join(outDir,'unwrappedPhase', product_dict[2][i][0])
+        tropo_reference = os.path.join(tropo_products,
+                          product_dict[2][i][0][:8] + '.ztd.vrt')
+        tropo_secondary = os.path.join(tropo_products,
+                          product_dict[2][i][0][9:] + '.ztd.vrt')
         # if .ztd products don't exist, check if .tif exists
         if not os.path.exists(tropo_reference):
-            tropo_reference=os.path.join(tropo_products,product_dict[2][i][0][:8]+'.ztd.tif.vrt')
+            tropo_reference = os.path.join(tropo_products,
+                              product_dict[2][i][0][:8] + '.ztd.tif.vrt')
         if not os.path.exists(tropo_secondary):
-            tropo_secondary=os.path.join(tropo_products,product_dict[2][i][0][9:]+'.ztd.tif.vrt')
+            tropo_secondary = os.path.join(tropo_products,
+                              product_dict[2][i][0][9:] + '.ztd.tif.vrt')
         # skip if corrected already generated and does not need to be updated
         if os.path.exists(outname):
             # get unwrappedPhase geotrans and productbounding box
@@ -908,74 +987,131 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
             tropo_prodcheck = gdal.Open(outname)
             output_geotrans = tropo_prodcheck.GetGeoTransform()
             tropo_prodcheck = np.isfinite(tropo_prodcheck.ReadAsArray())
-            if unw_geotrans == output_geotrans and np.array_equal(unw_prodcheck, tropo_prodcheck):
+            if unw_geotrans == output_geotrans and np.array_equal( \
+                               unw_prodcheck, tropo_prodcheck):
                 continue
             del unw_prodcheck, tropo_prodcheck
         if os.path.exists(tropo_reference) and os.path.exists(tropo_secondary):
             # Check if tropo products are temporally consistent with IFG
             for j in [tropo_reference, tropo_secondary]:
                 # Get ARIA product times
-                aria_rsc_dict={}
-                aria_rsc_dict['azimuthZeroDopplerMidTime']=[datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+m[11:], "%Y-%m-%d-%H:%M:%S.%f") for m in metadata_dict[0][0]]
+                aria_rsc_dict = {}
+                aria_rsc_dict['azimuthZeroDopplerMidTime'] = \
+                    [datetime.strptime(os.path.basename(j)[:4]
+                    + '-' + os.path.basename(j)[4:6]
+                    + '-' + os.path.basename(j)[6:8]
+                    + '-' + m[11:], "%Y-%m-%d-%H:%M:%S.%f") \
+                     for m in metadata_dict[0][0]]
                 # Get tropo product UTC times
-                tropo_rsc_dict={}
-                tropo_rsc_dict['TIME_OF_DAY']=open(j[:-4]+'.rsc', 'r').readlines()[-1].split()[1].split('UTC')[:-1]
+                tropo_rsc_dict = {}
+                tropo_rsc_dict['TIME_OF_DAY'] = open(j[:-4]+'.rsc', \
+                     'r').readlines()[-1].split()[1].split('UTC')[:-1]
+                # If new TIF product, UTC times not available
+                if 'None' in tropo_rsc_dict['TIME_OF_DAY'][0]:
+                    tropo_rsc_dict['TIME_OF_DAY'] = [ \
+                         max(aria_rsc_dict['azimuthZeroDopplerMidTime'])]
                 # If stitched tropo product, must account for date change (if applicable)
-                if '-' in tropo_rsc_dict['TIME_OF_DAY'][0]:
-                    tropo_rsc_dict['TIME_OF_DAY'] = [datetime.strptime(m[:10]+'-'+m[11:].split('.')[0]+'-'+str(round(float('0.'+m[11:].split('.')[1])*60)), "%Y-%m-%d-%H-%M") for m in tropo_rsc_dict['TIME_OF_DAY']]
+                elif '-' in tropo_rsc_dict['TIME_OF_DAY'][0]:
+                    tropo_rsc_dict['TIME_OF_DAY'] = [datetime.strptime(m[:10]
+                        + '-' + m[11:].split('.')[0] + '-'
+                        + str(round(float('0.' + m[11:].split('.')[1])*60)),
+                        "%Y-%m-%d-%H-%M") \
+                         for m in tropo_rsc_dict['TIME_OF_DAY']
+                    ]
                 else:
-                    tropo_rsc_dict['TIME_OF_DAY'] = [datetime.strptime(os.path.basename(j)[:4]+'-'+os.path.basename(j)[4:6]+'-'+os.path.basename(j)[6:8]+'-'+tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[0]+'-'+str(round(float('0.'+tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[-1])*60)), "%Y-%m-%d-%H-%M")]
+                    tropo_rsc_dict['TIME_OF_DAY'] = [datetime.strptime( \
+                         os.path.basename(j)[:4] + '-'
+                        + os.path.basename(j)[4:6] + '-'
+                        + os.path.basename(j)[6:8] + '-'
+                        + tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[0]
+                        + '-' + str(round(float('0.'
+                        + tropo_rsc_dict['TIME_OF_DAY'][0].split('.')[-1]) \
+                         *60)), "%Y-%m-%d-%H-%M")
+                    ]
 
                 # Check and report if tropospheric product falls outside of standard product range
-                latest_start = max(aria_rsc_dict['azimuthZeroDopplerMidTime']+[min(tropo_rsc_dict['TIME_OF_DAY'])])
-                earliest_end = min(aria_rsc_dict['azimuthZeroDopplerMidTime']+[max(tropo_rsc_dict['TIME_OF_DAY'])])
+                latest_start = max(aria_rsc_dict['azimuthZeroDopplerMidTime'] 
+                                   + [min(tropo_rsc_dict['TIME_OF_DAY'])])
+                earliest_end = min(aria_rsc_dict['azimuthZeroDopplerMidTime'] 
+                                   + [max(tropo_rsc_dict['TIME_OF_DAY'])])
                 delta = (earliest_end - latest_start).total_seconds() + 1
                 if delta<0:
-                    log.warning("tropospheric product was generated %f secs outside of acquisition interval for scene %s in IFG %s",
-                                        abs(delta), os.path.basename(j)[:8], product_dict[2][i][0])
+                    log.warning('tropospheric product was generated %f ' \
+                                'secs outside of acquisition interval for ' \
+                                'scene %s in IFG %s',
+                                abs(delta), os.path.basename(j)[:8],
+                                product_dict[2][i][0])
 
             # Open unwrappedPhase and mask nodata
-            unwphase=gdal.Open(unwname)
-            geotrans=unwphase.GetGeoTransform() ; proj=unwphase.GetProjection() ; unwnodata=unwphase.GetRasterBand(1).GetNoDataValue()
-            unwphase=unwphase.ReadAsArray()
-            arrshape=unwphase.shape # shape of output array to match ifgs
-            unwphase=np.ma.masked_where(unwphase == unwnodata, unwphase)
+            unwphase = gdal.Open(unwname)
+            geotrans = unwphase.GetGeoTransform()
+            proj = unwphase.GetProjection()
+            unwnodata = unwphase.GetRasterBand(1).GetNoDataValue()
+            unwphase = unwphase.ReadAsArray()
+            arrshape = unwphase.shape # shape of output array to match ifgs
+            unwphase = np.ma.masked_where(unwphase == unwnodata, unwphase)
 
             # Open corresponding tropo products and pass the difference
-            tropo_product = gdal.Warp('', tropo_reference, format="MEM", cutlineDSName=prods_TOTbbox,
-                          outputBounds=bounds, width=arrshape[1], height=arrshape[0], resampleAlg='lanczos',
-                          dstNodata=0., multithread=True, options=['NUM_THREADS=%s'%(num_threads)]).ReadAsArray()
+            tropo_product = gdal.Warp('', tropo_reference, format="MEM",
+                                      cutlineDSName=prods_TOTbbox,
+                                      outputBounds=bounds, width=arrshape[1],
+                                      height=arrshape[0], resampleAlg='lanczos',
+                                      dstNodata=0., multithread=True,
+                                      options=['NUM_THREADS=%s' \
+                                       %(num_threads)]).ReadAsArray()
 
-            tropo_product = np.ma.masked_where(tropo_product == 0., tropo_product)
-            tropo_secondary = gdal.Warp('', tropo_secondary, format="MEM", cutlineDSName=prods_TOTbbox,
-                                            outputBounds=bounds, width=arrshape[1], height=arrshape[0],
-                                            resampleAlg='lanczos', dstNodata=0., multithread=True,
-                                            options=['NUM_THREADS=%s'%(num_threads)]).ReadAsArray()
+            tropo_product = np.ma.masked_where(tropo_product == 0.,
+                                               tropo_product)
+            tropo_secondary = gdal.Warp('', tropo_secondary, format="MEM",
+                                        cutlineDSName=prods_TOTbbox,
+                                        outputBounds=bounds, width=arrshape[1],
+                                        height=arrshape[0],
+                                        resampleAlg='lanczos', dstNodata=0.,
+                                        multithread=True,
+                                        options=['NUM_THREADS=%s' \
+                                         %(num_threads)]).ReadAsArray()
 
-            tropo_secondary = np.ma.masked_where(tropo_secondary == 0., tropo_secondary)
-            tropo_product   = np.subtract(tropo_secondary,tropo_product)
+            tropo_secondary = np.ma.masked_where(tropo_secondary == 0.,
+                                                 tropo_secondary)
+            tropo_product   = np.subtract(tropo_secondary, tropo_product)
 
             # Convert troposphere to rad
-            tropo_product=np.divide(tropo_product,float(metadata_dict[1][i][0])/(4*np.pi))
+            tropo_product = np.divide(tropo_product, 
+                                      float(metadata_dict[1][i][0]) \
+                                      / (4*np.pi))
             # Account for lookAngle
             # if in TS mode, only 1 lookfile would be generated, so check for this
-            if os.path.exists(os.path.join(outDir,'lookAngle',product_dict[2][i][0])):
-                lookfile=gdal.Open(os.path.join(outDir,'lookAngle',product_dict[2][i][0])).ReadAsArray()
+            if os.path.exists(os.path.join(outDir, 'lookAngle',
+                              product_dict[2][i][0])):
+                lookfile = gdal.Open(os.path.join(outDir, 'lookAngle',
+                                   product_dict[2][i][0])).ReadAsArray()
             else:
-                lookfile=gdal.Open(os.path.join(outDir,'lookAngle',product_dict[2][0][0])).ReadAsArray()
-            lookfile=np.sin(np.deg2rad(np.ma.masked_where(lookfile == 0., lookfile)))
-            tropo_product=np.divide(tropo_product,lookfile)
+                lookfile = gdal.Open(os.path.join(outDir, 'lookAngle',
+                                     product_dict[2][0][0])).ReadAsArray()
+            lookfile = np.sin(np.deg2rad(np.ma.masked_where(lookfile == 0.,
+                              lookfile)))
+            tropo_product = np.divide(tropo_product, lookfile)
 
             #Correct phase and save to file
-            unwphase=np.subtract(unwphase,tropo_product)
-            np.ma.set_fill_value(unwphase, unwnodata); np.ma.set_fill_value(tropo_product, 0.)
-            renderVRT(outname+'_tropodiff', tropo_product.filled(), geotrans=geotrans, drivername=outputFormat, gdal_fmt='float32', proj=proj, nodata=0.)
-            renderVRT(outname, unwphase.filled(), geotrans=geotrans, drivername=outputFormat, gdal_fmt='float32', proj=proj, nodata=unwnodata)
+            unwphase = np.subtract(unwphase, tropo_product)
+            np.ma.set_fill_value(unwphase, unwnodata)
+            np.ma.set_fill_value(tropo_product, 0.)
+            renderVRT(outname+'_tropodiff', tropo_product.filled(),
+                      geotrans=geotrans, drivername=outputFormat,
+                      gdal_fmt='float32', proj=proj, nodata=0.)
+            renderVRT(outname, unwphase.filled(),
+                      geotrans=geotrans, drivername=outputFormat,
+                      gdal_fmt='float32', proj=proj, nodata=unwnodata)
 
-            del unwphase, tropo_product, tropo_reference, tropo_secondary, lookfile
+            del unwphase, tropo_product, tropo_reference, \
+                tropo_secondary, lookfile
 
         else:
-            log.warning("Must skip IFG %s, because the tropospheric products corresponding to the reference and/or secondary products are not found in the specified folder %s", product_dict[2][i][0], tropo_products)
+            log.warning('Must skip IFG %s, because the tropospheric ' \
+                        'products corresponding to the reference and/or ' \
+                        'secondary products are not found in the ' \
+                        'specified folder %s',
+                        product_dict[2][i][0], tropo_products)
             for j in [tropo_reference, tropo_secondary]:
                 if not os.path.exists(j) and j not in missing_products:
                     missing_products.append(j)
@@ -986,9 +1122,7 @@ def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox
         log.debug(missing_products)
 
 def main(inps=None):
-    """
-       Main workflow for extracting layers from ARIA products.
-    """
+    """Main workflow for extracting layers from ARIA products."""
     from ARIAtools.ARIAProduct import ARIA_standardproduct
     print ('*****************************************************************')
     print ('*** Extract Product Function ***')

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -64,6 +64,9 @@ def createParser():
         help="If turned on, IFGs resampled based off of the average of pixels in a given resampling window corresponding to the connected component mode (if multilooking specified). Program defaults to lanczos resampling algorithm through gdal (if multilooking specified).")
     parser.add_argument('-mo', '--minimumOverlap', dest='minimumOverlap', type=float, default=0.0081,
         help='Minimum km\u00b2 area of overlap of scenes wrt specified bounding box. Default 0.0081 = 0.0081km\u00b2 = area of single pixel at standard 90m resolution"')
+    parser.add_argument('--version', dest='version',  default=None,
+        help='Specify version as str, e.g. 2_0_4 or all prods; default: '
+             'newest')
     parser.add_argument('-verbose', '--verbose', action='store_true', dest='verbose',
         help="Toggle verbose mode on.")
 
@@ -393,7 +396,7 @@ def dl_dem(path_dem, path_prod_union, num_threads):
         chunk = True
         # Increase chunking size to discretize box into smaller grids
         log.warning('User-defined bounds results in an area of %d km which ' \
-                    'exceeds the maximum download area of 450000; ' \
+                    'exceeds the maximum download area of 400000; ' \
                     'downloading in chunks', \
                     shapefile_area(prod_shapefile, bounds = True))
         rows, cols = chunk_area(WSEN)
@@ -994,8 +997,12 @@ def main(inps=None):
     # if user bbox was specified, file(s) not meeting imposed spatial criteria are rejected.
     # Outputs = arrays ['standardproduct_info.products'] containing grouped “radarmetadata info” and “data layer keys+paths” dictionaries for each standard product
     # In addition, path to bbox file ['standardproduct_info.bbox_file'] (if bbox specified)
-    standardproduct_info = ARIA_standardproduct(inps.imgfile, bbox=inps.bbox,
-      workdir=inps.workdir, num_threads=inps.num_threads, verbose=inps.verbose)
+    standardproduct_info = ARIA_standardproduct(inps.imgfile,
+                                                bbox=inps.bbox,
+                                                workdir=inps.workdir,
+                                                num_threads=inps.num_threads,
+                                                url_version=inps.version,
+                                                verbose=inps.verbose)
 
     if not inps.layers and not inps.tropo_products:
         log.info('No layers specified; only creating bounding box shapes')

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -389,7 +389,7 @@ def dl_dem(path_dem, path_prod_union, num_threads):
     WSEN      = prod_shapefile.bounds
     # If area > 450000 km2, must split requests into chunks to successfully access data
     chunk = False
-    if shapefile_area(prod_shapefile, bounds = True) > 450000:
+    if shapefile_area(prod_shapefile, bounds = True) > 400000:
         chunk = True
         # Increase chunking size to discretize box into smaller grids
         log.warning('User-defined bounds results in an area of %d km which ' \
@@ -756,7 +756,7 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, lat,
 
 def tropo_correction(full_product_dict, tropo_products, bbox_file, prods_TOTbbox, outDir='./',outputFormat='VRT', verbose=None, num_threads='2'):
     """
-        Perform tropospheric corrections. Must provide valid path to 
+        Perform tropospheric corrections. Must provide valid path to
         GACOS products.
         All products are cropped by the bounds from the input bbox_file,
         and clipped to the track extent denoted by the input prods_TOTbbox.

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: Simran Sangha & David Bekaert
 # Copyright 2019, by the California Institute of Technology. ALL RIGHTS
@@ -395,12 +395,15 @@ def dl_dem(path_dem, path_prod_union, num_threads):
     root      = os.path.splitext(path_dem)[0]
     prod_shapefile = open_shapefile(path_prod_union, 0, 0)
     WSEN      = prod_shapefile.bounds
-    # If area > 225000 km2, must split requests into chunks to successfully access data
+    # If area > 450000 km2, must split requests into chunks to successfully access data
     chunk = False
-    if shapefile_area(prod_shapefile) > 300000:
+    if shapefile_area(prod_shapefile, bounds = True) > 450000:
         chunk = True
         # Increase chunking size to discretize box into smaller grids
-        log.warning('User-defined bounds results in an area of %d km which exceeds the maximum download area of 450000; downloading in chunks', shapefile_area(prod_shapefile))
+        log.warning('User-defined bounds results in an area of %d km which ' \
+                    'exceeds the maximum download area of 450000; ' \
+                    'downloading in chunks', \
+                    shapefile_area(prod_shapefile, bounds = True))
         rows, cols = chunk_area(WSEN)
 
     if chunk: # Download in chunks (if necessary)

--- a/tools/ARIAtools/mask_util.py
+++ b/tools/ARIAtools/mask_util.py
@@ -261,8 +261,8 @@ class NLCDMasker(object):
             outputFormat='ENVI'
 
         ## crop the raw nlcd in memory
-        path_nlcd = '/vsizip/vsicurl/https://s3-us-west-2.amazonaws.com/mrlc/NLCD_2016'\
-                    '_Land_Cover_L48_20190424.zip/NLCD_2016_Land_Cover_L48_20190424.img'
+        path_nlcd = '/vsizip/vsicurl/https://s3-us-west-2.amazonaws.com/mrlc/nlcd_2019'\
+                    '_land_cover_l48_20210604.zip/nlcd_2019_land_cover_l48_20210604.img'
 
         log.info('Cropping raw NLCD...')
         ds_crop   = crop_ds(path_nlcd, self.path_bbox)

--- a/tools/ARIAtools/productPlot.py
+++ b/tools/ARIAtools/productPlot.py
@@ -73,6 +73,9 @@ def createParser():
         "Default 0.0081 = 0.0081km\u00b2=area of single pixel at standard 90m resolution")
     parser.add_argument('--figwidth', dest='figwidth', type=str, default='standard',
         help='Width of lat extents figure in inches. Default is \"standard\", i.e., the 6.4-inch-wide standard figure size. Optionally, theuser may define the width manually, e.g,. 8 [inches] or set the parameter to \"wide\" format, i.e., the width of the figure automatically scales with the number of interferograms. Other options include')
+    parser.add_argument('--version', dest='version',  default=None,
+        help='Specify version as str, e.g. 2_0_4 or all prods; default: '
+             'newest')
     parser.add_argument('-verbose', '--verbose', action='store_true', dest='verbose',
         help="Toggle verbose mode on.")
     return parser
@@ -580,8 +583,11 @@ def main(inps=None):
     # Outputs = arrays ['standardproduct_info.products'] containing grouped “radarmetadata info” and “data layer keys+paths” dictionaries for each standard product
     # In addition, path to bbox file ['standardproduct_info.bbox_file'] (if bbox specified)
     standardproduct_info = ARIA_standardproduct(inps.imgfile,
-                    bbox=inps.bbox, workdir=inps.workdir,
-                    num_threads=inps.num_threads, verbose=inps.verbose)
+                                                bbox=inps.bbox,
+                                                workdir=inps.workdir,
+                                                num_threads=inps.num_threads,
+                                                url_version=inps.version,
+                                                verbose=inps.verbose)
 
     # If user requests to generate all plots.
     if inps.plotall:

--- a/tools/ARIAtools/shapefile_util.py
+++ b/tools/ARIAtools/shapefile_util.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: Simran Sangha & David Bekaert
 # Copyright 2019, by the California Institute of Technology. ALL RIGHTS
@@ -18,11 +18,7 @@ gdal.UseExceptions()
 gdal.PushErrorHandler('CPLQuietErrorHandler')
 
 def open_shapefile(fname, lyrind, ftind):
-    '''
-        Open a existing shapefile and pass the coordinates back.
-        ##SS => see commend on projection of the shapefile, expand the desciption of what the function would do based on this.
-    '''
-
+    """Open a existing shapefile and pass the coordinates back"""
     # import dependencies
     from shapely.wkt import loads
 
@@ -37,15 +33,12 @@ def open_shapefile(fname, lyrind, ftind):
     else:
         file_bbox = file_bbox.GetLayerByIndex(lyrind).GetFeature(ftind)
     geom = file_bbox.GetGeometryRef()
-    file_bbox = loads(geom.ExportToWkt())                       ##SS => We should track the projection of the shapefile adn pass it up? e.g. what it the data has different projection than that of the shapefile?
+    file_bbox = loads(geom.ExportToWkt())
 
     return file_bbox
 
 def save_shapefile(fname, polygon, drivername):
-    '''
-        ##SS => add descritpion and limitations. Is there not a way to add the projection pf the shape file as well?
-    '''
-
+    """Save a polygon shapefile"""
     # open file
     ds = ogr.GetDriverByName(drivername).CreateDataSource(fname)
     # create layer
@@ -65,11 +58,8 @@ def save_shapefile(fname, polygon, drivername):
 
     return
 
-def shapefile_area(file_bbox):
-    '''
-        Compute km\u00b2 area of shapefile.
-    '''
-
+def shapefile_area(file_bbox, bounds = False):
+    """Compute km\u00b2 area of shapefile"""
     # import dependencies
     from pyproj import Proj
     from shapely.geometry import shape
@@ -80,32 +70,42 @@ def shapefile_area(file_bbox):
     if file_bbox.type == 'Polygon': file_bbox = [file_bbox]
     for polyobj in file_bbox:
         # get coords
-        lon, lat=polyobj.exterior.coords.xy
+        if bounds:
+            # Pass coordinates of bounds as opposed to cutline
+            # Necessary for estimating DEM/mask footprints
+            WSEN = polyobj.bounds
+            lon = np.array([WSEN[0],WSEN[0],WSEN[2],WSEN[2],WSEN[0]])
+            lat = np.array([WSEN[1],WSEN[3],WSEN[3],WSEN[1],WSEN[1]])
+        else:
+            lon, lat = polyobj.exterior.coords.xy
 
         # use equal area projection centered on/bracketing AOI
-        pa = Proj("+proj=aea +lat_1={} +lat_2={} +lat_0={} +lon_0={}".format(min(lat), max(lat), (max(lat)+min(lat))/2, (max(lon)+min(lon))/2))
+        pa = Proj("+proj=aea +lat_1={} +lat_2={} +lat_0={} +lon_0={}". \
+             format(min(lat), max(lat), (max(lat)+min(lat))/2, \
+             (max(lon)+min(lon))/2))
         x, y = pa(lon, lat)
         cop = {"type": "Polygon", "coordinates": [zip(x, y)]}
-        shape_area+=shape(cop).area/1e6  # area in km^2
+        shape_area += shape(cop).area/1e6  # area in km^2
 
     return shape_area
 
 def chunk_area(WSEN):
-    """ Chunk an area ~evenly pieces < 450000 km required by the SRTM server """
+    """Chunk an area ~evenly pieces < 450000 km required by the SRTM server"""
     from shapely.geometry import Polygon
     max_area   = 400000 # need buffer for projections inconsistencies
     W, S, E, N = WSEN
-    n    = 2 # start with a 2 x 2 chunk
-    area = max_area+1
+    n = 2 # start with a 2 x 2 chunk
+    area = max_area + 1
     while area > max_area:
-        cols = np.linspace(W, E, n+1)
-        rows = np.linspace(S, N, n+1)
+        cols = np.linspace(W, E, n + 1)
+        rows = np.linspace(S, N, n + 1)
         Wi, Si, Ei, Ni = [cols[0], rows[0], cols[1], rows[1]]
         poly = Polygon([(Wi,Ni), (Wi,Si), (Ei,Si), (Ei,Ni)])
         area = shapefile_area(poly)
         n+=1
         if n>100:
-            log.error('There was a problem chunking the DEM; check input bounds')
+            log.error('There was a problem chunking the DEM; check input '
+                      'bounds')
             os.sys.exit()
     return rows, cols
 
@@ -159,13 +159,15 @@ def plot_shapefile(fname):
 
         # Add paths as patches to axes
         for path in paths:
-            patch = mpatches.PathPatch(path, fill=False, facecolor='blue', edgecolor='black', linewidth=1)
+            patch = mpatches.PathPatch(path, fill=False, facecolor='blue', \
+                 edgecolor='black', linewidth=1)
 
             ax.add_patch(patch)
 
         ax.set_xlabel('longitude', labelpad=15, fontsize=15)
         ax.set_ylabel('latitude', labelpad=15, fontsize=15)
-        ax.set_title(os.path.basename(os.path.splitext(fname)[0]), fontsize=15)
+        ax.set_title(os.path.basename(os.path.splitext(fname)[0]), \
+             fontsize=15)
         ax.set_aspect(1.0)
         ax.grid(False)
     plt.show()

--- a/tools/ARIAtools/shapefile_util.py
+++ b/tools/ARIAtools/shapefile_util.py
@@ -18,7 +18,7 @@ gdal.UseExceptions()
 gdal.PushErrorHandler('CPLQuietErrorHandler')
 
 def open_shapefile(fname, lyrind, ftind):
-    """Open a existing shapefile and pass the coordinates back"""
+    """Open a existing shapefile and pass the coordinates back."""
     # import dependencies
     from shapely.wkt import loads
 
@@ -38,7 +38,7 @@ def open_shapefile(fname, lyrind, ftind):
     return file_bbox
 
 def save_shapefile(fname, polygon, drivername):
-    """Save a polygon shapefile"""
+    """Save a polygon shapefile."""
     # open file
     ds = ogr.GetDriverByName(drivername).CreateDataSource(fname)
     # create layer
@@ -59,7 +59,7 @@ def save_shapefile(fname, polygon, drivername):
     return
 
 def shapefile_area(file_bbox, bounds = False):
-    """Compute km\u00b2 area of shapefile"""
+    """Compute km\u00b2 area of shapefile."""
     # import dependencies
     from pyproj import Proj
     from shapely.geometry import shape
@@ -90,7 +90,8 @@ def shapefile_area(file_bbox, bounds = False):
     return shape_area
 
 def chunk_area(WSEN):
-    """Chunk an area ~evenly pieces < 450000 km required by the SRTM server"""
+    """Chunk an area ~evenly pieces < 450000 km required by the
+       SRTM server."""
     from shapely.geometry import Polygon
     max_area   = 400000 # need buffer for projections inconsistencies
     W, S, E, N = WSEN
@@ -139,7 +140,7 @@ def plot_shapefile(fname):
             if geom_name == 'MULTIPOLYGON':
                 r = geom.GetGeometryRef(i)
                 for j in range(r.GetGeometryCount()):
-                    p = r.GetGeometryRef(0)
+                    p = r.GetGeometryRef(j)
                     r = p
             x = [r.GetX(j) for j in range(r.GetPointCount())]
             y = [r.GetY(j) for j in range(r.GetPointCount())]
@@ -153,7 +154,8 @@ def plot_shapefile(fname):
         paths.append(path)
 
     with plt.style.context(('seaborn')):
-        fig, ax = plt.subplots(figsize=(12, 9))
+        fig = plt.figure(figsize=(12, 9))
+        ax = fig.add_subplot(111)
         ax.set_xlim(ext[0]-xoff,ext[1]+xoff)
         ax.set_ylim(ext[2]-yoff,ext[3]+yoff)
 

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -123,6 +123,9 @@ def create_parser():
                         'area of overlap of scenes wrt specified bounding box.'
                         ' Default 0.0081 = 0.0081km\u00b2 = area of single'
                         ' pixel at standard 90m resolution')
+    parser.add_argument('--version', dest='version',  default=None,
+                        help='Specify version as str, e.g. 2_0_4 or all prods;'
+                        'default: newest')
     parser.add_argument('-verbose', '--verbose', action='store_true',
                         dest='verbose', help="Toggle verbose mode on.")
 
@@ -390,9 +393,12 @@ def main(inps=None):
     # standard product
     # In addition, path to bbox file ['standardproduct_info.bbox_file']
     # (if bbox specified)
-    standardproduct_info = ARIA_standardproduct(
-        inps.imgfile, bbox=inps.bbox,
-        workdir=inps.workdir, num_threads=inps.num_threads, verbose=inps.verbose)
+    standardproduct_info = ARIA_standardproduct(inps.imgfile,
+                                                bbox=inps.bbox,
+                                                workdir=inps.workdir,
+                                                num_threads=inps.num_threads,
+                                                url_version=inps.version,
+                                                verbose=inps.verbose)
 
     # pass number of threads for gdal multiprocessing computation
     if inps.num_threads.lower() == 'all':

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -313,7 +313,13 @@ def generate_stack(aria_prod, input_files, output_file_name,
             data_set = None
 
             metadata['wavelength'] = wavelength
-            metadata['utcTime'] = utc_time[dates]
+            try:
+                metadata['utcTime'] = utc_time[dates]
+            except:
+                log.debug('Skipping %s; it likely exists in the %s, '\
+                          'but was not specified in the product list',
+                          dates, os.path.dirname(data[1]))
+                continue
             metadata['bPerp'] = b_perp[dates]
             metadata['incAng'] = inc_angle[dates]
             metadata['lookAng'] = look_ang[dates]

--- a/tools/ARIAtools/url_manager.py
+++ b/tools/ARIAtools/url_manager.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Author: Simran Sangha
+# Copyright 2019, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged.
+#
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+import os, os.path as op
+
+###Capture and segregate duplicate products (if applicable)
+def url_versions(urls, user_version, wd):
+    """For duplicate products (other than version number)
+    Uses the the latest if user_version is None else use specified ver."""
+    if isinstance(user_version, str) and user_version.lower() == 'all':
+        return urls
+
+    url_bases = []
+    for url in urls:
+        url_base = '-'.join(url.split('-')[:-1])
+        if not url_base in url_bases:
+            url_bases.append(url_base)
+
+    urls_final = []
+    for url_base in url_bases:
+        # get the possible matches
+        duplicates = [url for url in urls if url_base in url]
+        if len(duplicates) == 1:
+            urls_final.append(duplicates[0])
+        else:
+            versions = []
+            for dupe in duplicates:
+                ver_str = dupe.split('-')[-1]
+                versions.append(float(ver_str.lstrip('v').rstrip('.nc')))
+
+            ## default, use latest version
+            if user_version is None:
+                version = str(max(versions))
+                version = f'v{version[0]}_{version[1]}_{version[2]}.nc'
+            else:
+                version=f'v{user_version}.nc'
+
+            urls_final.append(f'{url_base}-{version}')
+
+            ## move duplicates to a different folder
+            dupe_folder = op.join(wd, 'duplicated_products')
+            os.makedirs(dupe_folder, exist_ok=True)
+            for dupe in duplicates:
+                dupe_path = os.path.join(dupe_folder, os.path.basename(dupe))
+                wd_path = os.path.join(wd, os.path.basename(dupe))
+                if os.path.basename(dupe) != \
+                     os.path.basename(urls_final[-1]) and \
+                     os.path.exists(wd_path):
+                    os.rename(wd_path, dupe_path)
+    return urls_final

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -1,5 +1,4 @@
-#! /usr/bin/env python3
-
+#!/usr/bin/env python3
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: Brett A. Buzzanga
@@ -16,6 +15,7 @@ import numpy as np
 from datetime import datetime
 import logging
 from ARIAtools.logger import logger
+from ARIAtools.url_manager import url_versions
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import multiprocessing
@@ -271,53 +271,6 @@ def status_plot(inps, rates=None, elaps=None, use_all=False):
     kws = dict(dpi=150, bbox_inches='tight', pad_inches=0.025, transparent=False)
     fig.savefig(op.join(inps['wd'], 'AvgDlSpeed'), **kws)
     return
-
-
-def url_versions(urls, user_version, wd):
-    """ For duplicate products (other than version number)
-    Uses the the latest if user_version is None else use specified ver.
-    """
-    if isinstance(user_version, str) and user_version.lower() == 'all':
-        return urls
-
-    url_bases = []
-    for url in urls:
-        url_base = '-'.join(url.split('-')[:-1])
-        if not url_base in url_bases:
-            url_bases.append(url_base)
-
-    urls_final = []
-    for url_base in url_bases:
-        # get the possible matches
-        duplicates = [url for url in urls if url_base in url]
-        if len(duplicates) == 1:
-            urls_final.append(duplicates[0])
-        else:
-            versions = []
-            for dupe in duplicates:
-                ver_str = dupe.split('-')[-1]
-                versions.append(float(ver_str.lstrip('v').rstrip('.nc')))
-
-            ## default, use latest version
-            if user_version is None:
-                version = str(max(versions))
-                version = f'v{version[0]}_{version[1]}_{version[2]}.nc'
-            else:
-                version=f'v{user_version}.nc'
-
-            urls_final.append(f'{url_base}-{version}')
-
-            ## move duplicates to a different folder
-            dupe_folder = op.join(wd, 'duplicated_products')
-            os.makedirs(dupe_folder, exist_ok=True)
-            for dupe in duplicates:
-                dupe_path = os.path.join(dupe_folder, os.path.basename(dupe))
-                wd_path = os.path.join(wd, os.path.basename(dupe))
-                if os.path.basename(dupe) != \
-                     os.path.basename(urls_final[-1]) and \
-                     os.path.exists(wd_path):
-                    os.rename(wd_path, dupe_path)
-    return urls_final
 
 
 class Downloader(object):

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: Brett A. Buzzanga
 # Copyright 2019, by the California Institute of Technology. ALL RIGHTS
@@ -28,44 +28,69 @@ log = logging.getLogger('ARIAtools')
 def createParser():
     """ Download a bulk download script and execute it """
     parser = argparse.ArgumentParser(description=
-        'Command line interface to download GUNW products from the ASF DAAC. '\
-        'GUNW products are hosted at the NASA ASF DAAC.\nDownloading them '\
+        'Command line interface to download GUNW products from the ASF DAAC. '
+        'GUNW products are hosted at the NASA ASF DAAC.\nDownloading them '
         'requires a NASA Earthdata URS user login and requires users to add '
-        '"GRFN Door (PROD)" and "ASF Datapool Products" to their URS approved applications.',
-        epilog='Examples of use:\n\t ariaDownload.py --track 004 --output count'\
-                '\n\t ariaDownload.py --bbox "36.75 37.225 -76.655 -75.928"'\
+        '"GRFN Door (PROD)" and "ASF Datapool Products" to their URS '
+        'approved applications.',
+        epilog='Examples of use:\n\t ariaDownload.py --track 004 '
+                '--output count'
+                '\n\t ariaDownload.py --bbox "36.75 37.225 -76.655 -75.928"'
                 '\n\t ariaDownload.py -t 004,077 --start 20190101 -o count',
              formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('-o', '--output', dest='output', default='Download', type=str,
-        help='Output type, default is "Download". "Download", "Count", "Url" and "Kmz" are currently supported. Use "Url" for ingestion to aria*.py')
+    parser.add_argument('-o', '--output', dest='output', default='Download', \
+                        type=str,
+        help='Output type, default is "Download". "Download", "Count", "Url"'
+             'and "Kmz" are currently supported. Use "Url" for ingestion to '
+             'aria*.py')
     parser.add_argument('-t', '--track', dest='track', default=None, type=str,
-        help='track to download; single number (including leading zeros) or comma separated')
+        help='track to download; single number (including leading zeros) or '
+             'comma separated')
     parser.add_argument('-b', '--bbox', dest='bbox',  default=None, type=str,
-        help='Lat/Lon Bounding SNWE, or GDAL-readable file containing POLYGON geometry.')
-    parser.add_argument('-w', '--workdir', dest='wd', default='./products', type=str,
-        help='Specify directory to deposit all outputs. Default is "products" in local directory where script is launched.')
+        help='Lat/Lon Bounding SNWE, or GDAL-readable file containing '
+             'POLYGON geometry.')
+    parser.add_argument('-w', '--workdir', dest='wd', default='./products', \
+                        type=str,
+        help='Specify directory to deposit all outputs. Default is '
+             '"products" in local directory where script is launched.')
     parser.add_argument('-s', '--start', dest='start', default=None, type=str,
-        help='Start date as YYYYMMDD; If none provided, starts at beginning of Sentinel record (2014).')
+        help='Start date as YYYYMMDD; If none provided, starts at beginning '
+             'of Sentinel record (2014).')
     parser.add_argument('-e', '--end', dest='end', default=None, type=str,
         help='End date as YYYYMMDD. If none provided, ends today.')
     parser.add_argument('-u', '--user', dest='user', default=None, type=str,
-        help='NASA Earthdata URS user login. Users must add "GRFN Door (PROD)" and "ASF Datapool Products" to their URS approved applications.')
+        help='NASA Earthdata URS user login. Users must add "GRFN Door '
+             '(PROD)" and "ASF Datapool Products" to their URS approved '
+             'applications.')
     parser.add_argument('-p', '--pass', dest='passw', default=None, type=str,
-        help='NASA Earthdata URS user password. Users must add "GRFN Door (PROD)" and "ASF Datapool Products" to their URS approved applications.')
-    parser.add_argument('-l', '--daysless', dest='dayslt', default=None, type=int,
-        help='Take pairs with a temporal baseline -- days less than this value.')
-    parser.add_argument('-m', '--daysmore', dest='daysgt', default=None, type=int,
-        help='Take pairs with a temporal baseline -- days greater than this value. Example, annual pairs: ariaDownload.py -t 004 --daysmore 364.')
-    parser.add_argument('-nt', '--num_threads', dest='num_threads', default='1', type=str,
-        help='Specify number of threads for multiprocessing download. By default "1". Can also specify "All" to use all available threads.')
+        help='NASA Earthdata URS user password. Users must add "GRFN Door '
+             '(PROD)" and "ASF Datapool Products" to their URS approved '
+             'applications.')
+    parser.add_argument('-l', '--daysless', dest='dayslt', default=None, \
+                        type=int,
+        help='Take pairs with a temporal baseline -- days less than this '
+             'value.')
+    parser.add_argument('-m', '--daysmore', dest='daysgt', default=None, \
+                        type=int,
+        help='Take pairs with a temporal baseline -- days greater than this '
+             'value. Example, annual pairs: ariaDownload.py -t 004 '
+             '--daysmore 364.')
+    parser.add_argument('-nt', '--num_threads', dest='num_threads', \
+                        default='1', type=str,
+        help='Specify number of threads for multiprocessing '
+             'download. By default "1". Can also specify "All" to use all '
+             'available threads.')
     parser.add_argument('-i', '--ifg', dest='ifg', default=None, type=str,
-        help='Retrieve one interferogram by its start/end date, specified as YYYYMMDD_YYYYMMDD (order independent)')
-    parser.add_argument('-d', '--direction', dest='flightdir', default=None, type=str,
+        help='Retrieve one interferogram by its start/end date, specified as '
+             'YYYYMMDD_YYYYMMDD (order independent)')
+    parser.add_argument('-d', '--direction', dest='flightdir', default=None, \
+                        type=str,
         help='Flight direction, options: ascending, a, descending, d')
     parser.add_argument('--use_all', dest='use_all', action='store_true',
         help='Consider all calls to ariaDownload when plotting DL speeds')
     parser.add_argument('--version', dest='version',  default=None,
-        help='Specify version as str, e.g. 2_0_4 or all prods; default: newest')
+        help='Specify version as str, e.g. 2_0_4 or all prods; default: '
+             'newest')
     parser.add_argument('-v', '--verbose', dest='v', action='store_true',
         help='Print products to be downloaded to stdout')
     return parser
@@ -83,7 +108,8 @@ def cmdLineParse(iargs=None):
         raise Exception('Must specify either a bbox or track')
 
     if not inps.output.lower() in ['count', 'kmz', 'kml', 'url', 'download']:
-        raise Exception ('Incorrect output keyword. Choose "count", "kmz", "url", or "download"')
+        raise Exception ('Incorrect output keyword. Choose "count", "kmz", '
+                         '"url", or "download"')
 
     inps.output = 'Kml' if inps.output.lower() == 'kmz' or \
             inps.output.lower() == 'kml' else inps.output.title()
@@ -91,7 +117,7 @@ def cmdLineParse(iargs=None):
 
 
 def prod_dl(inps, dct_prod,wd):
-    """ Perform downloading using ASF bulk dl; parallel processing supported """
+    """Perform downloading using ASF bulk dl; parallel processing supported"""
     max_threads = multiprocessing.cpu_count()
 
     if inps.num_threads == 'all':
@@ -121,7 +147,8 @@ def prod_dl(inps, dct_prod,wd):
                 info = pool.map(_dl_helper, lst_dcts)
             except Exception as E:
                 print ('ASF bulk downloader error:', E)
-                print ('Likely a bad handshake with the ASF DAAC. Try rerunning')
+                print ('Likely a bad handshake with the ASF DAAC. '
+                       'Try rerunning')
                 os.sys.exit(1)
 
         check.extend(chunkc for chunkc in chunks) # in case products missed in split
@@ -131,16 +158,18 @@ def prod_dl(inps, dct_prod,wd):
     check = [item for sublist in check for item in sublist]
     for f in files:
         if not f in check:
-            log.critical('File splitting missed: %s; subset your ARIA in command in time to try again', f)
+            log.critical('File splitting missed: %s; subset your ARIA in '
+                         'command in time to try again', f)
     return
 
 
 def _dl_helper(inp_dct):
-    """ Helper function for parallel processing """
+    """Helper function for parallel processing"""
     # import threading
     prod_dct = {'product_list': ','.join(inp_dct['files'])}
     log.debug ('# of files: %d', len(inp_dct['files']))
-    script   = requests.post(f'{inp_dct["url_base"]}&output=Download', data=prod_dct).text
+    script   = requests.post(f'{inp_dct["url_base"]}&output=Download', \
+               data=prod_dct).text
 
     fname    = f'ASFDataDload{inp_dct["ext"]}.py'
     fpath    = os.path.join(inp_dct['wd'], fname)
@@ -157,7 +186,8 @@ def _dl_helper(inp_dct):
 
     status_plot(inp_dct, mini.avg_rates, mini.elap)
 
-    return dler.success, dler.failed, dler.skipped, dler.total_time, dler.total_bytes
+    return dler.success, dler.failed, dler.skipped, dler.total_time, \
+           dler.total_bytes
 
 
 def check_cookie_is_logged_in(cj):
@@ -179,7 +209,8 @@ def rewrite_summary(infos):
 
 
     log.info ('Successes: %d files, %s bytes', len(succeed), tot_bytes)
-    _ = [print ('\n\t-', sf['file'], f'{sf["size"]/1024**2:.2f}') for sf in succeed]
+    _ = [print ('\n\t-', sf['file'], f'{sf["size"]/1024**2:.2f}') \
+                for sf in succeed]
 
     if skipped: log.info('Skipped: %d files', len(skipped))
     _ = [print ('\n\t-', sf) for sf in skipped]
@@ -187,17 +218,20 @@ def rewrite_summary(infos):
     if failed: log.info('Failures: %d files', len(failed))
     _ = [print ('\n\t-', sf) for sf in failed]
 
-    if succeed: log.info('Average Rate: %.2f MB/sec', (tot_bytes/1024.0**2)/tot_time)
+    if succeed: log.info('Average Rate: %.2f MB/sec', \
+                         (tot_bytes/1024.0**2)/tot_time)
 
     if failed:
-        log.critical('We recommend rerunning the same ariaDownload command to address the %d failures', len(failed))
+        log.critical('We recommend rerunning the same ariaDownload command '
+                     'to address the %d failures', len(failed))
     else:
         log.info ('All files have been downloaded successfully')
     return
 
 
 def status_plot(inps, rates=None, elaps=None, use_all=False):
-    """Save plot after each chunk on each core; use_all shows all calls to script"""
+    """Save plot after each chunk on each core; use_all shows all calls 
+       to script"""
     if len(rates) <= 1: # in case all successful (for testing)
         return
     with open(op.join(inps['wd'], 'avg_rates.csv'), 'a') as fh:
@@ -278,10 +312,11 @@ def url_versions(urls, user_version, wd):
             os.makedirs(dupe_folder, exist_ok=True)
             for dupe in duplicates:
                 dupe_path = os.path.join(dupe_folder, os.path.basename(dupe))
+                wd_path = os.path.join(wd, os.path.basename(dupe))
                 if os.path.basename(dupe) != \
                      os.path.basename(urls_final[-1]) and \
-                     os.path.exists(dupe_path):
-                    os.rename(dupe, dupe_path)
+                     os.path.exists(wd_path):
+                    os.rename(wd_path, dupe_path)
     return urls_final
 
 
@@ -290,7 +325,8 @@ class Downloader(object):
         self.inps        = inps
         self.inps.output = self.inps.output.title()
         self.inps.wd     = op.abspath(self.inps.wd)
-        self.url_base    = 'https://api.daac.asf.alaska.edu/services/search/param?'
+        self.url_base    = 'https://api.daac.asf.alaska.edu/services/' \
+                           'search/param?'
         if self.inps.v: log.setLevel('DEBUG')
         return
 
@@ -312,15 +348,17 @@ class Downloader(object):
         elif self.inps.output == 'Kml':
             os.makedirs(self.inps.wd, exist_ok=True)
             dst    = self._fmt_dst()
-            script = requests.post(f'{self.url_base}&output={self.inps.output}',
-                                                    data=dct_prod).text
+            script = requests.post(
+                f'{self.url_base}&output={self.inps.output}', \
+                data=dct_prod).text
             print(script, file=open(dst, 'w'))
             log.info(f'Wrote .KMZ to:\n\t %s', dst)
 
         elif self.inps.output == 'Url':
             os.makedirs(self.inps.wd, exist_ok=True)
             dst = self._fmt_dst()
-            with open(dst, 'w') as fh: [print(url, sep='\n', file=fh) for url in urls]
+            with open(dst, 'w') as fh: [print(url, sep='\n', file=fh) \
+                                        for url in urls]
             log.info(f'Wrote -- {len(urls)} -- product urls to: {dst}')
 
         elif self.inps.output == 'Download':
@@ -338,8 +376,8 @@ class Downloader(object):
         return urls
 
     def form_url(self):
-        url = f'{self.url_base}asfplatform=Sentinel-1%20Interferogram%20(BETA)'\
-                    '&processingLevel=GUNW_STD&output=JSON'
+        url = f'{self.url_base}asfplatform=Sentinel-1%20Interferogram%20' \
+                    '(BETA)&processingLevel=GUNW_STD&output=JSON'
         if self.inps.track:
             url += f'&relativeOrbit={self.inps.track}'
         if self.inps.bbox:
@@ -368,7 +406,8 @@ class Downloader(object):
             i+=1
             FileId = prod['product_file_id']
             match = re.search(r'\d{8}_\d{8}', FileId).group()
-            dates = [datetime.strptime(i, '%Y%m%d').date() for i in match.split('_')]
+            dates = [datetime.strptime(i, '%Y%m%d').date() for i in \
+                     match.split('_')]
             st, end = sorted(dates)
 
             if self.inps.ifg:
@@ -386,14 +425,17 @@ class Downloader(object):
 
             if (self.inps.daysgt or self.inps.dayslt):
                 elap = (end - st).days
-                if self.inps.daysgt and not (elap > self.inps.daysgt): continue
-                if self.inps.dayslt and not (elap < self.inps.dayslt): continue
+                if self.inps.daysgt and not (elap > self.inps.daysgt):
+                    continue
+                if self.inps.dayslt and not (elap < self.inps.dayslt):
+                    continue
 
             prod_ids.append(FileId); dl_urls.append(prod['downloadUrl'])
 
 
         if len(prod_ids) == 0:
-            raise Exception('No products found that satisfy requested conditions.')
+            raise Exception('No products found that satisfy requested '
+                            'conditions.')
 
         data = {'product_list': ','.join(prod_ids)}
         return data, dl_urls
@@ -408,8 +450,9 @@ class Downloader(object):
             try:
                 S, N, W, E = self.inps.bbox.split()
             except:
-                raise Exception('Cannot understand the --bbox argument. '\
-                'Input string was entered incorrectly or path does not exist.')
+                raise Exception('Cannot understand the --bbox argument. '
+                'Input string was entered incorrectly or path does not '
+                'exist.')
         return ','.join([W,S,E,N])
 
     def _fmt_dst(self):
@@ -426,11 +469,13 @@ class Downloader(object):
                     WSEN_fmt.append(math.floor(float(coord)))
                 else:
                     WSEN_fmt.append(math.ceil(float(coord)))
-            dst = f'{dst}_{WSEN_fmt[0]}W{WSEN_fmt[1]}S{WSEN_fmt[2]}E{WSEN_fmt[3]}Nbbox'
+            dst = f'{dst}_{WSEN_fmt[0]}W{WSEN_fmt[1]}S{WSEN_fmt[2]}E' \
+                   '{WSEN_fmt[3]}Nbbox'
         dst  += f'_0{ext}'
         count = 1 # don't overwrite if already exists
         while op.exists(dst):
-            basen  = f'{re.split(str(count-1)+ext, op.basename(dst))[0]}{count}{ext}'
+            basen  = f'{re.split(str(count-1)+ext, op.basename(dst))[0]}' \
+                      '{count}{ext}'
             dst    = op.join(op.dirname(dst), basen)
             count += 1
         return dst
@@ -438,12 +483,15 @@ class Downloader(object):
     def make_nc_cookie(self):
        import netrc, base64
        from urllib.request import build_opener, Request
-       from urllib.request import HTTPHandler, HTTPSHandler, HTTPCookieProcessor
+       from urllib.request import HTTPHandler, HTTPSHandler, \
+                                  HTTPCookieProcessor
        from urllib.error import HTTPError, URLError
        from http.cookiejar import MozillaCookieJar
 
-       cookie_jar_path = op.join(op.expanduser('~'), '.bulk_download_cookiejar.txt')
-       asf_urs4        = {'url': 'https://urs.earthdata.nasa.gov/oauth/authorize',
+       cookie_jar_path = op.join(op.expanduser('~'), \
+                                 '.bulk_download_cookiejar.txt')
+       asf_urs4        = {'url': \
+                           'https://urs.earthdata.nasa.gov/oauth/authorize',
                          'client': 'BO_n7nTIlMljdvU6kRRB3g',
                          'redir': 'https://auth.asf.alaska.edu/login'}
        path_netrc      = op.join(op.expanduser('~'), '.netrc')
@@ -454,7 +502,8 @@ class Downloader(object):
            log.info('Attempting to obtaining user/pass from .netrc')
            try:
                os.chmod(path_netrc, 0o600)
-               user, _,  passw = netrc.netrc().authenticators('urs.earthdata.nasa.gov')
+               user, _,  passw = netrc.netrc().authenticators( \
+                                 'urs.earthdata.nasa.gov')
            except Exception as E:
                print (E)
                os.sys.exit()
@@ -463,14 +512,17 @@ class Downloader(object):
            return None
 
        # Build URS4 Cookie request
-       auth_cookie_url = f"{asf_urs4['url']}?client_id={asf_urs4['client']}&redirect_uri={asf_urs4['redir']}&response_type=code&state="
+       auth_cookie_url = f"{asf_urs4['url']}?client_id={asf_urs4['client']}" \
+                          f"&redirect_uri={asf_urs4['redir']}&response_type=" \
+                          f"code&state="
        user_pass = base64.b64encode(bytes(f'{user}:{passw}', 'utf-8')).decode('utf-8')
 
        # Authenticate against URS, grab all the cookies
        cookie_jar = MozillaCookieJar()
        opener     = build_opener(HTTPCookieProcessor(cookie_jar),
                                         HTTPHandler(), HTTPSHandler(**{}))
-       request    = Request(auth_cookie_url, headers={'Authorization': f'Basic {user_pass}'})
+       request    = Request(auth_cookie_url, headers={'Authorization': \
+           f'Basic {user_pass}'})
 
        # Watch out cookie rejection!
        try:
@@ -485,14 +537,16 @@ class Downloader(object):
           else:
              # If an error happens here, the user most likely has not confirmed EULA.
              log.info('\nThere was an error obtaining a download cookie')
-             log.info('Most likely you lack permission to download data from the ASF Datapool.')
-             log.info('\n\nNew users: you must first log into Vertex and accept the EULA. '\
-               'In addition, your Study Area must be set at Earthdata: '\
-               ' https://urs.earthdata.nasa.gov')
+             log.info('Most likely you lack permission to download data from '\
+                      'the ASF Datapool.')
+             log.info('\n\nNew users: you must first log into Vertex and '\
+                      'accept the EULA. In addition, your Study Area must '\
+                      'be set at Earthdata: https://urs.earthdata.nasa.gov')
              os.sys.exit(1)
 
        except URLError:
-          log.info('\nThere was a problem communicating with URS, unable to obtain cookie')
+          log.info('\nThere was a problem communicating with URS, unable to '
+                   'obtain cookie')
           log.info('Try cookie generation later.')
           os.sys.exit(1)
 


### PR DESCRIPTION
A few bug-fixes were implemented:

1. In `ariaDownloads.py`, duplicate products (if they already existed) were originally not moved into separate subdirectory so they may not be passed along. This patch ensures such duplicate products are indeed segregated to this subdirectory.

2. Option added to `shapefile_area` function in `shapefile_util.py` to estimate the area of the region, as opposed to just the cutline, in order to obtain an accurate estimate of the extent of a downloaded DEM and/or mask. This resolves issue where DEMs weren’t chunked when they should have been, leading to crashes as the SRTM server cannot handle such large requests. Addresses #265 . 

3. Incremental updates to be inline with pep standards also passed.