### PR TITLE
Some tweaks to allow editable installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,255 @@
-*.pyc
-*~
-*.swp
-*.DS_Store
-__pycache__
-.ipynb_checkpoints
+#### joe made this: http://goel.io/joe
+
+#### python ####
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
 *.log
-build
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+
+#### jupyternotebooks ####
+# gitignore template for Jupyter Notebooks
+# website: http://jupyter.org/
+
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/
+
+
+#### jetbrains ####
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+
+#### vim ####
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ Below we outline the different steps for setting up the ARIA-tools while leverag
 
 ```.tcsh
 git clone https://github.com/aria-tools/ARIA-tools.git
+cd ARIA-tools
 ```
 
 Run the commands below to install dependencies to a new conda environment `ARIA-tools` and activate it:
 
 ```.tcsh
-conda env create -f ./ARIA-tools/environment.yml
+conda env create -f environment.yml
 conda activate ARIA-tools
 ```
 
@@ -89,19 +90,18 @@ Or run the commands below to install dependencies to an existing conda environme
 
 ```.tcsh
 # add "jupyterlab jupyter_contrib_nbextensions rise" below to install the extra requirements for ARIA-tools-docs
-conda install -c conda-forge --yes --file ./ARIA-tools/requirements.txt
+conda install -c conda-forge --yes --file requirements.txt
 ```
 
-We have included a setup.py script which allows for easy compilation and installation of third-party dependencies (c-code), as well as for setting up the ARIA-tools package itself (python and command line tools).
+We have included a `setup.py` script which allows for easy compilation and installation of third-party dependencies (c-code), as well as for setting up the ARIA-tools package itself (python and command line tools).
 ```.tcsh
-python setup.py build
-python setup.py install
+python -m pip install .
 ```
 
 If not using the setup.py, users should compile third-party packages manually and ensure ARIA-tools and dependencies are included on their PATH and PYTHONPATH. For c-shell this can be done as follows (replace "ARIAtoolsREPO" to the location where you have cloned the ARIAtools repository):
 ```.tcsh
-setenv PYTHONPATH $PYTHONPATH:/ARIAtoolsREPO/tools/ARIAtools
-set PATH $PATH:'/ARIAtoolsREPO/tools/bin'
+setenv PYTHONPATH ${PYTHONPATH}:{$PWD}/tools/ARIAtools
+setenv PATH ${PATH}:${PWD}/tools/ARIAtools
 ```
 
 ### Other installation options

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if os.path.isdir(relaxPath):
            description = 'This is the ARIA tools package with RelaxIV support',
            ext_modules = [module1],
            packages=['ARIAtools'],
-           package_dir={'ARIAtools': 'tools/ARIAtools'},
+           package_dir={'': 'tools'},
            scripts=['tools/bin/ariaPlot.py','tools/bin/ariaDownload.py','tools/bin/ariaExtract.py','tools/bin/ariaTSsetup.py','tools/bin/ariaAOIassist.py','tools/bin/ariaMisclosure.py'])
 else:
     # Third party package RelaxIV not found
@@ -67,5 +67,5 @@ else:
            version = version0,
            description = 'This is the ARIA tools package without RelaxIV support',
            packages=['ARIAtools'],
-           package_dir={'ARIAtools': 'tools/ARIAtools'},
+           package_dir={'': 'tools'},
            scripts=['tools/bin/ariaPlot.py','tools/bin/ariaDownload.py','tools/bin/ariaExtract.py','tools/bin/ariaTSsetup.py','tools/bin/ariaAOIassist.py','tools/bin/ariaMisclosure.py'])


### PR DESCRIPTION
This changes `setup.py` to allow for develop/editable installs, which create a symbolic package pointing back to the repository and allows code changes to be automatically reflected in the environment. This is particularly useful for debugging. You can install in editable mode with the command:
```
# preferred
python -m pip install -e .
# depreciated
python setup.py develop
```
from the repository root. 


I've also:
* updated the install instructions in the README to prefer pip over directly calling `setup.py` which is preferred as pip handles dependency resolution and installation nuances better than vanilla setuptools. 
* Added a more comprehensive `.gitignore`, generated by [Joe](https://github.com/karan/joe) (no relation), that covers Python, Jupyter, Jetbrains IDEs (e.g. PyCharm) and vim. I can back this out if preferred.  
