### PR TITLE
Relative path patch

### DIFF
--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -335,7 +335,7 @@ def generate_stack(aria_prod, input_files, output_file_name,
                 print('Orbit direction not recognized')
                 metadata['orbit_direction'] = 'UNKNOWN'
 
-            path = os.path.abspath(data[1])
+            path = os.path.relpath(os.path.abspath(data[1]), start=stack_dir)
             outstr = '''  <VRTRasterBand dataType="{data_type}" band="{index}">
         <SimpleSource>
             <SourceFilename relativeToVRT="1">{path}</SourceFilename>


### PR DESCRIPTION
Following PR #160 and the advice of @yunjunz from #253, absolute path designations reverted back to relative path.

@ehavazli @bbuzz31 as a sanity check, do you recall any specific reason from previous discussions regarding why an absolute path would be preferred over relative paths?