### PR TITLE
Unpin scipy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - pip
   - pyproj
   - requests
-  - scipy<1.10
+  - scipy>1.10.0
   - mintpy
   - shapely
   #for ARIA-tools-docs


### PR DESCRIPTION
Update scipy requirement to use recent revisions with bug-fix.

This scipy issue has been captured and accounted for in other repos (e.g. [mintpy](https://github.com/insarlab/MintPy/pull/968))