### PR TITLE
adjust regex to only search version string

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -519,7 +519,8 @@ class ARIA_standardproduct:
                 scenes = [scene, new_scene]
                 for sc in scenes:
                     path_bbox = sc[1]['productBoundingBox']
-                    ver_str   = re.search(r'(v.*)\.', path_bbox).group(1)
+
+                    ver_str   = re.search(r'(v.*)\.', os.path.basename(path_bbox)).group(1)
                     ver_num   = float(ver_str[1:].replace('_', ''))
                     vers.append(ver_num)
 


### PR DESCRIPTION
currently the whole string is searched for version starting with 'v' and fails if there is e.g., a username joyvan