### PR TITLE
gdal workaround to fix virtual access

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -19,6 +19,7 @@ from ARIAtools.logger import logger
 
 gdal.UseExceptions()
 gdal.PushErrorHandler('CPLQuietErrorHandler')
+gdal.SetConfigOption('CPL_VSIL_CURL_USE_HEAD', 'NO')
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Set config option so that GDAL can once again access ARIA products virtually at ASF.

Fixes #283 

Also see: https://github.com/OSGeo/gdal/issues/1456

