### PR TITLE
Fix ML bug for unw/concomp fields

### DIFF
--- a/tools/ARIAtools.egg-info/PKG-INFO
+++ b/tools/ARIAtools.egg-info/PKG-INFO
@@ -1,5 +1,5 @@
 Metadata-Version: 2.1
 Name: ARIAtools
-Version: 1.1.4
+Version: 1.1.5
 Summary: This is the ARIA tools package without RelaxIV support
 License-File: LICENSE

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -70,7 +70,7 @@ def createParser():
                         'If "all" specified, then all layers are extracted. '
                         'If blank, will only extract bounding box.')
     parser.add_argument('-tm', '--tropo_models', dest='tropo_models',
-                        type=str, default='all', help='Provide list of '
+                        type=str, default=None, help='Provide list of '
                         'weather models you wish to extract. Refer to '
                         'ARIA_TROPO_MODELS for list of supported models')
     parser.add_argument('-d', '--demfile', dest='demfile', type=str,
@@ -1141,10 +1141,6 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
                     # If necessary, resample phs/conn_comp file
                     if multilooking is not None:
                         resampleRaster(outFilePhs, multilooking, bounds,
-                                       prods_TOTbbox, rankedResampling,
-                                       outputFormat=outputFormat,
-                                       num_threads=num_threads)
-                        resampleRaster(outFileConnComp, multilooking, bounds,
                                        prods_TOTbbox, rankedResampling,
                                        outputFormat=outputFormat,
                                        num_threads=num_threads)

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -26,11 +26,11 @@ from ARIAtools.logger import logger
 from ARIAtools.shapefile_util import open_shapefile, chunk_area
 from ARIAtools.mask_util import prep_mask
 from ARIAtools.unwrapStitching import product_stitch_overlap, \
-                                      product_stitch_2stage
+    product_stitch_2stage
 from ARIAtools.vrtmanager import renderVRT, resampleRaster, layerCheck, \
-                                 get_basic_attrs
+    get_basic_attrs, ancillaryLooks
 from ARIAtools.sequential_stitching import product_stitch_sequential, \
-                                           product_stitch_sequential_metadata
+    product_stitch_sequential_metadata
 import pyproj
 from pyproj import CRS, Transformer
 from rioxarray import open_rasterio
@@ -80,7 +80,7 @@ def createParser():
     parser.add_argument('-b', '--bbox', dest='bbox', type=str, default=None,
         help="Provide either valid shapefile or Lat/Lon Bounding SNWE. -- Example : '19 20 -99.5 -98.5'")
     parser.add_argument('-m', '--mask', dest='mask', type=str, default=None,
-        help="Path to mask file or 'Download'. File needs to be GDAL compatabile, contain spatial reference information, and have invalid/valid data represented by 0/1, respectively. If 'Download', will use GSHHS water mask. If 'NLCD', will mask classes 11, 12, 90, 95; see: https://www.mrlc.gov/national-land-cover-database-nlcd-201://www.mrlc.gov/national-land-cover-database-nlcd-2016")
+        help="Path to mask file or 'Download'. File needs to be GDAL compatabile, contain spatial reference information, and have invalid/valid data represented by 0/1, respectively. If 'Download', will use GSHHS water mask. If 'NLCD', will mask classes 11, 12, 90, 95; see: www.mrlc.gov/national-land-cover-database-nlcd-2016")
     parser.add_argument('-at', '--amp_thresh', dest='amp_thresh', default=None, type=str,
         help='Amplitude threshold below which to mask. Specify "None" to not use amplitude mask. By default "None".')
     parser.add_argument('-nt', '--num_threads', dest='num_threads', default='2', type=str,
@@ -1177,7 +1177,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
             if len(os.listdir(plots_subdir)) == 0:
                 shutil.rmtree(plots_subdir)
 
-    return
+    return [ref_height, ref_wid]
 
 
 def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
@@ -1759,19 +1759,21 @@ def main(inps=None):
     }
 
     # Extract user expected layers
-    export_products(**export_dict)
+    arrshape = export_products(**export_dict)
 
