### PR TITLE
Supress sequential stitcher print statements by default

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1135,8 +1135,8 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
                                                  output_format=outputFormat,
                                                  range_correction=True,
                                                  save_fig=False,
-                                                 overwrite=True,
-                                                 verbose=verbose)
+                                                 overwrite=True)
+                                                 #verbose=verbose)
 
                     # If necessary, resample phs/conn_comp file
                     if multilooking is not None:

--- a/tools/ARIAtools/sequential_stitching.py
+++ b/tools/ARIAtools/sequential_stitching.py
@@ -149,7 +149,8 @@ def stitch_2frames(unw_data1 : NDArray, conn_data1 : NDArray, rdict1 : dict,
                 conn_reverse[conn_reverse[:,0] == pair[0], 0] = \
                     np.float32(pair[1])
         else:
-            print('SKIPPED!:', correction, pair, '\n')
+            if verbose:
+                print('SKIPPED!:', correction, pair, '\n')
     
     # Backward correction
     for pair in conn_reverse:
@@ -330,7 +331,7 @@ def get_overlapping_conn(conn1 : NDArray,
 def _integer_2pi_cycles(unw1 : NDArray, concom1 : NDArray, ix1 : np.float32,
                         unw2 : NDArray, concom2 : NDArray, ix2 : np.float32,
                         range_correction : Optional[bool] = False,
-                        print_msg : Optional[bool] = True,) -> \
+                        print_msg : Optional[bool] = False) -> \
                                     Tuple[np.float32, np.float32, np.float32]:
     """
     Get mean difference of unwrapped Phase values for overlapping
@@ -411,7 +412,7 @@ def _integer_2pi_cycles(unw1 : NDArray, concom1 : NDArray, ix1 : np.float32,
         return None, None, None
 
 def _range_correction(unw1 : NDArray,
-                      unw2 : NDArray,) -> np.float32:
+                      unw2 : NDArray) -> np.float32:
     """
     Calculate range correction due to small non 2-pi shift caused by ESD 
     different between frames. If ESD is not used, this correction 
@@ -443,7 +444,7 @@ def _range_correction(unw1 : NDArray,
 
 
 def _metadata_offset(unw1 : NDArray, unw2 : NDArray,
-                     print_msg : Optional[bool] = True) -> Tuple[np.float32]:
+                     print_msg : Optional[bool] = False) -> Tuple[np.float32]:
     """
     Get mean difference of metadata layers
     
@@ -983,6 +984,10 @@ def write_GUNW_array(output_filename: Union[str, Path],
     """
 
     array_type = gdal_array.NumericTypeCodeToGDALTypeCode(array.dtype)
+
+    # File must be physically extracted, cannot proceed with VRT format.
+    # Defaulting to ENVI format.
+    format = 'ENVI' if format == 'VRT' else format
 
     # Output path
     output = Path(output_filename).absolute()

--- a/tools/ARIAtools/sequential_stitching.py
+++ b/tools/ARIAtools/sequential_stitching.py
@@ -985,10 +985,6 @@ def write_GUNW_array(output_filename: Union[str, Path],
 
     array_type = gdal_array.NumericTypeCodeToGDALTypeCode(array.dtype)
 
-    # File must be physically extracted, cannot proceed with VRT format.
-    # Defaulting to ENVI format.
-    format = 'ENVI' if format == 'VRT' else format
-
     # Output path
     output = Path(output_filename).absolute()
     output_vrt = output.with_suffix('.vrt') 
@@ -1303,3 +1299,5 @@ def plot_GUNW_stitched(stiched_unw_filename: str,
 
     fig.tight_layout()
     fig.savefig(str(output_fig))
+    fig.clear()
+    plt.close(fig)

--- a/tools/ARIAtools/unwrapStitching.py
+++ b/tools/ARIAtools/unwrapStitching.py
@@ -131,10 +131,7 @@ class Stitching:
 
     def setOutputFormat(self,outputFormat):
         """ Set the output format of the files to be generated """
-        # File must be physically extracted, cannot proceed with VRT format. Defaulting to ENVI format.
         self.outputFormat = outputFormat
-        if self.outputFormat=='VRT':
-            self.outputFormat='ENVI'
 
     def setOutFileUnw(self,outFileUnw):
         """ Set the output file name for the unwrapped stiched file to be generated"""

--- a/tools/ARIAtools/vrtmanager.py
+++ b/tools/ARIAtools/vrtmanager.py
@@ -78,10 +78,7 @@ def resampleRaster(fname, multilooking, bounds, prods_TOTbbox, rankedResampling=
     from scipy import stats
     from decimal import Decimal, ROUND_HALF_UP
 
-    # Check if physical raster exists and needs to be updated
-    # Also get datasource name (inputname)
-    if outputFormat=='VRT' and os.path.exists(fname.split('.vrt')[0]):
-        outputFormat='ENVI'
+    # Get datasource name (inputname)
     if os.path.exists(fname.split('.vrt')[0]):
         inputname=fname
     else:
@@ -218,8 +215,6 @@ def ancillaryLooks(mask, dem, arrshape, standardproduct_info, multilooking,
         if dem is not None:
             prod_wid, prod_height, \
             _, _, _ = get_basic_attrs(dem.GetDescription())
-            print('ref_height, ref_wid', ref_height, ref_wid)
-            print('prod_wid, prod_height', prod_wid, prod_height)
             if (ref_wid != prod_wid) or (ref_height != prod_height):
                 resampleRaster(dem.GetDescription(), multilooking,
                            bounds, prods_TOTbbox, rankedResampling,


### PR DESCRIPTION
Suppress the series of print statements made when running the sequential stitcher, even for verbose mode. They may be toggled manually by users wishing to debug the code, unless @mgovorcin advises otherwise?

Also, fix minor bug whereby program crashes if user specifies a `VRT` output. As with other layers, now default to `ENVI` in cases where user specifies `VRT`