### PR TITLE
bug fixes for stitching

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1145,7 +1145,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
                                               verbose=verbose)
 
                     elif stitchMethodType == 'sequential':
-                        from sequential_stitching import product_stitch_sequential
+                        from ARIAtools.sequential_stitching import product_stitch_sequential
                         product_stitch_sequential(phs_files,
                                                  conn_files,
                                                  bounds=bounds,
@@ -1153,7 +1153,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
                                                  output_unw=outFilePhs,
                                                  output_conn=outFileConnComp,
                                                  mask_file=mask, # str filename
-                                                 outputFormat=outputFormat,
+                                                 output_format=outputFormat,
                                                  range_correction=True,
                                                  save_fig=True,
                                                  overwrite=True,


### PR DESCRIPTION
@mgovorcin @sssangha this currently does not work due to bugs and does not support time series analysis. Please update ASAP for our tests.

I fixed two bugs in this PR but now am getting (hardcoded TS processing as you advised @mgovorcin )
```
Extracting unwrapped phase, coherence, and connected components for each interferogram pair
Generating: unwrappedPhase - [>                                                 ]Traceback (most recent call last):
  File "/u/leffe-data2/buzzanga/Miniconda3/envs/ARIA/bin/ariaTSsetup.py", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/u/leffe-data2/buzzanga/Software_InSAR/ARIA-tools_git/tools/bin/ariaTSsetup.py", line 18, in <module>
    main(inps)
  File "/u/leffe-data2/buzzanga/Software_InSAR/ARIA-tools_git/tools/ARIAtools/tsSetup.py", line 472, in main
    export_products(standardproduct_info.products[1],
  File "/u/leffe-data2/buzzanga/Software_InSAR/ARIA-tools_git/tools/ARIAtools/extractProduct.py", line 1149, in export_products
    product_stitch_sequential(phs_files,
  File "/u/leffe-data2/buzzanga/Software_InSAR/ARIA-tools_git/tools/ARIAtools/sequential_stitching.py", line 480, in product_stitch_sequential
    combined_unwrap, combined_snwe, _ = combine_data_to_single(corrected_unw_arrays, snwe_list,
UnboundLocalError: local variable 'corrected_unw_arrays' referenced before assignment
```