-    # If necessary, resample DEM/mask AFTER they have been used to extract metadata layers and mask output layers, respectively
-    if inps.multilooking is not None:
-        bounds=open_shapefile(standardproduct_info.bbox_file, 0, 0).bounds
-        # Resample mask
-        if inps.mask is not None:
-            resampleRaster(inps.mask.GetDescription(), inps.multilooking, bounds, prods_TOTbbox,
-                        inps.rankedResampling, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
-        # Resample DEM
-        if demfile is not None:
-            resampleRaster(demfile.GetDescription(), inps.multilooking, bounds,
-                            prods_TOTbbox, inps.rankedResampling, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+    # If necessary, resample DEM/mask AFTER they have been used to extract
+    ancillary_dict = {
+        'mask': inps.mask,
+        'dem': demfile,
+        'arrshape': arrshape,
+        'standardproduct_info': standardproduct_info,
+        'multilooking': inps.multilooking,
+        'prods_TOTbbox': prods_TOTbbox,
+        'rankedResampling': inps.rankedResampling,
+        'outputFormat': inps.outputFormat,
+        'num_threads': inps.num_threads
+    }
+    ancillaryLooks(**ancillary_dict)
 
     # Perform GACOS-based tropospheric corrections (if specified).
     if inps.gacos_products:

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -65,7 +65,7 @@ def create_parser():
                              'If "all" specified, then all layers are extracted. '
                              'If blank, will only extract bounding box.')
     parser.add_argument('-tm', '--tropo_models', dest='tropo_models',
-                        type=str, default='all', help='Provide list of '
+                        type=str, default=None, help='Provide list of '
                                                       'weather models you wish to extract. Refer to '
                                                       'ARIA_TROPO_INTERNAL for list of supported models')
     parser.add_argument('-d', '--demfile', dest='demfile', type=str,
@@ -557,9 +557,6 @@ def main(inps=None):
     for i in layers:
         lyr_dir = os.path.join(inps.workdir, i)
         if not os.path.exists(lyr_dir):
-            log.warning(f'Stack for default ARIA TS layer {i} cannot be '
-                        'generated as it does not exist in any of the input '
-                        'products')
             if i in layers:
                 remove_lyrs.append(i)
     layers = [i for i in layers if i not in remove_lyrs]

--- a/tools/ARIAtools/unwrapStitching.py
+++ b/tools/ARIAtools/unwrapStitching.py
@@ -429,7 +429,8 @@ class UnwrapOverlap(Stitching):
                 connCompData2 =connCompFile2.GetRasterBand(1).ReadAsArray()
                 connCompData2[(connCompData2==connCompNoData2) | (connCompData2==0)]=np.nan
                 connCompData2_temp = (connCompData2*100)
-                temp = connCompData2_temp.astype(int)-connCompData1.astype(int)
+                with np.errstate(invalid='ignore'):
+                    temp = connCompData2_temp.astype(int)-connCompData1.astype(int)
                 temp[(temp<0) | (temp>2000)]=0
                 temp_count = collections.Counter(temp.flatten())
                 maxKey = 0
@@ -1415,7 +1416,7 @@ def point2unwPhase(inputs):
     return unwPhase
 
 
-def gdalTest(file, verbose=False):
+def gdalTest(file):
     '''
         Checks if the file is GDAL compatible and return compatible VRT in case it exists
     '''
@@ -1449,13 +1450,10 @@ def gdalTest(file, verbose=False):
         if os.path.isfile(filetest):
             ds = gdal.Open(filetest, gdal.GA_ReadOnly)
             ds = None
-            log.debug("%s is GDAL compatible", filetest)
             return filetest
         else:
-            log.debug("%s is GDAL compatible", file)
             return file
     except:
-        log.debug("%s is GDAL compatible", file)
         return file
 
 


### PR DESCRIPTION
When the multilook option is specified and the user wishes to extract unw fields, the program had improperly applied the looks twice. This is because each call to `resampleRaster` (the multilook) function applies resampling to both unw and concomp fields in one go. However I caught two consecutive calls to `resampleRaster` passing unw and concomp, respectively. Thus, this is where "double-looks" were applied. This behavior has now been fixed, addressing issue #352 