### PR TITLE
Fix midnight crossing bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs:
             # mamba update -y mamba
             mamba env create -f environment.yml
 
-            mamba install -c anaconda git
-            mamba install -c anaconda wget
             conda activate ARIA-tools
+
+            mamba install -c conda-forge git wget pyresample
 
             echo "machine urs.earthdata.nasa.gov login $URSname password $URSkey" > ~/.netrc
             chmod 600 ~/.netrc

--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -558,7 +558,7 @@ class ARIA_standardproduct:
                      new_scene[0]['pair_name'] in track_rejected_pairs:
                     track_rejected_pairs.extend((scene[0]['pair_name'], \
                         new_scene[0]['pair_name']))
-                    continue    
+                    continue
                 # Check if IFG dict corresponding to ref prod already exists
                 # and if it does then append values
                 try:
@@ -616,7 +616,7 @@ class ARIA_standardproduct:
         # Remove duplicate dates
         track_rejected_pairs=list(set(track_rejected_pairs))
         if len(track_rejected_pairs)>0:
-            log.warning('%d out of %d interferograms rejected since ' 
+            log.warning('%d out of %d interferograms rejected since '
                         'stitched interferogram would have gaps', \
                         len(track_rejected_pairs), \
                         len([item[0] for item in sorted_products]))
@@ -631,7 +631,8 @@ class ARIA_standardproduct:
             record_rejected_scenes = list(set(record_rejected_scenes))
             record_rejected_scenes = [os.path.basename(i) \
                  for i in record_rejected_scenes]
-            [log.debug(i) for i in record_rejected_scenes]
+            for i in record_rejected_scenes:
+                log.debug(i)
         else:
             log.info('All (%d) interferograms are spatially continuous.', \
                      len(sorted_products))
@@ -645,8 +646,8 @@ class ARIA_standardproduct:
 
         ###Report dictionaries for all valid products
         if sorted_products==[[], []]: #Check if pairs successfully selected
-            raise Exception('No valid interferogram meet spatial criteria ' 
-                            'due to gaps and/or invalid input, ' 
+            raise Exception('No valid interferogram meet spatial criteria '
+                            'due to gaps and/or invalid input, '
                             'nothing to export.')
 
         return sorted_products

--- a/tools/ARIAtools/unwrapStitching.py
+++ b/tools/ARIAtools/unwrapStitching.py
@@ -365,7 +365,7 @@ class UnwrapOverlap(Stitching):
 
                 # determining the intersection between the two frames
                 if not bbox_frame1.intersects(bbox_frame2):
-                    log.error("Products do not overlap or were not provided in a contigious sorted list.")
+                    log.error("Products do not overlap or were not provided in a contiguous sorted list.")
                     raise Exception
                 polyOverlap = bbox_frame1.intersection(bbox_frame2)
 

--- a/tools/ARIAtools/unwrapStitching.py
+++ b/tools/ARIAtools/unwrapStitching.py
@@ -382,17 +382,45 @@ class UnwrapOverlap(Stitching):
                 # will first attempt to mask out connected component 0, and default to complete overlap if this fails.
                 # Cropping the unwrapped phase and connected component to the overlap region alone, inhereting the no-data.
                 # connected component
-                out_data,connCompNoData1,geoTrans,proj = GDALread(self.ccFile[counter],data_band=1,loadData=False)
-                out_data,connCompNoData2,geoTrans,proj = GDALread(self.ccFile[counter+1],data_band=1,loadData=False)
-                connCompFile1 = gdal.Warp('', self.ccFile[counter], options=gdal.WarpOptions(format="MEM", cutlineDSName=outname, outputBounds=polyOverlap.bounds, dstNodata=connCompNoData1))
-                connCompFile2 = gdal.Warp('', self.ccFile[counter+1], options=gdal.WarpOptions(format="MEM", cutlineDSName=outname, outputBounds=polyOverlap.bounds, dstNodata=connCompNoData2))
+                out_data,connCompNoData1,geoTrans,proj = GDALread( \
+                    self.ccFile[counter],data_band=1,loadData=False)
+                out_data,connCompNoData2,geoTrans,proj = GDALread( \
+                    self.ccFile[counter+1],data_band=1,loadData=False)
+                connCompFile1 = gdal.Warp( \
+                    '', self.ccFile[counter], options = gdal.WarpOptions( \
+                    format="MEM", cutlineDSName=outname, \
+                    outputBounds=polyOverlap.bounds, \
+                    dstNodata=connCompNoData1))
+                # need to specify spacing to avoid inconsistent dimensions
+                arrshape = connCompFile1.ReadAsArray().shape
+                connCompFile2 = gdal.Warp( \
+                    '', self.ccFile[counter+1], options=gdal.WarpOptions( \
+                    format="MEM", cutlineDSName=outname, \
+                    outputBounds=polyOverlap.bounds, \
+                    dstNodata=connCompNoData2, \
+                    width = arrshape[1], height = arrshape[0], \
+                    multithread = True))
 
 
                 # unwrapped phase
-                out_data,unwNoData1,geoTrans,proj = GDALread(self.inpFile[counter],data_band=1,loadData=False)
-                out_data,unwNoData2,geoTrans,proj = GDALread(self.inpFile[counter+1],data_band=1,loadData=False)
-                unwFile1 = gdal.Warp('', self.inpFile[counter], options=gdal.WarpOptions(format="MEM", cutlineDSName=outname, outputBounds=polyOverlap.bounds, dstNodata=unwNoData1))
-                unwFile2 = gdal.Warp('', self.inpFile[counter+1], options=gdal.WarpOptions(format="MEM", cutlineDSName=outname, outputBounds=polyOverlap.bounds, dstNodata=unwNoData2))
+                out_data,unwNoData1,geoTrans,proj = GDALread( \
+                    self.inpFile[counter],data_band=1,loadData=False)
+                out_data,unwNoData2,geoTrans,proj = GDALread( \
+                    self.inpFile[counter+1],data_band=1,loadData=False)
+                unwFile1 = gdal.Warp( \
+                    '', self.inpFile[counter], options=gdal.WarpOptions( \
+                    format="MEM", cutlineDSName=outname, \
+                    outputBounds=polyOverlap.bounds, \
+                    dstNodata=unwNoData1, \
+                    width = arrshape[1], height = arrshape[0], \
+                    multithread = True))
+                unwFile2 = gdal.Warp( \
+                    '', self.inpFile[counter+1], options=gdal.WarpOptions( \
+                    format="MEM", cutlineDSName=outname, \
+                    outputBounds=polyOverlap.bounds, \
+                    dstNodata=unwNoData2, \
+                    width = arrshape[1], height = arrshape[0], \
+                    multithread = True))
 
 
                 # finding the component with the largest overlap


### PR DESCRIPTION
The code had failed to properly recognize spatiotemporal continuity across protects that span midnight.

E.g. the following two products for track 48 over Tibet (see issue #308 on how to access), which are continuous in space and time, were treated as two separate products:
S1-GUNW-D-R-048-tops-20161015_20160730-**000002**-00089E_00035N-PP-b2bb-v2_0_5.nc
S1-GUNW-D-R-048-tops-20161015_20160730-**235937**-00089E_00036N-PP-ea06-v2_0_5.nc

This leads to issues internally downstream where multiple products point to the same extracted shapefile without being stitched together. For instance, if one gets rejected for not meeting user-defined spatial criteria, the program crashes in a loop after deleting the corresponding extracted shapefile as the next product in the loop points to the now deleted shapefile (see issue #308).


I also cleaned up some of the more egregious examples of list comprehension in the code to assist with debugging and readability.


Addresses issue #308. Note I performed tests on a subset of the products specified in issue #309 due to bandwidth issues, but it appears as if the issue is resolved on my end.