### PR TITLE
Correct dupes

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -519,7 +519,7 @@ class ARIA_standardproduct:
                 scenes = [scene, new_scene]
                 for sc in scenes:
                     path_bbox = sc[1]['productBoundingBox']
-                    ver_str   = re.search('(v.*)\.', path_bbox).group(1)
+                    ver_str   = re.search(r'(v.*)\.', path_bbox).group(1)
                     ver_num   = float(ver_str[1:].replace('_', ''))
                     vers.append(ver_num)
 

--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -8,6 +8,7 @@
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 import os
+import re
 import numpy as np
 from joblib import Parallel, delayed
 import logging
@@ -511,12 +512,25 @@ class ARIA_standardproduct:
                 # If applicable, overwrite smaller scene with larger one
                 if same_area > inv_same_area:
                     i = (i[0]-1, new_scene)
-                log.debug("Duplicate product captured. Rejecting scene %s",
-                    os.path.basename( \
-                     new_scene[1]['unwrappedPhase'].split('"')[1]))
-                # Overwrite latter scene with former
-                self.products[i[0]+1] = scene
+
+                # Try to use newer version
+                # else overwrite latter scene with former (argmax=0 when no max)
+                vers   = []
+                scenes = [scene, new_scene]
+                for sc in scenes:
+                    path_bbox = sc[1]['productBoundingBox']
+                    ver_str   = re.search('(v.*)\.', path_bbox).group(1)
+                    ver_num   = float(ver_str[1:].replace('_', ''))
+                    vers.append(ver_num)
+
+                use_scene = scenes[np.argmax(vers)]
+                scenes.remove(use_scene) # now scenes has the rejected scene
+                self.products[i[0]+1] = use_scene
                 num_dups.append(i[0])
+
+                log.debug("Duplicate product captured. Rejecting scene %s",
+                    os.path.basename(scenes[0][1]['unwrappedPhase'].split(':')[1]))
+
         # Delete duplicate products
         self.products=list(self.products for self.products,_ in \
                            itertools.groupby(self.products))

--- a/tools/ARIAtools/url_manager.py
+++ b/tools/ARIAtools/url_manager.py
@@ -16,6 +16,10 @@ def url_versions(urls, user_version, wd):
     Uses the the latest if user_version is None else use specified ver.
     """
     if user_version is not None and str(user_version).lower() != 'all':
+        # dummy-proof if version entered as digit, as opposed to 2_X_X
+        if len(user_version) == 1:
+            raise Exception('Input version {} not in format 2_X_X'
+                                      'as expected'.format(user_version))
         print (f'Only using products version: {user_version}')
         urls_final = [url for url in urls if user_version in url]
         if not urls_final:

--- a/tools/ARIAtools/url_manager.py
+++ b/tools/ARIAtools/url_manager.py
@@ -9,8 +9,25 @@
 
 import os, os.path as op
 
-###Capture and segregate duplicate products (if applicable)
+## Grab older version products if specified.
 def url_versions(urls, user_version, wd):
+    """ For duplicate products (other than version number)
+
+    Uses the the latest if user_version is None else use specified ver.
+    """
+    if user_version is not None and str(user_version).lower() != 'all':
+        print (f'Only using products version: {user_version}')
+        urls_final = [url for url in urls if user_version in url]
+        if not urls_final:
+            raise Exception(f'No products with user specified version: {urls_final}')
+    else:
+        urls_final = urls
+
+    return urls_final
+
+# Currently does not work as expected, as lat/lon coords of newer versions do not match older
+# Will only support specific versions or 'all'
+def url_versions_full(urls, user_version, wd):
     """For duplicate products (other than version number)
     Uses the the latest if user_version is None else use specified ver."""
     if isinstance(user_version, str) and user_version.lower() == 'all':


### PR DESCRIPTION
Previously, we identified new version products based on the first ten fields of the file name (see [Product Filename Convention](https://aria.jpl.nasa.gov/products/standard-displacement-products.html)). 

However, the newer version products have different Decimal latitude than previous versions, despite covering the same area. 

For now there are two options available to the user:

1.  (default): all products are downloaded regardless of version number. 
    - Duplicates are identified by opening the file and comparing the timing and and area. 
    - The newest version is used for processing.
    
2. A user can specify a product version, and ONLY products which match that version are used.
