### PR TITLE
Fix bounds for metadata layers

### DIFF
--- a/tools/ARIAtools/ARIA_global_variables.py
+++ b/tools/ARIAtools/ARIA_global_variables.py
@@ -19,9 +19,9 @@ ARIA_EXTERNAL_CORRECTIONS = ['troposphereHydrostatic',
 
 ARIA_INTERNAL_CORRECTIONS = ['ionosphere']
 
-ARIA_TROPO_INTERNAL = ['HRES',
-                     'ERA5',
+ARIA_TROPO_INTERNAL = ['ERA5',
                      'GMAO',
+                     'HRES',
                      'HRRR']
 
 ARIA_TROPO_MODELS = ARIA_TROPO_INTERNAL + ['GACOS']

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1042,7 +1042,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
             handle_epoch_layers(**lyr_input_dict)
 
         # Track consistency of dimensions
-        prev_outname = os.path.abspath(os.path.join(workdir,
+        prev_outname = os.path.abspath(os.path.join(workdir, i,
                                        product_dict[1][0][0]))
         ref_wid, ref_hgt, ref_geotrans, \
             _, _ = get_basic_attrs(prev_outname + '.vrt')

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1264,6 +1264,7 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
 
     # only perform DEM intersection for rasters with valid height levels
     nohgt_lyrs = ['ionosphere']
+    print('INSIDE!!!')
     if metadatalyr_name not in nohgt_lyrs:
         tmp_name = outname+'_temp'
         # Define lat/lon/height arrays for metadata layers
@@ -1326,7 +1327,7 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
               width=arrshape[1], height=arrshape[0],
               options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
     #remove temp files
-    for i in glob.glob(outname+'_temp*'): os.remove(i)
+    for i in glob.glob(outname+'*_temp*'): os.remove(i)
 
     # Update VRT
     gdal.Translate(outname+'.vrt',

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1048,7 +1048,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
                 prev_outname_check = deepcopy(prev_outname)
 
         # track consistency of dimensions
-        if prev_outname_check in locals():
+        if 'prev_outname_check' in locals():
             ref_wid, ref_hgt, ref_geotrans, \
                 _, _ = get_basic_attrs(prev_outname_check + '.vrt')
             ref_arr = [ref_wid, ref_hgt, ref_geotrans,

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -956,7 +956,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
     if not layers and not tropo_total: return # only bbox
 
     # initiate tracker of output dimensions
-    ref_wid = None; ref_height = None ; ref_geotrans = None
+    ref_wid = None; ref_hgt = None ; ref_geotrans = None
 
     # create dictionary of all inputs needed for correction lyr extraction
     lyr_input_dict = {
@@ -1041,6 +1041,14 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
             # extract layers
             handle_epoch_layers(**lyr_input_dict)
 
+        # Track consistency of dimensions
+        prev_outname = os.path.abspath(os.path.join(workdir,
+                                       product_dict[1][0][0]))
+        ref_wid, ref_hgt, ref_geotrans, \
+            _, _ = get_basic_attrs(prev_outname + '.vrt')
+        ref_arr = [ref_wid, ref_hgt, ref_geotrans,
+                   prev_outname]
+
     # If specified, extract solid earth tides
     tropo_lyrs = list(set(tropo_lyrs))
     ext_corr_lyrs = tropo_lyrs + ['solidEarthTide', 'troposphereTotal']
@@ -1071,6 +1079,14 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
 
         # extract layers
         handle_epoch_layers(**lyr_input_dict)
+
+        # Track consistency of dimensions
+        prev_outname = os.path.abspath(os.path.join(workdir,
+                                       product_dict[1][0][0]))
+        ref_wid, ref_hgt, ref_geotrans, \
+            _, _ = get_basic_attrs(prev_outname + '.vrt')
+        ref_arr = [ref_wid, ref_hgt, ref_geotrans,
+                   prev_outname]
 
     # Loop through other user expected layers
     layers = [i for i in layers if i not in ext_corr_lyrs]
@@ -1229,7 +1245,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
             if len(os.listdir(plots_subdir)) == 0:
                 shutil.rmtree(plots_subdir)
 
-    return [ref_height, ref_wid, ref_geotrans, prev_outname]
+    return [ref_hgt, ref_wid, ref_geotrans, prev_outname]
 
 
 def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -940,7 +940,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
     if not layers and not tropo_total: return # only bbox
 
     # initiate tracker of output dimensions
-    ref_wid = None; ref_height = None
+    ref_wid = None; ref_height = None ; ref_geotrans = None
 
     # create dictionary of all inputs needed for correction lyr extraction
     lyr_input_dict = {
@@ -1006,6 +1006,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
             ]
 
             # set iterative keys
+            prev_outname = os.path.abspath(os.path.join(workdir, i))
             prog_bar = progBar.progressBar(maxValue=len(product_dict[0]),
                                        prefix=f'Generating: {model} {key} - ')
             lyr_input_dict['prog_bar'] = prog_bar
@@ -1028,6 +1029,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
             [j["pair_name"] for j in full_product_dict if key in j.keys()]]
 
         workdir = os.path.join(outDir, key)
+        prev_outname = deepcopy(workdir)
         prog_bar = progBar.progressBar(maxValue=len(product_dict[0]),
                                        prefix='Generating: '+key+' - ')
 
@@ -1264,7 +1266,6 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
 
     # only perform DEM intersection for rasters with valid height levels
     nohgt_lyrs = ['ionosphere']
-    print('INSIDE!!!')
     if metadatalyr_name not in nohgt_lyrs:
         tmp_name = outname+'_temp'
         # Define lat/lon/height arrays for metadata layers

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1041,13 +1041,18 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
             # extract layers
             handle_epoch_layers(**lyr_input_dict)
 
-        # Track consistency of dimensions
-        prev_outname = os.path.abspath(os.path.join(workdir, i,
+            # track valid files
+            prev_outname = os.path.abspath(os.path.join(workdir, i,
                                        product_dict[1][0][0]))
-        ref_wid, ref_hgt, ref_geotrans, \
-            _, _ = get_basic_attrs(prev_outname + '.vrt')
-        ref_arr = [ref_wid, ref_hgt, ref_geotrans,
-                   prev_outname]
+            if os.path.exists(prev_outname + '.vrt'):
+                prev_outname_check = deepcopy(prev_outname)
+
+        # track consistency of dimensions
+        if prev_outname_check in locals():
+            ref_wid, ref_hgt, ref_geotrans, \
+                _, _ = get_basic_attrs(prev_outname_check + '.vrt')
+            ref_arr = [ref_wid, ref_hgt, ref_geotrans,
+                       prev_outname]
 
     # If specified, extract solid earth tides
     tropo_lyrs = list(set(tropo_lyrs))

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -418,9 +418,9 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
 
     # Define lat/lon arrays for fullres layers
     gt, xs, ys  = ds_aria.GetGeoTransform(), ds_aria.RasterXSize, ds_aria.RasterYSize
-    Latitude    = np.linspace(gt[3], gt[3]+(gt[5]*ys), ys)
+    Latitude    = np.linspace(gt[3], gt[3]+(gt[5]*(ys-1)), ys)
     Latitude    = np.repeat(Latitude[:, np.newaxis], xs, axis=1)
-    Longitude   = np.linspace(gt[0], gt[0]+(gt[1]*xs), xs)
+    Longitude   = np.linspace(gt[0], gt[0]+(gt[1]*(xs-1)), xs)
     Longitude   = np.repeat(Longitude[:, np.newaxis], ys, axis=1).T
 
     return aria_dem, ds_aria, Latitude, Longitude

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -939,6 +939,9 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
 
     if not layers and not tropo_total: return # only bbox
 
+    # initiate tracker of output dimensions
+    ref_wid = None; ref_height = None
+
     # create dictionary of all inputs needed for correction lyr extraction
     lyr_input_dict = {
             'layers': layers,
@@ -1020,8 +1023,9 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
         key = 'solidEarthTide'
         ref_key = key
         sec_key = key
-        product_dict = [[j[key] for j in full_product_dict], \
-                      [j["pair_name"] for j in full_product_dict]]
+        product_dict = \
+            [[j[key] for j in full_product_dict if key in j.keys()],
+            [j["pair_name"] for j in full_product_dict if key in j.keys()]]
 
         workdir = os.path.join(outDir, key)
         prog_bar = progBar.progressBar(maxValue=len(product_dict[0]),

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -29,8 +29,7 @@ from ARIAtools.unwrapStitching import product_stitch_overlap, \
     product_stitch_2stage
 from ARIAtools.vrtmanager import renderVRT, resampleRaster, layerCheck, \
     get_basic_attrs, ancillaryLooks
-from ARIAtools.sequential_stitching import product_stitch_sequential, \
-    product_stitch_sequential_metadata
+from ARIAtools.sequential_stitching import product_stitch_sequential
 import pyproj
 from pyproj import CRS, Transformer
 from rioxarray import open_rasterio
@@ -357,7 +356,7 @@ class metadata_qualitycheck:
 
 
 def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
-                        proj, arrshape=None, workdir='./',
+                        proj, arrres=None, workdir='./',
                         outputFormat='ENVI', num_threads='2', dem_name: str = 'glo_90'):
     """Function to load and export DEM, lat, lon arrays.
     If "Download" flag is specified, DEM will be downloaded on the fly.
@@ -394,8 +393,9 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
     else:
         gdal.Warp(aria_dem, demfilename, format=outputFormat,
                 cutlineDSName=prods_TOTbbox, outputBounds=bounds,
-                outputType=gdal.GDT_Int16, width=arrshape[1], height=arrshape[0],
-                multithread=True, options=['NUM_THREADS=%s'%(num_threads)])
+                outputType=gdal.GDT_Int16, xRes=arrres[0], yRes=arrres[1],
+                targetAlignedPixels=True, multithread=True,
+                options=['NUM_THREADS=%s'%(num_threads)])
 
         update_file = gdal.Open(aria_dem, gdal.GA_Update)
         update_file.SetProjection(proj); del update_file
@@ -407,7 +407,8 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
         bounds  = list(open_shapefile(prods_TOTbbox_metadatalyr, 0, 0).bounds)
         gt      = ds_aria.GetGeoTransform()
         ds_aria = gdal.Warp('', aria_dem, format='MEM', outputBounds=bounds,
-                                         xRes=abs(gt[1]), yRes=abs(gt[-1]),
+                     xRes=abs(gt[1]), yRes=abs(gt[-1]),
+                     targetAlignedPixels=True,
                      multithread=True, options=['NUM_THREADS=%s'%(num_threads)])
         ds_aria.SetProjection(proj); ds_aria.SetDescription(aria_dem)
 
@@ -433,9 +434,9 @@ def dl_dem(path_dem, path_prod_union, num_threads, dem_name: str = 'glo_90'):
     extent = prod_shapefile.bounds
 
     dem_tile_paths = get_dem_tile_paths(bounds=extent,
-                                        dem_name=dem_name,
-                                        localize_tiles_to_gtiff=(False if dem_name == 'glo_30' else True),
-                                        tile_dir=f'{dem_name}_tiles')
+            dem_name=dem_name,
+            localize_tiles_to_gtiff=(False if dem_name == 'glo_30' else True),
+            tile_dir=f'{dem_name}_tiles')
 
     vrt_path = f'{root}_uncropped.vrt'
     ds = gdal.BuildVRT(vrt_path, dem_tile_paths)
@@ -570,21 +571,31 @@ def merged_productbbox(metadata_dict, product_dict, workdir='./',
         bbox_file=prods_TOTbbox
 
     # Warp the first scene with the output-bounds defined above
-    # ensure output-bounds are an integer multiple of interferometric grid and adjust if necessary
+    # ensure output-bounds are an integer multiple of interferometric grid
+    # and adjust if necessary
     OG_bounds = list(open_shapefile(bbox_file, 0, 0).bounds)
     arrres = gdal.Open(product_dict[0]['unwrappedPhase'][0])
-    arrres = [abs(arrres.GetGeoTransform()[1]), abs(arrres.GetGeoTransform()[-1])]
-    ds = gdal.Warp('', gdal.BuildVRT('', product_dict[0]['unwrappedPhase'][0]), options=gdal.WarpOptions(format="MEM", \
-        outputBounds = OG_bounds, xRes = arrres[0], yRes = arrres[1], targetAlignedPixels = True, \
-        options = ['NUM_THREADS = %s'%(num_threads)]))
+    arrres = [abs(arrres.GetGeoTransform()[1]),
+              abs(arrres.GetGeoTransform()[-1])]
+    ds = gdal.Warp('',
+                   gdal.BuildVRT('', product_dict[0]['unwrappedPhase'][0]),
+                   options=gdal.WarpOptions(format="MEM",
+                   outputBounds = OG_bounds,
+                   xRes = arrres[0], yRes = arrres[1],
+                   targetAlignedPixels = True,
+                   options = ['NUM_THREADS = %s'%(num_threads)]))
     # Get shape of full res layers
-    arrshape=[ds.RasterYSize, ds.RasterXSize]
-    new_bounds = [ds.GetGeoTransform()[0], ds.GetGeoTransform()[3] + (ds.GetGeoTransform()[-1] * arrshape[0]), \
-        ds.GetGeoTransform()[0] + (ds.GetGeoTransform()[1] * arrshape[1]), ds.GetGeoTransform()[3]]
+    arrshape = [ds.RasterYSize, ds.RasterXSize]
+    ds_gt = ds.GetGeoTransform()
+    new_bounds = [ds_gt[0], ds_gt[3] + (ds_gt[-1]*arrshape[0]),
+                  ds_gt[0] + (ds_gt[1] * arrshape[1]), ds_gt[3]]
     if OG_bounds != new_bounds:
         # Use shapely to make list
-        user_bbox = Polygon(np.column_stack((np.array([new_bounds[0],new_bounds[2],new_bounds[2],new_bounds[0],new_bounds[0]]),
-                    np.array([new_bounds[1],new_bounds[1],new_bounds[3],new_bounds[3],new_bounds[1]])))) #Pass lons/lats to create polygon
+        user_bbox = Polygon(np.column_stack((np.array( \
+                            [new_bounds[0], new_bounds[2], new_bounds[2], \
+                            new_bounds[0], new_bounds[0]]),
+                            np.array([new_bounds[1], new_bounds[1], \
+                            new_bounds[3], new_bounds[3], new_bounds[1]]))))
         # Save polygon in shapefile
         bbox_file = os.path.join(os.path.dirname(workdir), 'user_bbox.json')
         save_shapefile(bbox_file, user_bbox, 'GeoJSON')
@@ -595,7 +606,8 @@ def merged_productbbox(metadata_dict, product_dict, workdir='./',
     proj=ds.GetProjection()
     del ds
 
-    return metadata_dict, product_dict, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr, arrshape, proj
+    return metadata_dict, product_dict, bbox_file, prods_TOTbbox, \
+           prods_TOTbbox_metadatalyr, arrres, proj
 
 
 def prep_metadatalayers(outname, metadata_arr, dem, key, layers,
@@ -658,14 +670,7 @@ def prep_metadatalayers(outname, metadata_arr, dem, key, layers,
         for i in tup_outputs:
             # delete temporary files to circumvent potential inconsistent dims
             for j in glob.glob(i[0]+'*'): os.remove(j)
-            # handle expected offset between frames only for SET
-            if key == 'solidEarthTide':
-                product_stitch_sequential_metadata(i[1],
-                                                   output_meta=i[0],
-                                                   output_format=driver,
-                                                   verbose=True)
-            else:
-                gdal.BuildVRT(i[0]+'.vrt', i[1])
+            gdal.BuildVRT(i[0]+'.vrt', i[1])
 
             # write height layers
             gdal.Open(i[0]+'.vrt').SetMetadataItem(hgt_field, \
@@ -842,7 +847,6 @@ def handle_epoch_layers(layers,
                 sec_diff = sec_outname
                 outname_diff = os.path.join(model_dir, 'dates',
                     os.path.basename(ref_diff))
-                print('ref_diff, sec_diff, outname_diff', ref_diff, sec_diff, outname_diff)
                 if not os.path.exists(outname_diff):
                     generate_diff(ref_diff, sec_diff, outname_diff, key,
                       sec_key, tropo_total, hgt_field, outputFormat)
@@ -918,8 +922,8 @@ def handle_epoch_layers(layers,
     return
 
 def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
-                    rankedResampling=False, dem=None, lat=None, lon=None,
-                    mask=None, outDir='./', outputFormat='VRT',
+                    arrres, rankedResampling=False, dem=None, lat=None,
+                    lon=None, mask=None, outDir='./', outputFormat='VRT',
                     stitchMethodType='overlap', verbose=None, num_threads='2',
                     multilooking=None, tropo_total=False, model_names=[]):
     """Export layer and 2D meta-data layers (at the product resolution).
@@ -953,9 +957,11 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
     bounds = open_shapefile(bbox_file, 0, 0).bounds
     lyr_input_dict['bounds'] = bounds
     if dem is not None:
-        dem_bounds = [dem.GetGeoTransform()[0],dem.GetGeoTransform()[3]+ \
-        (dem.GetGeoTransform()[-1]*dem.RasterYSize),dem.GetGeoTransform()[0]+ \
-        (dem.GetGeoTransform()[1]*dem.RasterXSize),dem.GetGeoTransform()[3]]
+        dem_gt = dem.GetGeoTransform()
+        dem_bounds = [dem_gt[0],
+                      dem_gt[3] + (dem_gt[-1]*dem.RasterYSize),
+                      dem_gt[0] + (dem_gt[1]*dem.RasterXSize),
+                      dem_gt[3]]
         lyr_input_dict['dem_bounds'] = dem_bounds
 
     # Mask specified, so file must be physically extracted,
@@ -1049,7 +1055,7 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
         # Iterate through all IFGs
         for i in enumerate(product_dict[0]):
             ifg = product_dict[1][i[0]][0]
-            outname=os.path.abspath(os.path.join(workdir, ifg))
+            outname = os.path.abspath(os.path.join(workdir, ifg))
             ##Update progress bar
             prog_bar.update(i[0]+1,suffix=ifg)
 
@@ -1068,27 +1074,43 @@ def export_products(full_product_dict, bbox_file, prods_TOTbbox, layers,
                                   i[1], mask, outputFormatPhys,
                                   verbose=verbose)
 
-            # Extract/crop full res layers, except for "unw" and "conn_comp" which requires advanced stitching
+            # Extract/crop full res layers, except for "unw" and "conn_comp"
+            # which requires advanced stitching
             elif key!='unwrappedPhase' and \
                  key!='connectedComponents':
                 if outputFormat=='VRT':
                     # building the virtual vrt
                     gdal.BuildVRT(outname+ "_uncropped" +'.vrt', i[1])
                     # building the cropped vrt
-                    gdal.Warp(outname+'.vrt', outname+"_uncropped"+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, options=['NUM_THREADS=%s'%(num_threads)]))
+                    gdal.Warp(outname+'.vrt', outname+"_uncropped"+'.vrt',
+                              options=gdal.WarpOptions(format=outputFormat,
+                              cutlineDSName=prods_TOTbbox,
+                              outputBounds=bounds,
+                              xRes=arrres[0], yRes=arrres[1],
+                              targetAlignedPixels=True,
+                              options=['NUM_THREADS=%s'%(num_threads)]))
                 else:
                     # building the VRT
                     gdal.BuildVRT(outname +'.vrt', i[1])
-                    gdal.Warp(outname, outname+'.vrt', options=gdal.WarpOptions(format=outputFormat, cutlineDSName=prods_TOTbbox, outputBounds=bounds, options=['NUM_THREADS=%s'%(num_threads)]))
+                    gdal.Warp(outname, outname+'.vrt',
+                              options=gdal.WarpOptions(format=outputFormat,
+                              cutlineDSName=prods_TOTbbox,
+                              outputBounds=bounds,
+                              xRes=arrres[0], yRes=arrres[1],
+                              targetAlignedPixels=True,
+                              options=['NUM_THREADS=%s'%(num_threads)]))
 
                     # Update VRT
-                    gdal.Translate(outname+'.vrt', outname, options=gdal.TranslateOptions(format="VRT"))
+                    gdal.Translate(outname+'.vrt', outname,
+                              options=gdal.TranslateOptions(format="VRT"))
 
                     # Apply mask (if specified).
                     if mask is not None:
-                        update_file=gdal.Open(outname,gdal.GA_Update)
-                        update_file.GetRasterBand(1).WriteArray(mask.ReadAsArray()*gdal.Open(outname+'.vrt').ReadAsArray())
-                        del update_file
+                        update_file = gdal.Open(outname,gdal.GA_Update)
+                        mask_arr = mask.ReadAsArray() * \
+                                   gdal.Open(outname + '.vrt').ReadAsArray()
+                        update_file.GetRasterBand(1).WriteArray(mask_arr)
+                        del update_file, mask_arr
 
             # Extract/crop phs and conn_comp layers
             else:
@@ -1194,17 +1216,15 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
     # import dependencies
     from scipy.interpolate import RegularGridInterpolator
 
-    # File must be physically extracted, cannot proceed with VRT format. Defaulting to ENVI format.
-    if outputFormat=='VRT':
-        outputFormat='ENVI'
-
     # get final shape
-    arrshape=gdal.Open(dem.GetDescription()).ReadAsArray().shape
+    arrres = gdal.Open(dem.GetDescription())
+    arrres = [abs(arrres.GetGeoTransform()[1]),
+              abs(arrres.GetGeoTransform()[-1])]
     # load layered metadata array
     tmp_name = outname+'.vrt'
     data_array = gdal.Warp('', tmp_name,
                      options=gdal.WarpOptions(format="MEM",
-                         options=['NUM_THREADS=%s'%(num_threads)]))
+                     options=['NUM_THREADS=%s'%(num_threads)]))
 
     # get minimum version
     version_check = []
@@ -1245,11 +1265,11 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
         latitudeMeta = np.linspace(data_array.GetGeoTransform()[3],
                            data_array.GetGeoTransform()[3] + \
                            (data_array.GetGeoTransform()[5] * \
-                           data_array.RasterYSize), data_array.RasterYSize)
+                           (data_array.RasterYSize-1)), data_array.RasterYSize)
         longitudeMeta = np.linspace(data_array.GetGeoTransform()[0],
                            data_array.GetGeoTransform()[0] + \
                            (data_array.GetGeoTransform()[1] * \
-                           data_array.RasterXSize), data_array.RasterXSize)
+                           (data_array.RasterXSize-1)), data_array.RasterXSize)
 
         da_dem = open_rasterio(dem.GetDescription(), 
                      band_as_variable=True)['band_1']
@@ -1289,14 +1309,15 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
                   cutlineDSName=prods_TOTbbox,
                   outputBounds=bbox_bounds,
                   dstNodata=data_array.GetRasterBand(1).GetNoDataValue(),
-                  width=arrshape[1],
-                  height=arrshape[0],
+                  xRes=arrres[0], yRes=arrres[1], targetAlignedPixels=True,
                   options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
     #remove temp files
     for i in glob.glob(outname+'_temp*'): os.remove(i)
 
     # Update VRT
-    gdal.Translate(outname+'.vrt', outname, options=gdal.TranslateOptions(format="VRT"))
+    gdal.Translate(outname+'.vrt',
+                   outname,
+                   options=gdal.TranslateOptions(format="VRT"))
 
     # Apply mask (if specified)
     if mask is not None:
@@ -1526,7 +1547,7 @@ def gacos_correction(full_product_dict, gacos_products, bbox_file,
             meta = gdal.Info(unwname, format='json')
             geoT = meta['geoTransform']
             proj = meta['coordinateSystem']['wkt']
-            arrshape = list(reversed(meta['size']))
+            arrres = [abs(geoT[1]), abs(geoT[-1])]
 
         tropo_reference = os.path.join(gacos_products, f'{ifg[:8]}.ztd.vrt')
         tropo_secondary = os.path.join(gacos_products, f'{ifg[9:]}.ztd.vrt')
@@ -1605,11 +1626,13 @@ def gacos_correction(full_product_dict, gacos_products, bbox_file,
 
             # Open corresponding tropo products and pass the difference
             tropo_reference = gdal.Warp('', tropo_reference, format="MEM",
-                                      outputBounds=bounds, width=arrshape[1],
-                                      height=arrshape[0]).ReadAsArray()
+                                      outputBounds=bounds, xRes=arrres[0],
+                                      yRes=arrres[1],
+                                      targetAlignedPixels=True).ReadAsArray()
             tropo_secondary = gdal.Warp('', tropo_secondary, format="MEM",
-                                        outputBounds=bounds, width=arrshape[1],
-                                        height=arrshape[0]).ReadAsArray()
+                                      outputBounds=bounds, xRes=arrres[0],
+                                      yRes=arrres[1],
+                                      targetAlignedPixels=True).ReadAsArray()
             tropo_product  = np.subtract(tropo_secondary, tropo_reference)
 
             # Convert troposphere from m to rad
@@ -1718,24 +1741,47 @@ def main(inps=None):
     log.info('Thread count specified for gdal multiprocessing = %s', inps.num_threads)
 
     # extract/merge productBoundingBox layers for each pair and update dict,
-    # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
-    standardproduct_info.products[0], standardproduct_info.products[1], standardproduct_info.bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr, arrshape, proj = merged_productbbox(standardproduct_info.products[0], standardproduct_info.products[1], os.path.join(inps.workdir,'productBoundingBox'), standardproduct_info.bbox_file, inps.croptounion, num_threads=inps.num_threads, minimumOverlap=inps.minimumOverlap, verbose=inps.verbose)
+    # report common track bbox (default is to take common intersection,
+    # but user may specify union), and expected shape for DEM.
+    (standardproduct_info.products[0], standardproduct_info.products[1],
+     standardproduct_info.bbox_file, prods_TOTbbox,
+     prods_TOTbbox_metadatalyr, arrres,
+     proj) = merged_productbbox(standardproduct_info.products[0],
+                                standardproduct_info.products[1],
+                                os.path.join(inps.workdir,
+                                             'productBoundingBox'),
+                                standardproduct_info.bbox_file,
+                                inps.croptounion,
+                                num_threads=inps.num_threads,
+                                minimumOverlap=inps.minimumOverlap,
+                                verbose=inps.verbose)
+
     # Load or download mask (if specified).
     if inps.mask is not None:
-        inps.mask = prep_mask([[item for sublist in [list(set(d['amplitude']))
-                        for d in standardproduct_info.products[1] if 'amplitude' in d] for item in sublist],
-                        [item for sublist in [list(set(d['pair_name'])) for d in
-                        standardproduct_info.products[1] if 'pair_name' in d] for item in sublist]],
-                        inps.mask, standardproduct_info.bbox_file, prods_TOTbbox, proj, amp_thresh=inps.amp_thresh, arrshape=arrshape,
-                        workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+        # Extract amplitude layers
+        amplitude_products = []
+        for d in standardproduct_info.products[1]:
+            if 'amplitude' in d:
+                for item in list(set(d['amplitude'])):
+                    amplitude_products.append(item)
+        inps.mask = prep_mask(amplitude_products, inps.mask,
+                              standardproduct_info.bbox_file,
+                              prods_TOTbbox, proj, amp_thresh=inps.amp_thresh,
+                              arrres=arrres,
+                              workdir=inps.workdir,
+                              outputFormat=inps.outputFormat,
+                              num_threads=inps.num_threads)
 
-    # Download/Load DEM & Lat/Lon arrays, providing bbox, expected DEM shape, and output dir as input.
+    # Download/Load DEM & Lat/Lon arrays, providing bbox,
+    # expected DEM shape, and output dir as input.
     if inps.demfile is not None:
+        print('Download/cropping DEM')
         # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-        inps.demfile, demfile, Latitude, Longitude = prep_dem(inps.demfile,
-                    standardproduct_info.bbox_file, prods_TOTbbox,
-                    prods_TOTbbox_metadatalyr, proj, arrshape=arrshape,
-                    workdir=inps.workdir, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+        inps.demfile, demfile, Latitude, Longitude = prep_dem(
+            inps.demfile, standardproduct_info.bbox_file,
+            prods_TOTbbox, prods_TOTbbox_metadatalyr, proj,
+            arrres=arrres, workdir=inps.workdir,
+            outputFormat=inps.outputFormat, num_threads=inps.num_threads)
     else:
         demfile, Latitude, Longitude = None, None, None
 
@@ -1746,6 +1792,7 @@ def main(inps=None):
         'bbox_file': standardproduct_info.bbox_file,
         'prods_TOTbbox': prods_TOTbbox,
         'layers': inps.layers,
+        'arrres': arrres,
         'rankedResampling': inps.rankedResampling,
         'dem': demfile,
         'lat': Latitude,
@@ -1781,8 +1828,9 @@ def main(inps=None):
     # Perform GACOS-based tropospheric corrections (if specified).
     if inps.gacos_products:
         gacos_correction(standardproduct_info.products, inps.gacos_products,
-                         standardproduct_info.bbox_file, prods_TOTbbox, outDir=inps.workdir,
-                         outputFormat=inps.outputFormat, verbose=inps.verbose, num_threads=inps.num_threads)
+                         standardproduct_info.bbox_file, prods_TOTbbox,
+                         outDir=inps.workdir, outputFormat=inps.outputFormat,
+                         verbose=inps.verbose, num_threads=inps.num_threads)
 
 
 def transformPoints(lats: np.ndarray, lons: np.ndarray, hgts: np.ndarray, old_proj: CRS, new_proj: CRS) -> np.ndarray:

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1314,11 +1314,13 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
         latitudeMeta = np.linspace(data_array.GetGeoTransform()[3],
                            data_array.GetGeoTransform()[3] + \
                            (data_array.GetGeoTransform()[5] * \
-                           (data_array.RasterYSize-1)), data_array.RasterYSize)
+                           (data_array.RasterYSize-1)), data_array.RasterYSize,
+                           dtype='float32')
         longitudeMeta = np.linspace(data_array.GetGeoTransform()[0],
                            data_array.GetGeoTransform()[0] + \
                            (data_array.GetGeoTransform()[1] * \
-                           (data_array.RasterXSize-1)), data_array.RasterXSize)
+                           (data_array.RasterXSize-1)), data_array.RasterXSize,
+                           dtype='float32')
 
         da_dem = open_rasterio(dem.GetDescription(), 
                      band_as_variable=True)['band_1']
@@ -1332,8 +1334,9 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
         pnts = transformPoints(lat, lon, da_dem1.data, 'EPSG:4326', 'EPSG:4326')
 
         # set up the interpolator with the GUNW cube
+        data_array_inp = data_array.ReadAsArray().astype('float32')
         interper = RegularGridInterpolator((latitudeMeta, longitudeMeta,
-                   heightsMeta), data_array.ReadAsArray().transpose(1, 2, 0),
+                   heightsMeta), data_array_inp.transpose(1, 2, 0),
                    fill_value=np.nan, bounds_error=False)
 
         # interpolate cube to DEM points
@@ -1935,6 +1938,6 @@ def transformPoints(lats: np.ndarray, lons: np.ndarray, hgts: np.ndarray, old_pr
         res = t.transform(lats, lons, hgts)
 
     if out_flip == 'east':
-        return np.stack((res[1], res[0], res[2]), axis=-1).T
+        return np.stack((res[1], res[0], res[2]), axis=-1, dtype='float32').T
     else:
-        return np.stack(res, axis=-1).T
+        return np.stack(res, axis=-1, dtype='float32').T

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -423,9 +423,9 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
 
     # Define lat/lon arrays for fullres layers
     gt, xs, ys  = ds_aria.GetGeoTransform(), ds_aria.RasterXSize, ds_aria.RasterYSize
-    Latitude    = np.linspace(gt[3], gt[3]+(gt[5]*ys), ys)
+    Latitude    = np.linspace(gt[3], gt[3]+(gt[5]*(ys-1)), ys)
     Latitude    = np.repeat(Latitude[:, np.newaxis], xs, axis=1)
-    Longitude   = np.linspace(gt[0], gt[0]+(gt[1]*xs), xs)
+    Longitude   = np.linspace(gt[0], gt[0]+(gt[1]*(xs-1)), xs)
     Longitude   = np.repeat(Longitude[:, np.newaxis], ys, axis=1).T
 
     return aria_dem, ds_aria, Latitude, Longitude
@@ -1270,15 +1270,10 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
         heightsMeta = np.array(gdal.Open(outname+'.vrt').GetMetadataItem( \
              hgt_field)[1:-1].split(','), dtype='float32')
 
-        latitudeMeta = np.linspace(data_array.GetGeoTransform()[3],
-                           data_array.GetGeoTransform()[3] + \
-                           (data_array.GetGeoTransform()[5] * \
-                           data_array.RasterYSize-1), data_array.RasterYSize)
-        longitudeMeta = np.linspace(data_array.GetGeoTransform()[0],
-                           data_array.GetGeoTransform()[0] + \
-                           (data_array.GetGeoTransform()[1] * \
-                           data_array.RasterXSize-1), data_array.RasterXSize)
-
+        gt = data_array.GetGeoTransform()
+        xs, ys = data_array.RasterXSize, data_array.RasterYSize
+        latitudeMeta = np.linspace(gt[3], gt[3]+(gt[5]*(ys-1)), ys)
+        longitudeMeta = np.linspace(gt[0], gt[0]+(gt[1]*(xs-1)), xs)
         da_dem = open_rasterio(dem.GetDescription(), 
                      band_as_variable=True)['band_1']
 
@@ -1317,8 +1312,6 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem, \
                   cutlineDSName=prods_TOTbbox,
                   outputBounds=bbox_bounds,
                   dstNodata=data_array.GetRasterBand(1).GetNoDataValue(),
-                  width=arrshape[1],
-                  height=arrshape[0],
                   options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
     #remove temp files
     for i in glob.glob(outname+'_temp*'): os.remove(i)

--- a/tools/ARIAtools/mask_util.py
+++ b/tools/ARIAtools/mask_util.py
@@ -26,7 +26,7 @@ logger.setLevel(logging.DEBUG)
 
 
 def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj,
-                    amp_thresh=None, arrres=None, workdir='./',
+                    amp_thresh=None, arrshape=None, workdir='./',
                     outputFormat='ENVI', num_threads='2'):
     """Function to load and export mask file.
     If "Download" flag, GSHHS water mask will be donwloaded on the fly.
@@ -48,7 +48,8 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj,
     # Get bounds of user bbox_file
     bounds = open_shapefile(bbox_file, 0, 0).bounds
 
-    # File must be physically extracted, cannot proceed with VRT format. Defaulting to ENVI format.
+    # File must be physically extracted, cannot proceed with VRT format
+    # Defaulting to ENVI format.
     if outputFormat=='VRT':
         outputFormat='ENVI'
 
@@ -57,20 +58,20 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj,
         log.info("***Downloading water mask... ***")
         maskfilename=os.path.join(workdir,'watermask'+'.msk')
         os.environ['CPL_ZIP_ENCODING'] = 'UTF-8'
-        ###Make coastlines/islands union VRT
-        renderOGRVRT(os.path.join(workdir,'watermsk_shorelines.vrt'), _world_watermask[::2])
-        ###Make lakes/ponds union VRT
-        renderOGRVRT(os.path.join(workdir,'watermsk_lakes.vrt'), _world_watermask[1::2])
+        # Make coastlines/islands union VRT
+        renderOGRVRT(os.path.join(workdir,'watermsk_shorelines.vrt'),
+                     _world_watermask[::2])
+        # Make lakes/ponds union VRT
+        renderOGRVRT(os.path.join(workdir,'watermsk_lakes.vrt'),
+                     _world_watermask[1::2])
 
-        ###Initiate water-mask with coastlines/islands union VRT
+        # Initiate water-mask with coastlines/islands union VRT
         # save uncropped mask
         gdal.Rasterize(os.path.join(workdir,'watermask_uncropped.msk'),
                        os.path.join(workdir,'watermsk_shorelines.vrt'),
                        format=outputFormat, outputBounds=bounds,
-                       outputType=gdal.GDT_Byte,
-                       xRes=arrres[0], yRes=arrres[1],
-                       targetAlignedPixels=True, burnValues=[1],
-                       layers='merged')
+                       outputType=gdal.GDT_Byte, width=arrshape[1],
+                       height=arrshape[0], burnValues=[1], layers='merged')
         gdal.Translate(os.path.join(workdir,'watermask_uncropped.msk.vrt'),
                        os.path.join(workdir,'watermask_uncropped.msk'),
                        format="VRT")
@@ -78,29 +79,30 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj,
         gdal.Warp(maskfilename,
                   os.path.join(workdir,'watermask_uncropped.msk.vrt'),
                   format=outputFormat, outputBounds=bounds,
-                  outputType=gdal.GDT_Byte, xRes=arrres[0], yRes=arrres[1],
-                  targetAlignedPixels=True, multithread=True,
+                  outputType=gdal.GDT_Byte, width=arrshape[1],
+                  height=arrshape[0], multithread=True,
                   options=['NUM_THREADS=%s'%(num_threads)])
 
-        update_file=gdal.Open(maskfilename,gdal.GA_Update)
+        update_file = gdal.Open(maskfilename, gdal.GA_Update)
         update_file.SetProjection(proj)
-        update_file.GetRasterBand(1).SetNoDataValue(0.); del update_file
+        update_file.GetRasterBand(1).SetNoDataValue(0.)
+        del update_file
         gdal.Translate(f'{maskfilename}.vrt', maskfilename, format='VRT')
 
         # Take inverse of lakes/ponds union because of opposite designation
         # (1 for water, 0 for land) as desired (0 for water, 1 for land)
         lake_masks = gdal.Rasterize('',
-                  os.path.join(workdir,'watermsk_lakes.vrt'), format='MEM',
-                  outputBounds=bounds, outputType=gdal.GDT_Byte,
-                  xRes=arrres[0], yRes=arrres[1], targetAlignedPixels=True,
-                  burnValues=[1], layers='merged', inverse=True)
+                os.path.join(workdir,'watermsk_lakes.vrt'),
+                format='MEM', outputBounds=bounds, outputType=gdal.GDT_Byte,
+                width=arrshape[1], height=arrshape[0], burnValues=[1],
+                layers='merged', inverse=True)
 
         lake_masks.SetProjection(proj)
         lake_masks = lake_masks.ReadAsArray()
 
         ## Update water-mask with lakes/ponds union
         mask_file = gdal.Open(maskfilename, gdal.GA_Update)
-        mask_array = lake_masks*gdal.Open(maskfilename).ReadAsArray()
+        mask_array = lake_masks * gdal.Open(maskfilename).ReadAsArray()
         mask_file.GetRasterBand(1).WriteArray(mask_array)
         #Delete temp files
         del lake_masks, mask_file
@@ -109,7 +111,7 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj,
     elif os.path.basename(maskfilename).lower().startswith('nlcd'):
         log.info("***Accessing and cropping the NLCD mask...***")
         maskfilename = NLCDMasker(os.path.dirname(workdir), product_dict)(
-                                  proj, bounds, arrres, outputFormat)
+                                  proj, bounds, arrshape, outputFormat)
 
     ## User specified mask
     else:
@@ -129,13 +131,14 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj,
             ds = gdal.BuildVRT(f'{local_mask_unc}.vrt', user_mask,
                                                     outputBounds=bounds)
 
-            assert ds is not None, f'GDAL could not open user mask: {user_mask}'
+            assert ds is not None, \
+                f'GDAL could not open user mask: {user_mask}'
 
             # crop the user mask and write
             gdal.Warp(f'{local_mask}', ds,
                       format=outputFormat, cutlineDSName=prods_TOTbbox,
-                      outputBounds=bounds, xRes=arrres[0], yRes=arrres[1],
-                      targetAlignedPixels=True, multithread=True,
+                      outputBounds=bounds, width=arrshape[1],
+                      height=arrshape[0], multithread=True,
                       options=[f'NUM_THREADS={num_threads}'])
 
             # set projection of the local mask
@@ -164,8 +167,7 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj,
     # crop/expand mask to DEM size?
     gdal.Warp(maskfilename, maskfilename, format=outputFormat,
               cutlineDSName=prods_TOTbbox, outputBounds=bounds,
-              xRes=arrres[0], yRes=arrres[1], targetAlignedPixels=True,
-              multithread=True,
+              width=arrshape[1], height=arrshape[0], multithread=True,
               options=[f'NUM_THREADS={num_threads} -overwrite'])
     mask = gdal.Open(maskfilename, gdal.GA_Update)
     mask.SetProjection(proj)
@@ -201,47 +203,49 @@ def make_mask(ds_crop, lc):
 
     arr = np.where(np.isnan(arr), np.nan, 1)
     ds  = arr2ds(ds_crop, arr)
+
     return ds
 
 
-def resamp(src, proj, bounds, arrres, view=False):
+def resamp(src, proj, bounds, arrshape, view=False):
     """ Resample a dataset from src dims using result of merged_productbbox """
     if isinstance(src, str) and op.exists(src):
         src = gdal.Open(src, gdal.GA_ReadOnly)
     path = path if op.exists(src.GetDescription()) else ''
 
     ## compute geotranform
-    pix_width, pix_height = arrres
-    pix_width *= np.sign(bounds[2] - bounds[0])
-    pix_height *= np.sign(bounds[1] - bounds[3])
-    width = (bounds[2] - bounds[0]) / pix_width
-    height = (bounds[1] - bounds[3]) / pix_height
+    height, width = arrshape
+    pix_width = (bounds[2] - bounds[0]) / width
+    pix_height = (bounds[1] - bounds[3]) / height
     gt = [bounds[0], pix_width, 0, bounds[3], 0, pix_height]
 
     if path:
         dst = gdal.GetDriverByName('ENVI').Create(path, width, height, 1,
-                                                        gdalconst.GDT_Float32)
+                                                  gdalconst.GDT_Float32)
 
     else:
         dst = gdal.GetDriverByName('MEM').Create(path, width, height, 1,
-                                                        gdalconst.GDT_Int16)
+                                                 gdalconst.GDT_Int16)
 
     dst.SetGeoTransform(gt)
     dst.SetProjection(proj)
     gdal.ReprojectImage(src, dst, src.GetProjection(), proj,
-                                                gdalconst.GRA_NearestNeighbour)
+                        gdalconst.GRA_NearestNeighbour)
     del src
+
     return dst
 
 
 def crop_ds(path_raster, path_poly, path_write=''):
-    """ Crop path_raster (or dataset opened with gdal) to a polygon on disk """
-    assert op.exists(path_raster) or path_raster.startswith('/vsi'), 'Invalid path to NLCD mask'
+    """ Crop path_raster to a polygon on disk """
+    assert op.exists(path_raster) or \
+        path_raster.startswith('/vsi'), 'Invalid path to NLCD mask'
     path_raster = gdal.BuildVRT('', path_raster)
-    ds          = gdal.Warp(path_write, path_raster, format='VRT', cutlineDSName=path_poly,
-                                             cropToCutline=True, dstNodata=0)
+    ds = gdal.Warp(path_write, path_raster, format='VRT',
+                   cutlineDSName=path_poly, cropToCutline=True, dstNodata=0)
 
     if path_write: ds_vrt = gdal.BuildVRT('{}.vrt'.format(path_write), ds)
+
     return ds
 
 
@@ -249,8 +253,9 @@ def arr2ds(ds_orig, arr, noData=0):
     """Create a new dataset identical to ds_orig except with values of 'arr'
     Performed in memory
     """
-    ds_orig = gdal.Open(ds_orig, gdal.GA_ReadOnly) if isinstance(ds_orig, str) else ds_orig
-    arr     = np.where(np.isnan(arr), noData, arr)
+    ds_orig = gdal.Open(ds_orig, gdal.GA_ReadOnly) \
+        if isinstance(ds_orig, str) else ds_orig
+    arr = np.where(np.isnan(arr), noData, arr)
 
     if arr.ndim == 3:
         ds_out = gdal.GetDriverByName('MEM').Create('', ds_orig.RasterXSize,
@@ -268,6 +273,7 @@ def arr2ds(ds_orig, arr, noData=0):
     ds_out.SetGeoTransform(ds_orig.GetGeoTransform())
     ds_out.SetProjection(ds_orig.GetProjection())
     del ds_orig
+
     return ds_out
 
 
@@ -281,7 +287,7 @@ class NLCDMasker(object):
         gdal.PushErrorHandler('CPLQuietErrorHandler')
 
 
-    def __call__(self, proj, bounds, arrres, outputFormat='ENVI', test=False):
+    def __call__(self, proj, bounds, arrshape, outputFormat='ENVI', test=False):
         """ view=True to plot the mask; test=True to apply mask to dummy data """
         # File must be physically extracted, cannot proceed with VRT format. Defaulting to ENVI format.
         if outputFormat=='VRT':
@@ -296,7 +302,7 @@ class NLCDMasker(object):
 
         ## resample the mask to the size of the products (mimic ariaExtract)
         log.info('Resampling NLCD to selected bbox...')
-        ds_resamp = resamp(ds_crop, proj, bounds, arrres)
+        ds_resamp = resamp(ds_crop, proj, bounds, arrshape)
 
         ## mask the landcover classes in lc
         log.info('Masking water and wetlands...')
@@ -320,10 +326,9 @@ class NLCDMasker(object):
         if test:
             # create temporary reference file to access geolocation info
             self.path_temp = gdal.Warp('', self.product_dict[0][1],
-                                       xRes=arrres[0], yRes=arrres[1],
-                                       targetAlignedPixels=True,
+                                       width=arrshape[1], height=arrshape[0],
                                        options=gdal.WarpOptions(format="MEM",
-                                           outputBounds=bounds))
+                                       outputBounds=bounds))
             self.__test__(ds_mask)
             self.path_temp = None
 
@@ -346,7 +351,7 @@ class NLCDMasker(object):
 
 
     def _dummy_data(self, ds2match):
-        """ Create raster of dummy data using the dem (for sizing); For test """
+        """ Create raster of dummy data using the dem (for sizing) """
         if isinstance(ds2match, str) and op.exists(ds2match):
             arr = gdal.Open(ds2match, gdal.GA_ReadOnly).ReadAsArray()
         else:
@@ -356,6 +361,7 @@ class NLCDMasker(object):
         arr = np.ones(arr.shape) * 10
         ds  = arr2ds(ds2match, arr)
         arr1 = ds.ReadAsArray()
+
         return ds
 
 
@@ -365,4 +371,5 @@ class NLCDMasker(object):
         arr = np.where(arr == 0, np.nan, 1)
         masked    = ds_2mask.ReadAsArray() * arr
         ds_masked = arr2ds(ds_mask, masked)
+
         return ds_masked

--- a/tools/ARIAtools/mask_util.py
+++ b/tools/ARIAtools/mask_util.py
@@ -214,8 +214,8 @@ def resamp(src, proj, bounds, arrres, view=False):
     pix_width, pix_height = arrres
     pix_width *= np.sign(bounds[2] - bounds[0])
     pix_height *= np.sign(bounds[1] - bounds[3])
-    width = (bounds[2] - bounds[0]) / pix_width
-    height = (bounds[1] - bounds[3]) / pix_height
+    width = int((bounds[2] - bounds[0]) / pix_width)
+    height = int((bounds[1] - bounds[3]) / pix_height)
     gt = [bounds[0], pix_width, 0, bounds[3], 0, pix_height]
 
     if path:
@@ -223,7 +223,8 @@ def resamp(src, proj, bounds, arrres, view=False):
                                                         gdalconst.GDT_Float32)
 
     else:
-        dst = gdal.GetDriverByName('MEM').Create(path, width, height, 1,
+        print('width, height', width, height)
+        dst = gdal.GetDriverByName('MEM').Create('', width, height, 1,
                                                         gdalconst.GDT_Int16)
 
     dst.SetGeoTransform(gt)

--- a/tools/ARIAtools/mask_util.py
+++ b/tools/ARIAtools/mask_util.py
@@ -121,6 +121,7 @@ def prep_mask(product_dict, maskfilename, bbox_file, prods_TOTbbox, proj,
         if user_mask == local_mask:
             log.warning('The mask you specified already exists in %s, '\
                     'using the existing one...', os.path.dirname(local_mask))
+            ds = gdal.Open(local_mask)
 
         else:
             # move the mask to the local directory and built a VRT for it

--- a/tools/ARIAtools/productPlot.py
+++ b/tools/ARIAtools/productPlot.py
@@ -93,13 +93,14 @@ class PlotClass(object):
     mpl._log.setLevel('ERROR')
 
     def __init__(self, product_dict, workdir='./', bbox_file=None,
-                        prods_TOTbbox=None, mask=None, outputFormat='ENVI',
-                        croptounion=False, num_threads='2'):
+                 prods_TOTbbox=None, arrres=None, mask=None,
+                 outputFormat='ENVI', croptounion=False, num_threads='2'):
         # Pass inputs, and initialize list of pairs
         self.product_dict  = product_dict
         self.bbox_file     = bbox_file
         self.workdir       = os.path.join(workdir,'figures')
         self.prods_TOTbbox = prods_TOTbbox
+        self.arrres        = arrres
         self.mask          = mask
         self.outputFormat  = outputFormat
         self.croptounion   = croptounion
@@ -407,8 +408,10 @@ class PlotClass(object):
         outname = os.path.join(self.workdir, f'avgcoherence{self.mask_ext}')
 
         ## Make average coherence raster
-        coh_file = rasterAverage(outname, self.product_dict[0], self.bbox_file,
-                            self.prods_TOTbbox, outputFormat=self.outputFormat)
+        coh_file = rasterAverage(outname, self.product_dict[0],
+                                 self.bbox_file,
+                                 self.prods_TOTbbox, self.arrres,
+                                 outputFormat=self.outputFormat)
 
         # Apply mask (if specified).
         if self.mask is not None:
@@ -618,7 +621,7 @@ def main(inps=None):
         # report common track bbox (default is to take common intersection, but user may specify union), and expected shape for DEM.
         standardproduct_info.products[0], standardproduct_info.products[1], \
         standardproduct_info.bbox_file, prods_TOTbbox, \
-            prods_TOTbbox_metadatalyr, arrshape, proj = merged_productbbox(
+            prods_TOTbbox_metadatalyr, arrres, proj = merged_productbbox(
             standardproduct_info.products[0], standardproduct_info.products[1],
             os.path.join(inps.workdir, 'productBoundingBox'),
             standardproduct_info.bbox_file, inps.croptounion,
@@ -632,33 +635,33 @@ def main(inps=None):
     # Make spatial extent plot
     if inps.plottracks:
         log.info("- Make plot of track latitude extents vs bounding bbox/common track extent.")
-        make_plot=PlotClass([[j['productBoundingBox'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, croptounion=inps.croptounion)
+        make_plot=PlotClass([[j['productBoundingBox'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, arrres=None, croptounion=inps.croptounion)
         make_plot.plot_extents(figwidth=inps.figwidth)
 
 
     # Make pbaseline plot
     if inps.plotbperp:
         log.info("- Make baseline plot and histogram.")
-        make_plot=PlotClass([[j['bPerpendicular'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir)
+        make_plot=PlotClass([[j['bPerpendicular'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], arrres=None, workdir=inps.workdir)
         make_plot.plot_pbaselines()
 
 
     # Make average land coherence plot
     if inps.plotcoh:
         log.info("- Make average IFG coherence plot in time, and histogram of average IFG coherence.")
-        make_plot=PlotClass([[j['coherence'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, mask=inps.mask, num_threads=inps.num_threads)
+        make_plot=PlotClass([[j['coherence'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, arrres=None, mask=inps.mask, num_threads=inps.num_threads)
         make_plot.plot_coherence()
 
 
     # Generate average land coherence raster
     if inps.makeavgoh:
         log.info("- Generate 2D raster of average coherence.")
-        make_plot=PlotClass([[j['coherence'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, mask=inps.mask, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
+        make_plot=PlotClass([[j['coherence'] for j in standardproduct_info.products[1]], [j["pair_name"] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, arrres=None, mask=inps.mask, outputFormat=inps.outputFormat, num_threads=inps.num_threads)
         make_plot.plot_avgcoherence()
 
 
     # Make pbaseline/coherence combo plot
     if inps.plotbperpcoh:
         log.info("- Make baseline plot that is color-coded with respect to mean IFG coherence.")
-        make_plot=PlotClass([[j['bPerpendicular'] for j in standardproduct_info.products[1]],  [j["pair_name"] for j in standardproduct_info.products[1]], [j['coherence'] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, mask=inps.mask)
+        make_plot=PlotClass([[j['bPerpendicular'] for j in standardproduct_info.products[1]],  [j["pair_name"] for j in standardproduct_info.products[1]], [j['coherence'] for j in standardproduct_info.products[1]]], workdir=inps.workdir, bbox_file=standardproduct_info.bbox_file, prods_TOTbbox=prods_TOTbbox, arrres=None, mask=inps.mask)
         make_plot.plotbperpcoh()

--- a/tools/ARIAtools/sequential_stitching.py
+++ b/tools/ARIAtools/sequential_stitching.py
@@ -487,6 +487,7 @@ def _metadata_offset(unw1 : NDArray, unw2 : NDArray,
 
 def product_stitch_sequential(input_unw_files : List[str],
                              input_conncomp_files : List[str],
+                             arrres : List[float],
                              output_unw : Optional[str] = './unwMerged',
                              output_conn : Optional[str] = './connCompMerged',
                              output_format : Optional[str] = 'ENVI',
@@ -704,8 +705,10 @@ def product_stitch_sequential(input_unw_files : List[str],
                        str(input.with_suffix('.vrt')),
                        format=output_format,
                        cutlineDSName=clip_json,
-                       outputBounds=bounds,
+                       xRes=arrres[0], yRes=arrres[1],
+                       targetAlignedPixels=True,
                        #cropToCutline = True,
+                       outputBounds=bounds
                     )
         ds = None
         # Update VRT
@@ -747,7 +750,7 @@ def product_stitch_sequential(input_unw_files : List[str],
 
     # Remove temp files
     [ii.unlink() for ii in [temp_unw_out, 
-                            temp_unw_out] if ii.exists()]
+                            temp_unw_out] if ii.exists()]              
 
     return
 
@@ -954,16 +957,16 @@ def get_GUNW_array(filename : Union[str, Path],
     return data
 
 def write_GUNW_array(output_filename: Union[str, Path], 
-                     array: np.ndarray, 
-                     snwe: list,
+                     array:np.ndarray, 
+                     snwe:list,
                      nodata: Optional[str] = 'NAN',
-                     format: Optional[str] ='ENVI',
-                     epsg: Optional[int]= 4326,
-                     add_vrt: Optional[bool] = True, 
-                     verbose: Optional[bool] = False,
-                     update_mode: Optional[bool] = True) -> None:
+                     format : Optional[str] ='ENVI',
+                     epsg : Optional[int]= 4326,
+                     add_vrt : Optional[bool] = True, 
+                     verbose : Optional[bool] = False,
+                     update_mode : Optional[bool] = True) -> None:
     """
-    Use GDAL to write raster
+    Use GDAl to write raster 
 
     Parameters
     ----------
@@ -1052,7 +1055,7 @@ def write_GUNW_array(output_filename: Union[str, Path],
         # Build virtual VRT  
         vrt = gdal.BuildVRT(str(output_vrt), str(output), srcNodata=nodata)
         vrt.FlushCache()
-        vrt = None
+        vrt = None      
 
 # Extract overlap bounds
 def frame_overlap(snwe1 : list,

--- a/tools/ARIAtools/sequential_stitching.py
+++ b/tools/ARIAtools/sequential_stitching.py
@@ -743,7 +743,11 @@ def product_stitch_sequential(input_unw_files : List[str],
     # NOTE: saving output figure adds 4 seconds 
     if save_fig:
         plot_GUNW_stitched(str(output_unw.with_suffix('.vrt')),
-                           str(output_conn.with_suffix('.vrt')))                
+                           str(output_conn.with_suffix('.vrt')))
+
+    # Remove temp files
+    [ii.unlink() for ii in [temp_unw_out, 
+                            temp_unw_out] if ii.exists()]
 
     return
 

--- a/tools/ARIAtools/sequential_stitching.py
+++ b/tools/ARIAtools/sequential_stitching.py
@@ -954,16 +954,16 @@ def get_GUNW_array(filename : Union[str, Path],
     return data
 
 def write_GUNW_array(output_filename: Union[str, Path], 
-                     array:np.ndarray, 
-                     snwe:list,
+                     array: np.ndarray, 
+                     snwe: list,
                      nodata: Optional[str] = 'NAN',
-                     format : Optional[str] ='ENVI',
-                     epsg : Optional[int]= 4326,
-                     add_vrt : Optional[bool] = True, 
-                     verbose : Optional[bool] = False,
-                     update_mode : Optional[bool] = True) -> None:
+                     format: Optional[str] ='ENVI',
+                     epsg: Optional[int]= 4326,
+                     add_vrt: Optional[bool] = True, 
+                     verbose: Optional[bool] = False,
+                     update_mode: Optional[bool] = True) -> None:
     """
-    Use GDAl to write raster 
+    Use GDAL to write raster
 
     Parameters
     ----------
@@ -1052,7 +1052,7 @@ def write_GUNW_array(output_filename: Union[str, Path],
         # Build virtual VRT  
         vrt = gdal.BuildVRT(str(output_vrt), str(output), srcNodata=nodata)
         vrt.FlushCache()
-        vrt = None      
+        vrt = None
 
 # Extract overlap bounds
 def frame_overlap(snwe1 : list,

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -412,7 +412,7 @@ def main(inps=None):
     # but user may specify union), and expected shape for DEM.
     (standardproduct_info.products[0], standardproduct_info.products[1],
      standardproduct_info.bbox_file, prods_TOTbbox,
-     prods_TOTbbox_metadatalyr, arrres,
+     prods_TOTbbox_metadatalyr, arrshape,
      proj) = merged_productbbox(standardproduct_info.products[0],
                                 standardproduct_info.products[1],
                                 os.path.join(inps.workdir,
@@ -431,7 +431,7 @@ def main(inps=None):
         inps.demfile, demfile, Latitude, Longitude = prep_dem(
             inps.demfile, standardproduct_info.bbox_file,
             prods_TOTbbox, prods_TOTbbox_metadatalyr, proj,
-            arrres=arrres, workdir=inps.workdir,
+            arrshape=arrshape, workdir=inps.workdir,
             outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Load or download mask (if specified).
@@ -445,7 +445,7 @@ def main(inps=None):
         inps.mask = prep_mask(amplitude_products, inps.mask,
                               standardproduct_info.bbox_file,
                               prods_TOTbbox, proj, amp_thresh=inps.amp_thresh,
-                              arrres=arrres,
+                              arrshape=arrshape,
                               workdir=inps.workdir,
                               outputFormat=inps.outputFormat,
                               num_threads=inps.num_threads)
@@ -456,7 +456,6 @@ def main(inps=None):
         'bbox_file': standardproduct_info.bbox_file,
         'prods_TOTbbox': prods_TOTbbox,
         'dem': demfile,
-        'arrres': arrres,
         'lat': Latitude,
         'lon': Longitude,
         'mask': inps.mask,

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -530,11 +530,10 @@ def main(inps=None):
         dim_check(ref_arr_record, prod_arr_record)
 
     # If necessary, resample DEM/mask AFTER they have been used to extract
-    # If necessary, resample DEM/mask AFTER they have been used to extract
     ancillary_dict = {
         'mask': inps.mask,
         'dem': demfile,
-        'arrshape': arrshape,
+        'arrshape': ref_arr_record,
         'standardproduct_info': standardproduct_info,
         'multilooking': inps.multilooking,
         'prods_TOTbbox': prods_TOTbbox,

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -412,7 +412,7 @@ def main(inps=None):
     # but user may specify union), and expected shape for DEM.
     (standardproduct_info.products[0], standardproduct_info.products[1],
      standardproduct_info.bbox_file, prods_TOTbbox,
-     prods_TOTbbox_metadatalyr, arrshape,
+     prods_TOTbbox_metadatalyr, arrres,
      proj) = merged_productbbox(standardproduct_info.products[0],
                                 standardproduct_info.products[1],
                                 os.path.join(inps.workdir,
@@ -431,7 +431,7 @@ def main(inps=None):
         inps.demfile, demfile, Latitude, Longitude = prep_dem(
             inps.demfile, standardproduct_info.bbox_file,
             prods_TOTbbox, prods_TOTbbox_metadatalyr, proj,
-            arrshape=arrshape, workdir=inps.workdir,
+            arrres=arrres, workdir=inps.workdir,
             outputFormat=inps.outputFormat, num_threads=inps.num_threads)
 
     # Load or download mask (if specified).
@@ -445,7 +445,7 @@ def main(inps=None):
         inps.mask = prep_mask(amplitude_products, inps.mask,
                               standardproduct_info.bbox_file,
                               prods_TOTbbox, proj, amp_thresh=inps.amp_thresh,
-                              arrshape=arrshape,
+                              arrres=arrres,
                               workdir=inps.workdir,
                               outputFormat=inps.outputFormat,
                               num_threads=inps.num_threads)
@@ -456,6 +456,7 @@ def main(inps=None):
         'bbox_file': standardproduct_info.bbox_file,
         'prods_TOTbbox': prods_TOTbbox,
         'dem': demfile,
+        'arrres': arrres,
         'lat': Latitude,
         'lon': Longitude,
         'mask': inps.mask,

--- a/tools/ARIAtools/unwrapStitching.py
+++ b/tools/ARIAtools/unwrapStitching.py
@@ -268,33 +268,49 @@ class Stitching:
         # remove existing output file(s)
         for file in glob.glob(self.outFileUnw + "*"):
             os.remove(file)
-        gdal.BuildVRT(self.outFileUnw+'.vrt', unwFiles, options=gdal.BuildVRTOptions(srcNodata=0))
-        gdal.Warp(self.outFileUnw, self.outFileUnw+'.vrt', options=gdal.WarpOptions(format=self.outputFormat, cutlineDSName=self.setTotProdBBoxFile, outputBounds=self.bbox_file))
+        gdal.BuildVRT(self.outFileUnw+'.vrt', unwFiles,
+                      options=gdal.BuildVRTOptions(srcNodata=0))
+        gdal.Warp(self.outFileUnw, self.outFileUnw+'.vrt',
+                  options=gdal.WarpOptions(format=self.outputFormat,
+                  cutlineDSName=self.setTotProdBBoxFile,
+                  outputBounds=self.bbox_file))
         # Update VRT
-        gdal.Translate(self.outFileUnw+'.vrt', self.outFileUnw, options=gdal.TranslateOptions(format="VRT"))
+        gdal.Translate(self.outFileUnw+'.vrt', self.outFileUnw,
+                       options=gdal.TranslateOptions(format="VRT"))
         # Apply mask (if specified).
         if self.mask is not None:
-            update_file=gdal.Open(self.outFileUnw,gdal.GA_Update)
-            update_file=update_file.GetRasterBand(1).WriteArray(self.mask.ReadAsArray()*gdal.Open(self.outFileUnw+'.vrt').ReadAsArray())
-            update_file=None
+            update_file = gdal.Open(self.outFileUnw, gdal.GA_Update)
+            update_file = update_file.GetRasterBand(1).WriteArray( \
+                self.mask.ReadAsArray() * \
+                gdal.Open(self.outFileUnw+'.vrt').ReadAsArray())
+            update_file = None
 
         # remove existing output file(s)
         for file in glob.glob(self.outFileConnComp + "*"):
             os.remove(file)
-        gdal.BuildVRT(self.outFileConnComp+'.vrt', conCompFiles, options=gdal.BuildVRTOptions(srcNodata=-1))
-        gdal.Warp(self.outFileConnComp, self.outFileConnComp+'.vrt', options=gdal.WarpOptions(format=self.outputFormat, cutlineDSName=self.setTotProdBBoxFile, outputBounds=self.bbox_file))
+        gdal.BuildVRT(self.outFileConnComp+'.vrt', conCompFiles,
+                     options=gdal.BuildVRTOptions(srcNodata=-1))
+        gdal.Warp(self.outFileConnComp, self.outFileConnComp+'.vrt',
+                  options=gdal.WarpOptions(format=self.outputFormat,
+                  cutlineDSName=self.setTotProdBBoxFile,
+                  outputBounds=self.bbox_file))
         # Update VRT
-        gdal.Translate(self.outFileConnComp+'.vrt', self.outFileConnComp, options=gdal.TranslateOptions(format="VRT"))
+        gdal.Translate(self.outFileConnComp+'.vrt', self.outFileConnComp,
+                       options=gdal.TranslateOptions(format="VRT"))
         # Apply mask (if specified).
         if self.mask is not None:
-            update_file=gdal.Open(self.outFileConnComp,gdal.GA_Update)
+            update_file = gdal.Open(self.outFileConnComp,gdal.GA_Update)
             #mask value for conncomp must be set to nodata value -1
-            ma_update_file=np.ma.masked_where(self.mask.ReadAsArray() == 0., gdal.Open(self.outFileConnComp+'.vrt').ReadAsArray())
-            np.ma.set_fill_value(ma_update_file, update_file.GetRasterBand(1).GetNoDataValue())
-            update_file=update_file.GetRasterBand(1).WriteArray(ma_update_file.filled())
-            update_file=None
+            ma_update_file = np.ma.masked_where(self.mask.ReadAsArray() == 0.,
+                gdal.Open(self.outFileConnComp+'.vrt').ReadAsArray())
+            np.ma.set_fill_value(ma_update_file,
+                update_file.GetRasterBand(1).GetNoDataValue())
+            update_file = update_file.GetRasterBand(1).WriteArray( \
+                ma_update_file.filled())
+            update_file = None
 
-        cmd = "gdal_translate -of png -scale -ot Byte -q " + self.outFileUnw + ".vrt " + self.outFileUnw + ".png"
+        cmd = "gdal_translate -of png -scale -ot Byte -q " + \
+              self.outFileUnw + ".vrt " + self.outFileUnw + ".png"
         os.system(cmd)
 
         # Remove the directory with intermediate files as they are no longer needed
@@ -309,7 +325,8 @@ class UnwrapOverlap(Stitching):
     def __init__(self):
         '''
             Inheret properties from the parent class
-            Parse the filenames and bbox as None as they need to be set by the user, which will be caught when running the class
+            Parse the filenames and bbox as None as they need to be set
+            by the user, which will be caught when running the class
         '''
         Stitching.__init__(self)
 
@@ -343,10 +360,15 @@ class UnwrapOverlap(Stitching):
         return
 
     def __calculateCyclesOverlap__(self):
-        '''Function that will calculate the number of cycles each component needs to be shifted in order to minimize the two-pi modulu residual between a neighboring component. Outputs a fileMappingDict with as key a file number. Within fileMappingDict with a integer phase shift value for each unique connected component.
+        '''Function that will calculate the number of cycles each component
+           needs to be shifted in order to minimize the two-pi modulu residual
+           between a neighboring component. Outputs a fileMappingDict with as
+           key a file number. Within fileMappingDict with a integer phase
+           shift value for each unique connected component.
         '''
 
-        # only need to comptue the minimize the phase offset if the number of files is larger than 2
+        # only need to comptue the minimize the phase offset if the
+        # number of files is larger than 2
         if self.nfiles>1:
 
             # initiate the residuals and design matrix
@@ -354,7 +376,8 @@ class UnwrapOverlap(Stitching):
             residualrange = np.zeros((self.nfiles-1,1))
             A = np.zeros((self.nfiles-1,self.nfiles))
 
-            # the files are already sorted in the ARIAproduct class, will make consecutive overlaps between these sorted products
+            # the files are already sorted in the ARIAproduct class, will make
+            # consecutive overlaps between these sorted products
             for counter in range(self.nfiles-1):
                 # getting the two neighboring frames
                 bbox_frame1 = self.prodbbox[counter]
@@ -385,17 +408,17 @@ class UnwrapOverlap(Stitching):
                     self.ccFile[counter+1],data_band=1,loadData=False)
                 connCompFile1 = gdal.Warp( \
                     '', self.ccFile[counter], options = gdal.WarpOptions( \
-                    format="MEM", cutlineDSName=outname, \
-                    outputBounds=polyOverlap.bounds, \
+                    format="MEM", cutlineDSName=outname,
+                    outputBounds=polyOverlap.bounds,
                     dstNodata=connCompNoData1))
                 # need to specify spacing to avoid inconsistent dimensions
                 arrshape = connCompFile1.ReadAsArray().shape
                 connCompFile2 = gdal.Warp( \
                     '', self.ccFile[counter+1], options=gdal.WarpOptions( \
-                    format="MEM", cutlineDSName=outname, \
-                    outputBounds=polyOverlap.bounds, \
-                    dstNodata=connCompNoData2, \
-                    width = arrshape[1], height = arrshape[0], \
+                    format="MEM", cutlineDSName=outname,
+                    outputBounds=polyOverlap.bounds,
+                    dstNodata=connCompNoData2,
+                    width = arrshape[1], height = arrshape[0],
                     multithread = True))
 
 
@@ -406,28 +429,31 @@ class UnwrapOverlap(Stitching):
                     self.inpFile[counter+1],data_band=1,loadData=False)
                 unwFile1 = gdal.Warp( \
                     '', self.inpFile[counter], options=gdal.WarpOptions( \
-                    format="MEM", cutlineDSName=outname, \
-                    outputBounds=polyOverlap.bounds, \
-                    dstNodata=unwNoData1, \
-                    width = arrshape[1], height = arrshape[0], \
+                    format="MEM", cutlineDSName=outname,
+                    outputBounds=polyOverlap.bounds,
+                    dstNodata=unwNoData1,
+                    width = arrshape[1], height = arrshape[0],
                     multithread = True))
                 unwFile2 = gdal.Warp( \
                     '', self.inpFile[counter+1], options=gdal.WarpOptions( \
-                    format="MEM", cutlineDSName=outname, \
-                    outputBounds=polyOverlap.bounds, \
-                    dstNodata=unwNoData2, \
-                    width = arrshape[1], height = arrshape[0], \
+                    format="MEM", cutlineDSName=outname,
+                    outputBounds=polyOverlap.bounds,
+                    dstNodata=unwNoData2,
+                    width = arrshape[1], height = arrshape[0],
                     multithread = True))
 
 
                 # finding the component with the largest overlap
-                connCompData1 =connCompFile1.GetRasterBand(1).ReadAsArray()
-                connCompData1[(connCompData1==connCompNoData1) | (connCompData1==0)]=np.nan
-                connCompData2 =connCompFile2.GetRasterBand(1).ReadAsArray()
-                connCompData2[(connCompData2==connCompNoData2) | (connCompData2==0)]=np.nan
+                connCompData1 = connCompFile1.GetRasterBand(1).ReadAsArray()
+                connCompData1[(connCompData1==connCompNoData1) | \
+                    (connCompData1==0)] = np.nan
+                connCompData2 = connCompFile2.GetRasterBand(1).ReadAsArray()
+                connCompData2[(connCompData2==connCompNoData2) | \
+                    (connCompData2==0)] = np.nan
                 connCompData2_temp = (connCompData2*100)
                 with np.errstate(invalid='ignore'):
-                    temp = connCompData2_temp.astype(int)-connCompData1.astype(int)
+                    temp = connCompData2_temp.astype(int) - \
+                           connCompData1.astype(int)
                 temp[(temp<0) | (temp>2000)]=0
                 temp_count = collections.Counter(temp.flatten())
                 maxKey = 0
@@ -438,40 +464,49 @@ class UnwrapOverlap(Stitching):
                             maxKey =key
                             maxCount=keyCount
 
-                # if the max key count is 0, this means there is no good overlap region between products.
+                # if the max key count is 0, this means there is no
+                # good overlap region between products.
                 # In that scenario default to different stitching approach.
                 if maxKey!=0 and maxCount>75:
-                    # masking the unwrapped phase and only use the largest overlapping connected component
+                    # masking the unwrapped phase and only use the
+                    # largest overlapping connected component
                     unwData1 = unwFile1.GetRasterBand(1).ReadAsArray()
-                    unwData1[(unwData1==unwNoData1) | (temp!=maxKey)]=np.nan
-                    unwData2 =unwFile2.GetRasterBand(1).ReadAsArray()
-                    unwData2[(unwData2==unwNoData2) | (temp!=maxKey)]=np.nan
+                    unwData1[(unwData1==unwNoData1) | (temp!=maxKey)] = np.nan
+                    unwData2 = unwFile2.GetRasterBand(1).ReadAsArray()
+                    unwData2[(unwData2==unwNoData2) | (temp!=maxKey)] = np.nan
 
                     # Calculation of the range correction
-                    unwData1_wrapped = unwData1-np.round(unwData1/(2*np.pi))*(2*np.pi)
-                    unwData2_wrapped =unwData2-np.round(unwData2/(2*np.pi))*(2*np.pi)
-                    arr =unwData1_wrapped-unwData2_wrapped
+                    unwData1_wrapped = unwData1 - \
+                                       np.round(unwData1/(2*np.pi))*(2*np.pi)
+                    unwData2_wrapped = unwData2 - \
+                                       np.round(unwData2/(2*np.pi))*(2*np.pi)
+                    arr = unwData1_wrapped - unwData2_wrapped
 
                     # data is not fully decorrelated
                     arr = arr - np.round(arr/(2*np.pi))*2*np.pi
                     range_temp =  np.angle(np.nanmean(np.exp(1j*arr)))
 
-                    # calculation of the number of 2 pi cycles accounting for range correction
-                    cycles_temp = np.round((np.nanmean(unwData1-(unwData2+range_temp)))/(2*np.pi))
+                    # calculation of the number of 2 pi cycles
+                    # accounting for range correction
+                    cycles_temp = np.round((np.nanmean(unwData1 - \
+                                           (unwData2+range_temp)))/(2*np.pi))
 
                 else:
-                    # account for the case that no-data was left, e.g. fully decorrelated
-                    # in that scenario use all data and estimate from wrapped, histogram will be broader...
+                    # account for the case that no-data was left,
+                    # e.g. fully decorrelated in that scenario use all data
+                    # and estimate from wrapped, histogram will be broader...
                     unwData1 = unwFile1.GetRasterBand(1).ReadAsArray()
                     unwData1[(unwData1==unwNoData1)]
-                    unwData2 =unwFile2.GetRasterBand(1).ReadAsArray()
+                    unwData2 = unwFile2.GetRasterBand(1).ReadAsArray()
                     unwData2[(unwData2==unwNoData2)]
                     # Calculation of the range correction
-                    unwData1_wrapped = unwData1-np.round(unwData1/(2*np.pi))*(2*np.pi)
-                    unwData2_wrapped =unwData2-np.round(unwData2/(2*np.pi))*(2*np.pi)
-                    arr =unwData1_wrapped-unwData2_wrapped
+                    unwData1_wrapped = unwData1 - \
+                                       np.round(unwData1/(2*np.pi))*(2*np.pi)
+                    unwData2_wrapped = unwData2 - \
+                                       np.round(unwData2/(2*np.pi))*(2*np.pi)
+                    arr = unwData1_wrapped-unwData2_wrapped
                     arr = arr - np.round(arr/(2*np.pi))*2*np.pi
-                    range_temp =  np.angle(np.nanmean(np.exp(1j*arr)))
+                    range_temp = np.angle(np.nanmean(np.exp(1j*arr)))
 
                     # data is decorelated assume no 2-pi cycles
                     cycles_temp = 0
@@ -494,13 +529,16 @@ class UnwrapOverlap(Stitching):
 
 
             # invert the offsets with respect to the first product
-            cycles = np.round(np.linalg.lstsq(A[:,1:], residualcycles,rcond=None)[0])
-            rangesoffset = np.linalg.lstsq(A[:,1:], residualrange,rcond=None)[0]
+            cycles = np.round(np.linalg.lstsq(A[:,1:],
+                              residualcycles,rcond=None)[0])
+            rangesoffset = np.linalg.lstsq(A[:,1:],
+                                           residualrange, rcond=None)[0]
             #pdb.set_trace()
 
             # force first product to have 0 as offset
-            cycles = -1*np.concatenate((np.zeros((1,1)), cycles), axis=0)
-            rangesoffset = -1*np.concatenate((np.zeros((1,1)), rangesoffset), axis=0)
+            cycles = -1 * np.concatenate((np.zeros((1,1)), cycles), axis=0)
+            rangesoffset = -1 * np.concatenate((np.zeros((1,1)),
+                                               rangesoffset), axis=0)
 
         else:
             # nothing to be done, i.e. no phase cycles to be added
@@ -520,18 +558,23 @@ class UnwrapOverlap(Stitching):
             connComp = np.array(range(0,n_comp+1))
             connComp = connComp.reshape((n_comp+1,1))
 
-            # The cyclemapping of product using a single offset (i.e. all connectedComponents have the same mapping)
-            cycleMapping = np.ones((n_comp+1,1))*cycles[fileCounter,0]
-            rangeOffsetMapping = np.ones((n_comp+1,1))*rangesoffset[fileCounter,0]
+            # The cyclemapping of product using a single offset
+            # (i.e. all connectedComponents have the same mapping)
+            cycleMapping = np.ones((n_comp+1,1)) * cycles[fileCounter,0]
+            rangeOffsetMapping = np.ones((n_comp+1,1)) * \
+                                 rangesoffset[fileCounter,0]
 
             # Generate the mapping of connectedComponents
-            # Increment based on unique components of the merged product, 0 is grouped for all products
+            # Increment based on unique components of the merged product,
+            # 0 is grouped for all products
             connCompMapping = connComp
-            connCompMapping[1:]=connComp[1:]+connCompOffset
+            connCompMapping[1:] = connComp[1:] + connCompOffset
 
             # concatenate and generate a connComponent based mapping matrix
             # [original comp, new component, 2pi unw offset]
-            connCompMapping = np.concatenate((connComp, connCompMapping,cycleMapping,rangeOffsetMapping), axis=1)
+            connCompMapping = np.concatenate((connComp, connCompMapping,
+                                             cycleMapping,rangeOffsetMapping),
+                                             axis=1)
 
             # Increment the count of total number of unique components
             connCompOffset = connCompOffset+n_comp
@@ -539,7 +582,7 @@ class UnwrapOverlap(Stitching):
             # populate mapping dictionary for each product
             fileMappingDict_temp = {}
             fileMappingDict_temp['connCompMapping'] = connCompMapping
-            fileMappingDict_temp['connFile'] =  self.ccFile[fileCounter]
+            fileMappingDict_temp['connFile'] = self.ccFile[fileCounter]
             fileMappingDict_temp['unwFile'] = self.inpFile[fileCounter]
             # store it in the general mapping dictionary
             fileMappingDict[fileCounter]=fileMappingDict_temp
@@ -555,7 +598,8 @@ class UnwrapComponents(Stitching):
     def __init__(self):
         '''
             Inheret properties from the parent class
-            Parse the filenames and bbox as None as they need to be set by the user, which will be caught when running the class
+            Parse the filenames and bbox as None as they need to be set by
+            the user, which will be caught when running the class
         '''
         Stitching.__init__(self)
 
@@ -693,13 +737,21 @@ class UnwrapComponents(Stitching):
 
     def __populatePointTable__(self):
         '''
-            Function that populates a table of points which maps two closest points between two connected components. Loops over all possible connected component pairings.
-            The table is populated with columns as: Source Unique CC ID, Source CC ID, Source CC FILE, Source UNW FILE, Source X-geocoordinate, Source Y-geocoordinate, Source geoTrans, Partner Unique CC, Dist to partner, Source unw phase, Source X-coordinate, Source Y-coordinate
+            Function that populates a table of points which maps two closest
+            points between two connected components. Loops over all possible
+            connected component pairings.
+            The table is populated with columns as: Source Unique CC ID,
+            Source CC ID, Source CC FILE, Source UNW FILE,
+            Source X-geocoordinate, Source Y-geocoordinate, Source geoTrans,
+            Partner Unique CC, Dist to partner, Source unw phase,
+            Source X-coordinate, Source Y-coordinate
         '''
 
-        # only proceed if there are polygons that needs mapping to a closest polygon
+        # only proceed if there are polygons that needs
+        # mapping to a closest polygon
         if len(self.polyTableDict) <=1:
-            raise Exception("Nothing to do as all are from same connected component")
+            raise Exception('Nothing to do as all are '
+                            'from same connected component')
 
         # populate table  of all polygons
         polygon_pair_counter = 0
@@ -709,18 +761,22 @@ class UnwrapComponents(Stitching):
             # polygon 1
             poly1 = self.polyTableDict[poly_counter_1]['poly']
             connCompID1 = self.polyTableDict[poly_counter_1]['connCompID']
-            connCompID_unique1 = self.polyTableDict[poly_counter_1]['connCompID_unique']
+            connCompID_unique1 = \
+                self.polyTableDict[poly_counter_1]['connCompID_unique']
             connFile1 = self.polyTableDict[poly_counter_1]['connFile']
             unwFile1 = self.polyTableDict[poly_counter_1]['unwFile']
             geoTrans1 = self.polyTableDict[poly_counter_1]['geoTrans']
             sizeData1 = self.polyTableDict[poly_counter_1]['sizeData']
 
-            # loop over all poygons and keep track of min distance polygon not of own component
-            for poly_counter_2 in range(poly_counter_1,len(self.polyTableDict)):
+            # loop over all poygons and keep track of min distance
+            # polygon not of own component
+            for poly_counter_2 in range(poly_counter_1,
+                                        len(self.polyTableDict)):
                 # polygon 2
                 poly2 = self.polyTableDict[poly_counter_2]['poly']
                 connCompID2 = self.polyTableDict[poly_counter_2]['connCompID']
-                connCompID_unique2 = self.polyTableDict[poly_counter_2]['connCompID_unique']
+                connCompID_unique2 = \
+                    self.polyTableDict[poly_counter_2]['connCompID_unique']
                 connFile2 = self.polyTableDict[poly_counter_2]['connFile']
                 unwFile2 = self.polyTableDict[poly_counter_2]['unwFile']
                 geoTrans2 = self.polyTableDict[poly_counter_2]['geoTrans']
@@ -729,7 +785,8 @@ class UnwrapComponents(Stitching):
                 # will skip the pairing of the two polygons under the following two conditions:
                 # 1) when mapping two of the same polyons, i.e. i==j or a diagonal element of the matrix of combinations
                 # 2) when the two polygons are from the same connected component and originate from the same connected comp file
-                if poly_counter_1==poly_counter_2 and connCompID1==connCompID2 and connFile1==connFile2:
+                if poly_counter_1==poly_counter_2 and \
+                   connCompID1==connCompID2 and connFile1==connFile2:
                     continue
 
                 # finding the minMatch of closest points between two polygons lists
@@ -746,8 +803,10 @@ class UnwrapComponents(Stitching):
                             pairing = (polygon1,polygon2,connFile1,connFile2)
                             # append all tuples in a single tuple
                             pairings = pairings + (pairing,)
-                    temp = Parallel(n_jobs=-1,max_nbytes=1e6)(delayed(minDistancePoints)(ii) for ii in pairings)
-                    # unpackign the tuple back to a numpy array of two variables
+                    temp = Parallel(n_jobs=-1, max_nbytes=1e6)( \
+                        delayed(minDistancePoints)(ii) for ii in pairings)
+                    # unpackign the tuple back to a numpy array of
+                    # two variables
                     for line in temp:
                         pointDistance.append(line[0])
                         points.append(line[1])
@@ -762,7 +821,8 @@ class UnwrapComponents(Stitching):
                         for polygon2 in poly2:
                             # parse inputs as a tuple
                             pairing = (polygon1,polygon2,connFile1,connFile2)
-                            pointDistance_temp, points_temp = minDistancePoints(pairing)
+                            pointDistance_temp, points_temp = \
+                                minDistancePoints(pairing)
                             points.append(points_temp)
                             pointDistance.append(pointDistance_temp)
                     stop = time.time()
@@ -810,17 +870,21 @@ class UnwrapComponents(Stitching):
 
                 # append the list of points
                 try:
-                    tablePoints = np.concatenate((tablePoints,point1_array, point2_array), axis=0)
+                    tablePoints = np.concatenate((tablePoints, point1_array,
+                                                 point2_array), axis=0)
                 except:
-                    tablePoints = np.concatenate((point1_array, point2_array), axis=0)
+                    tablePoints = np.concatenate((point1_array,
+                                                 point2_array), axis=0)
 
 
         ## making sure the points are unique based on coordinate and unique connected compoenent id
-        tablePoints_unique, unique_indices = np.unique(tablePoints[:, (0,4,5) ], axis=0,return_index=True)
+        tablePoints_unique, unique_indices = np.unique( \
+            tablePoints[:, (0,4,5) ], axis=0,return_index=True)
         self.tablePoints =tablePoints[unique_indices[:],:]
 
         # compute the phase values
-        log.info('Calculating the phase values for %s points', self.tablePoints.shape[0])
+        log.info('Calculating the phase values for '
+                 f'{self.tablePoints.shape[0]} points')
         # will try multi-core version and default to for loop in case of failure
         try:
             start = time.time()
@@ -830,14 +894,18 @@ class UnwrapComponents(Stitching):
                 connCompID1_temp = self.tablePoints[counter,1]
                 connFile1_temp = self.tablePoints[counter,2]
                 unwFile1_temp = self.tablePoints[counter,3]
-                point1_temp = np.array([self.tablePoints[counter,4], self.tablePoints[counter,5]])
+                point1_temp = np.array([self.tablePoints[counter,4],
+                              self.tablePoints[counter,5]])
                 geoTrans1_temp =self.tablePoints[counter,6]
                 # parse inputs as a tuple
-                inputs = (connCompID1_temp,connFile1_temp,unwFile1_temp,point1_temp,geoTrans1_temp,self.region)
+                inputs = (connCompID1_temp, connFile1_temp, unwFile1_temp, \
+                          point1_temp, geoTrans1_temp, self.region)
                 # append all tuples in a single tuple
                 all_inputs = all_inputs + (inputs,)
             # compute the phase value using multi-thread functionality
-            unwPhase_value = Parallel(n_jobs=-1,max_nbytes=1e6)(delayed(point2unwPhase)(ii) for ii in all_inputs)
+            unwPhase_value = Parallel(n_jobs=-1,max_nbytes=1e6)( \
+                                      delayed(point2unwPhase)(ii) \
+                                      for ii in all_inputs)
             # end timer
             end = time.time()
         except:
@@ -849,10 +917,12 @@ class UnwrapComponents(Stitching):
                 connCompID1_temp = self.tablePoints[counter,1]
                 connFile1_temp = self.tablePoints[counter,2]
                 unwFile1_temp = self.tablePoints[counter,3]
-                point1_temp = np.array([self.tablePoints[counter,4], self.tablePoints[counter,5]])
+                point1_temp = np.array([self.tablePoints[counter,4],
+                                       self.tablePoints[counter,5]])
                 geoTrans1_temp =self.tablePoints[counter,6]
                 # parse inputs as a tuple
-                inputs = (connCompID1_temp,connFile1_temp,unwFile1_temp,point1_temp,geoTrans1_temp,self.region)
+                inputs = (connCompID1_temp, connFile1_temp, unwFile1_temp, \
+                          point1_temp, geoTrans1_temp, self.region)
                 # compute the phase value
                 unwPhase_temp = point2unwPhase(inputs)
                 unwPhase_value.append(unwPhase_temp)
@@ -863,7 +933,8 @@ class UnwrapComponents(Stitching):
         # Appending the phase to the table stored in self with the points
         unwPhase_value = np.array(unwPhase_value)
         unwPhase_value = unwPhase_value.reshape((unwPhase_value.shape[0],1))
-        self.tablePoints = np.concatenate((self.tablePoints, unwPhase_value), axis=1)
+        self.tablePoints = np.concatenate((self.tablePoints,
+                                          unwPhase_value), axis=1)
 
         ## The two-stager only works with integer coordinate system in its triangulation, and needs unique points for each node. Will apply two steps to ensure this
         # STEP 1) will convert the geo-coordiantes with respect to the most southwest point and normalize with respect to original grid sampling
@@ -873,8 +944,10 @@ class UnwrapComponents(Stitching):
         geoTrans_global = list(geoTrans1)
         geoTrans_global[0] = np.min(self.tablePoints[:,4].astype(np.float64))
         geoTrans_global[3] = np.max(self.tablePoints[:,5].astype(np.float64))
-        X_coordinate = ((self.tablePoints[:,4].astype(np.float64) - geoTrans_global[0])/geoTrans_global[1]).astype(int)
-        Y_coordinate = ((self.tablePoints[:,5].astype(np.float64) - geoTrans_global[3])/geoTrans_global[5]).astype(int)
+        X_coordinate = ((self.tablePoints[:,4].astype(np.float64) - \
+            geoTrans_global[0])/geoTrans_global[1]).astype(int)
+        Y_coordinate = ((self.tablePoints[:,5].astype(np.float64) - \
+            geoTrans_global[3])/geoTrans_global[5]).astype(int)
         X_coordinate = X_coordinate.reshape((X_coordinate.shape[0],1))
         Y_coordinate = Y_coordinate.reshape((Y_coordinate.shape[0],1))
 
@@ -890,29 +963,39 @@ class UnwrapComponents(Stitching):
                 matches = np.where(np.all(point==points,axis=1))[0]
                 if matches.shape[0]>1:
                     #print('Found ' + str(matches.shape[0]) + ' non-unique points')
-                    X_coordinate[matches[1:],0] = X_coordinate[matches[1:],0] + random.sample(range(-3,3),matches.shape[0]-1)
-                    Y_coordinate[matches[1:],0] = Y_coordinate[matches[1:],0] + random.sample(range(-3,3),matches.shape[0]-1)
+                    X_coordinate[matches[1:],0] = \
+                        X_coordinate[matches[1:],0] + \
+                        random.sample(range(-3,3),matches.shape[0]-1)
+                    Y_coordinate[matches[1:],0] = \
+                        Y_coordinate[matches[1:],0] + \
+                        random.sample(range(-3,3),matches.shape[0]-1)
 
             test = np.concatenate((X_coordinate, Y_coordinate), axis=1)
-            test_unique, test_unique_indices = np.unique(test, axis=0,return_index=True)
-            log.info('Shifting coordinates by a pixel to make all points unique: iteration %s', while_count)
-            while_count = while_count+1
+            test_unique, test_unique_indices = np.unique(test, axis=0,
+                                                         return_index=True)
+            log.info('Shifting coordinates by a pixel to make '
+                     f'all points unique: iteration {while_count}')
+            while_count = while_count + 1
 
         if test_unique.shape!=test.shape:
-            log.error('Coordinates are not-unique, need to implement a while loop, run again for another random sample...')
+            log.error('Coordinates are not-unique, need to implement '
+                      'a while loop, run again for another random sample...')
             import pdb
             pdb.set_trace()
         else:
             log.info('Coordinates are unique')
 
         # appending the X and Y-coordinates to the points table.
-        self.tablePoints = np.concatenate((self.tablePoints, X_coordinate), axis=1)
-        self.tablePoints = np.concatenate((self.tablePoints, Y_coordinate), axis=1)
+        self.tablePoints = np.concatenate((self.tablePoints,
+                                          X_coordinate), axis=1)
+        self.tablePoints = np.concatenate((self.tablePoints,
+                                          Y_coordinate), axis=1)
 
 
     def __compToCycle__(self, cycle, compnum):
         '''
-            Generate a mapping from unique connected component to the number of phase cycles that needs to be applied
+            Generate a mapping from unique connected component
+            to the number of phase cycles that needs to be applied
         '''
 
         compMap = {}
@@ -923,7 +1006,8 @@ class UnwrapComponents(Stitching):
                 if (compN == n):
                     continue
                 else:
-                    raise ValueError("Incorrect phaseunwrap output: Different cycles in same components")
+                    raise ValueError('Incorrect phaseunwrap output: '
+                                     'Different cycles in same components')
             except:
                 # Component cycle doesn't exist in the dictionary
                 compMap[c] = n
@@ -933,7 +1017,12 @@ class UnwrapComponents(Stitching):
 
     def __calculateCycles__(self):
         '''
-            Function that will calculate the number of cycles each component needs to be shifted in order to minimize the two-pi modulu residual between a neighboring component. Outputs a fileMappingDict with as key a file number. Within fileMappingDict with a integer phase shift value for each unique connected component.
+            Function that will calculate the number of cycles each component
+            needs to be shifted in order to minimize the two-pi modulu
+            residual between a neighboring component. Outputs a
+            fileMappingDict with as key a file number. Within fileMappingDict
+            with a integer phase shift value for each unique
+            connected component.
         '''
 
         # import dependecies, looks liek the general import does not percolate down to this level.
@@ -944,7 +1033,8 @@ class UnwrapComponents(Stitching):
         y = list(self.tablePoints[:,11].astype(int)+1)
         phase = (self.tablePoints[:,9].astype(np.float32))
         compNum = list(self.tablePoints[:,7].astype(int))
-        phaseunwrap = PhaseUnwrap(x=x, y=y, phase=phase, compNum=compNum, redArcs=redarcsTypes[self.redArcs])
+        phaseunwrap = PhaseUnwrap(x=x, y=y, phase=phase, compNum=compNum,
+                                  redArcs=redarcsTypes[self.redArcs])
         phaseunwrap.solve(self.solver)
         cycles = phaseunwrap.unwrapLP()
 
@@ -967,7 +1057,9 @@ class UnwrapComponents(Stitching):
                         pdb.set_trace()
             cycleMapping = np.array(cycleMapping)
             cycleMapping = cycleMapping.reshape((cycleMapping.shape[0],1))
-            connCompMapping = np.concatenate((fileMappingDict['connCompMapping'], cycleMapping), axis=1)
+            connCompMapping = \
+                np.concatenate((fileMappingDict['connCompMapping'],
+                               cycleMapping), axis=1)
 
             # update the original dictionary and store it back in self
             fileMappingDict['connCompMapping'] = connCompMapping
@@ -1045,11 +1137,13 @@ def polygonizeConn(ccFile):
     """
         Polygonize a connected component image.
         Ignores polygons for no-data value and connected component 0
-        Takes a GDAL compatible file as input, and returns shaply polygons and a list of corresponding connected components
+        Takes a GDAL compatible file as input, and returns shaply polygons
+        and a list of corresponding connected components
     """
 
     # will save the geojson under a temp local filename
-    tmfile = tempfile.NamedTemporaryFile(mode='w+b',suffix='.json', prefix='ConnPolygonize_', dir='.')
+    tmfile = tempfile.NamedTemporaryFile(mode='w+b',suffix='.json',
+                                         prefix='ConnPolygonize_', dir='.')
     outname = tmfile.name
     # will remove it as GDAL polygonize function cannot overwrite files
     tmfile.close()
@@ -1074,7 +1168,8 @@ def polygonizeConn(ccFile):
     ccomp = []
     # default structure is features/properties/geometry/coordinates
     for ft in dt['features']:
-        # Connected component 0 is an actual data value, but not used for 2-stager and is removed here
+        # Connected component 0 is an actual data value, but not used for
+        # 2-stager and is removed here
         if ft['properties']['DN'] <= 0:
             continue
         ccomp.append(ft['properties']['DN'])
@@ -1087,7 +1182,8 @@ def polygonizeConn(ccFile):
     ccomp_unique = []
     for ccomp_it in np.unique(ccomp):
         ccomp_unique.append(ccomp_it)
-        # find all the polygons for this connected component and add them as a list
+        # find all the polygons for this connected component and
+        # add them as a list
         index = np.where(np.array(ccomp)==ccomp_it)[0]
         polylist = []
         for it in index:
@@ -1139,8 +1235,10 @@ def GDALread(filename,data_band=1,loadData=True):
 
 def createConnComp_Int(inputs):
     '''
-        Function to generate intermediate connected component files and unwrapped VRT files that have with interger 2pi pixel shift applied.
-        Will parse inputs in a single argument as it allows for parallel processing.
+        Function to generate intermediate connected component files and
+        unwrapped VRT files that have with interger 2pi pixel shift applied.
+        Will parse inputs in a single argument as it allows for
+        parallel processing.
         Return a list of files in a unqiue temp folder
     '''
 
@@ -1182,27 +1280,38 @@ def createConnComp_Int(inputs):
 
     ## STEP 3: writing out the datasets
     # writing out the unqiue ID connected component file
-    connDataName = os.path.abspath(os.path.join(saveDir,'connComp', saveNameID + '_connComp.tif'))
-    write_ambiguity(connData,connDataName,connProj,connGeoTrans,connNoData)
+    connDataName = os.path.abspath(os.path.join(saveDir, 'connComp',
+                                   saveNameID + '_connComp.tif'))
+    write_ambiguity(connData, connDataName, connProj, connGeoTrans,
+                    connNoData)
 
     # writing out the integer map as tiff file
-    intShiftName = os.path.abspath(os.path.join(saveDir,'unw',saveNameID + '_intShift.tif'))
-    write_ambiguity(intShift,intShiftName,connProj,connGeoTrans)
+    intShiftName = os.path.abspath(os.path.join(saveDir, 'unw',
+                                   saveNameID + '_intShift.tif'))
+    write_ambiguity(intShift, intShiftName, connProj, connGeoTrans)
 
 
     # writing out the scalled vrt => 2PI * integer map
     length = intShift.shape[0]
     width = intShift.shape[1]
-    scaleVRTName = os.path.abspath(os.path.join(saveDir,'unw',saveNameID + '_scale.vrt'))
-    build2PiScaleVRT(scaleVRTName,intShiftName,length=length,width=width)
+    scaleVRTName = os.path.abspath(os.path.join(saveDir, 'unw',
+                                   saveNameID + '_scale.vrt'))
+    build2PiScaleVRT(scaleVRTName, intShiftName,
+                     length=length, width=width)
 
     # Offseting the vrt for the range offset correctiom
-    unwRangeOffsetVRTName = os.path.abspath(os.path.join(saveDir,'unw',saveNameID + '_rangeOffset.vrt'))
-    buildScaleOffsetVRT(unwRangeOffsetVRTName,unwFile,connProj,connGeoTrans,File1_offset=connCompMapping[1,3],length=length,width=width)
+    unwRangeOffsetVRTName = os.path.abspath(os.path.join(saveDir, 'unw',
+                                            saveNameID + '_rangeOffset.vrt'))
+    buildScaleOffsetVRT(unwRangeOffsetVRTName, unwFile, connProj,
+                        connGeoTrans, File1_offset=connCompMapping[1,3],
+                        length=length, width=width)
 
     # writing out the corrected unw phase vrt => phase + 2PI * integer map
-    unwVRTName = os.path.abspath(os.path.join(saveDir,'unw',saveNameID + '.vrt'))
-    buildSumVRT(unwVRTName,unwRangeOffsetVRTName,scaleVRTName,connProj,connGeoTrans,length,width,description= inputs['description'])
+    unwVRTName = os.path.abspath(os.path.join(saveDir, 'unw',
+                                 saveNameID + '.vrt'))
+    buildSumVRT(unwVRTName, unwRangeOffsetVRTName, scaleVRTName, connProj,
+                connGeoTrans, length, width,
+                description=inputs['description'])
 
     return [connDataName, unwVRTName]
 
@@ -1225,7 +1334,8 @@ def write_ambiguity(data, outName,proj, geoTrans,noData=False):
     # leverage the compression option to ensure small file size
     dst_options = ['COMPRESS=LZW']
     # create the dataset
-    ds = driver.Create(outName , data.shape[1], data.shape[0], 1, Int16, dst_options)
+    ds = driver.Create(outName, data.shape[1], data.shape[0], 1, Int16,
+                       dst_options)
     # setting the proj and transformation
     ds.SetGeoTransform(geoTrans)
     ds.SetProjection(proj)

--- a/tools/ARIAtools/vrtmanager.py
+++ b/tools/ARIAtools/vrtmanager.py
@@ -567,7 +567,7 @@ def dim_check(ref_arr, prod_arr):
 
     if (ref_wid != prod_wid) or (ref_hgt != prod_hgt):
         raise Exception('Inconsistent product dims '
-            f'between products {outname} and {prev_outname}: '
+            f'between products {prev_outname} and {outname}: '
             f'check respective width ({ref_wid}, {prod_wid}) '
             f'and height ({ref_hgt}, {prod_hgt}) and geotrans '
             f'({ref_geotrans}, {prod_geotrans})')

--- a/tools/ARIAtools/vrtmanager.py
+++ b/tools/ARIAtools/vrtmanager.py
@@ -24,7 +24,8 @@ log = logging.getLogger(__name__)
 
 
 ###Save file with gdal
-def renderVRT(fname, data_lyr, geotrans=None, drivername='ENVI', gdal_fmt='float32', proj=None, nodata=None, verbose=False):
+def renderVRT(fname, data_lyr, geotrans=None, drivername='ENVI',
+              gdal_fmt='float32', proj=None, nodata=None, verbose=False):
     """Exports raster and renders corresponding VRT file."""
     gdalMap = { 'byte'   : 1,
                 'int16'  : 3,
@@ -34,7 +35,9 @@ def renderVRT(fname, data_lyr, geotrans=None, drivername='ENVI', gdal_fmt='float
                 'cfloat32' : 10,
                 'cfloat64': 11}
 
-    gdalfile=gdal.GetDriverByName(drivername).Create(fname, data_lyr.shape[1], data_lyr.shape[0], 1, gdalMap[gdal_fmt])
+    gdalfile = gdal.GetDriverByName(drivername).Create(fname,
+                   data_lyr.shape[1], data_lyr.shape[0], 1,
+                   gdalMap[gdal_fmt])
     gdalfile.GetRasterBand(1).WriteArray(data_lyr)
     if geotrans: #If user wishes to update geotrans.
         gdalfile.SetGeoTransform(geotrans)
@@ -43,10 +46,15 @@ def renderVRT(fname, data_lyr, geotrans=None, drivername='ENVI', gdal_fmt='float
     if nodata is not None: #If user wishes to set nodata val.
         gdalfile.GetRasterBand(1).SetNoDataValue(nodata)
         # Finalize VRT
-        gdal.Translate(fname+'.vrt', gdalfile, options=gdal.TranslateOptions(format="VRT", noData=nodata))
+        gdal.Translate(fname+'.vrt', gdalfile,
+                       options=gdal.TranslateOptions(format="VRT",
+                                                     noData=nodata)
+                       )
     else:
         # Finalize VRT
-        gdal.Translate(fname+'.vrt', gdalfile, options=gdal.TranslateOptions(format="VRT"))
+        gdal.Translate(fname+'.vrt', gdalfile,
+                       options=gdal.TranslateOptions(format="VRT")
+                       )
 
     gdalfile = None
 
@@ -56,15 +64,20 @@ def renderVRT(fname, data_lyr, geotrans=None, drivername='ENVI', gdal_fmt='float
 ###Make OGR VRT file
 def renderOGRVRT(vrt_filename, src_datasets):
     """Generate VRT of shapefile unions."""
-    vrt_head='<OGRVRTDataSource>\n  <OGRVRTUnionLayer name="merged">\n    <FieldStrategy>Union</FieldStrategy>\n'
-    vrt_tail='  </OGRVRTUnionLayer>\n</OGRVRTDataSource>\n'
+    vrt_head = '<OGRVRTDataSource>\n  ' \
+               '<OGRVRTUnionLayer name="merged">\n    ' \
+               '<FieldStrategy>Union</FieldStrategy>\n'
+    vrt_tail = '  </OGRVRTUnionLayer>\n</OGRVRTDataSource>\n'
 
     with open(vrt_filename,'w') as vrt_write:
         vrt_write.write(vrt_head)
         for i in enumerate(src_datasets):
-            vrt_write.write('    <OGRVRTLayer name="Dataset%i_%s">\n'%(i[0],os.path.basename(i[1]).split('.shp')[0]))
-            vrt_write.write('      <SrcDataSource shared="1">%s</SrcDataSource>\n'%(i[1]))
-            vrt_write.write('      <SrcLayer>%s</SrcLayer>\n'%(os.path.basename(i[1]).split('.shp')[0]))
+            vrt_write.write('    <OGRVRTLayer name="Dataset%i_%s">\n'%(i[0],
+                            os.path.basename(i[1]).split('.shp')[0]))
+            vrt_write.write('      <SrcDataSource shared="1">%s'%(i[1]))
+            vrt_write.write('</SrcDataSource>\n')
+            vrt_write.write('      <SrcLayer>%s</SrcLayer>\n'%( \
+                            os.path.basename(i[1]).split('.shp')[0]))
             vrt_write.write('    </OGRVRTLayer>\n')
         vrt_write.write(vrt_tail)
 
@@ -82,44 +95,41 @@ def resampleRaster(fname, multilooking, bounds, prods_TOTbbox,
 
     # Get datasource name (inputname)
     if os.path.exists(fname.split('.vrt')[0]):
-        inputname=fname
+        inputname = fname
     else:
-        fname+='.vrt'
-        inputname=gdal.Open(fname).GetFileList()[-1]
+        fname += '.vrt'
+        inputname = gdal.Open(fname).GetFileList()[-1]
 
     # Access original shape
     ds = gdal.Warp('', fname, options=gdal.WarpOptions(format="MEM",
-                   cutlineDSName=prods_TOTbbox,
-                   outputBounds=bounds,
+                   cutlineDSName=prods_TOTbbox, outputBounds=bounds,
                    multithread=True,
                    options=['NUM_THREADS=%s'%(num_threads)]))
-    # Get output res
-    arrres = [abs(ds.GetGeoTransform()[1])*multilooking,
+    arrshape = [abs(ds.GetGeoTransform()[1])*multilooking,
                 abs(ds.GetGeoTransform()[-1])*multilooking]
-    # Get geotrans/proj
+    #get geotrans/proj
     ds = gdal.Warp('', fname, options=gdal.WarpOptions(format="MEM",
-                   cutlineDSName=prods_TOTbbox,
-                   outputBounds=bounds,
-                   xRes=arrres[0], yRes=arrres[1],
-                   resampleAlg='near', multithread=True,
+                   cutlineDSName=prods_TOTbbox, outputBounds=bounds,
+                   xRes=arrshape[0], yRes=arrshape[1], resampleAlg='near',
+                   multithread=True,
                    options=['NUM_THREADS=%s'%(num_threads)]))
     geotrans = ds.GetGeoTransform()
     proj = ds.GetProjection()
 
     # Must resample mask with nearest-neighbor
-    if fname.split('/')[-2]=='mask':
+    if fname.split('/')[-2] == 'mask':
         # Resample raster
         gdal.Warp(fname, inputname,
                   options=gdal.WarpOptions(format=outputFormat,
                   cutlineDSName=prods_TOTbbox, outputBounds=bounds,
-                  xRes=arrres[0], yRes=arrres[1],
-                  resampleAlg='near', multithread=True,
+                  xRes=arrshape[0], yRes=arrshape[1], resampleAlg='near',
+                  multithread=True,
                   options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
 
     # Use pixel function to downsample connected components/unw files
     # based off of frequency of connected components in each window
-    elif fname.split('/')[-2]=='connectedComponents' \
-         or fname.split('/')[-2]=='unwrappedPhase':
+    elif fname.split('/')[-2]=='connectedComponents' or \
+        fname.split('/')[-2]=='unwrappedPhase':
         # Resample unw phase based off of mode of connected components
         fnameunw = os.path.join('/'.join(fname.split('/')[:-2]), 
             'unwrappedPhase',
@@ -174,11 +184,11 @@ def resampleRaster(fname, multilooking, bounds, prods_TOTbbox,
                                  ).quantize(0, ROUND_HALF_UP))]
             unwmap = np.ma.masked_invalid(unwmap)
             np.ma.set_fill_value(unwmap, ds_unw_nodata)
-            #unwphase
+            # unwphase
             renderVRT(fnameunw, unwmap.filled(), geotrans=geotrans,
                       drivername=outputFormat, gdal_fmt='float32',
                       proj=proj, nodata=ds_unw_nodata)
-            #temp workaround for gdal bug
+            # temp workaround for gdal bug
             try:
                 gdal.Open(fnameunw)
             except RuntimeError:
@@ -193,13 +203,12 @@ def resampleRaster(fname, multilooking, bounds, prods_TOTbbox,
             gdal.Warp(fnameconcomp, fnameconcomp,
                       options=gdal.WarpOptions(format=outputFormat,
                       cutlineDSName=prods_TOTbbox, outputBounds=bounds,
-                      xRes=arrres[0], yRes=arrres[1],
-                      resampleAlg='mode', multithread=True,
+                      xRes=arrshape[0], yRes=arrshape[1], resampleAlg='mode',
+                      multithread=True,
                       options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
             # update VRT
             gdal.BuildVRT(fnameconcomp+'.vrt', fnameconcomp,
-                          options=gdal.BuildVRTOptions( \
-                          options=['-overwrite']))
+                         options=gdal.BuildVRTOptions(options=['-overwrite']))
         # Default: resample unw phase with gdal average algorithm
         else:
             # Resample unwphase
@@ -208,13 +217,12 @@ def resampleRaster(fname, multilooking, bounds, prods_TOTbbox,
             gdal.Warp(fnameunw, fnameunw,
                       options=gdal.WarpOptions(format=outputFormat,
                       cutlineDSName=prods_TOTbbox, outputBounds=bounds,
-                      xRes=arrres[0], yRes=arrres[1],
-                      resampleAlg='average',multithread=True,
+                      xRes=arrshape[0], yRes=arrshape[1],
+                      resampleAlg='average', multithread=True,
                       options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
             # update VRT
             gdal.BuildVRT(fnameunw+'.vrt', fnameunw,
-                          options=gdal.BuildVRTOptions( \
-                          options=['-overwrite']))
+                         options=gdal.BuildVRTOptions(options=['-overwrite']))
             #temp workaround for gdal bug
             try:
                 gdal.Open(fnameunw)
@@ -232,8 +240,8 @@ def resampleRaster(fname, multilooking, bounds, prods_TOTbbox,
             gdal.Warp(fnameconcomp, fnameconcomp,
                       options=gdal.WarpOptions(format=outputFormat,
                       cutlineDSName=prods_TOTbbox, outputBounds=bounds,
-                      xRes=arrres[0], yRes=arrres[1],
-                      resampleAlg='near', multithread=True,
+                      xRes=arrshape[0], yRes=arrshape[1], resampleAlg='near',
+                      multithread=True,
                       options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
             # update VRT
             gdal.BuildVRT(fnameconcomp+'.vrt', fnameconcomp,
@@ -245,11 +253,11 @@ def resampleRaster(fname, multilooking, bounds, prods_TOTbbox,
         gdal.Warp(fname, inputname,
                   options=gdal.WarpOptions(format=outputFormat,
                   cutlineDSName=prods_TOTbbox, outputBounds=bounds,
-                  xRes=arrres[0], yRes=arrres[1],
-                  resampleAlg='lanczos', multithread=True,
+                  xRes=arrshape[0], yRes=arrshape[1], resampleAlg='lanczos',
+                  multithread=True,
                   options=['NUM_THREADS=%s'%(num_threads)+' -overwrite']))
 
-    if outputFormat != 'VRT':
+    if outputFormat!='VRT':
         # update VRT
         gdal.BuildVRT(fname+'.vrt', fname,
                       options=gdal.BuildVRTOptions(options=['-overwrite']))
@@ -295,7 +303,8 @@ def ancillaryLooks(mask, dem, arrshape, standardproduct_info, multilooking,
 
 
 ###Average rasters
-def rasterAverage(outname, product_dict, bounds, prods_TOTbbox, outputFormat='ENVI', thresh=None):
+def rasterAverage(outname, product_dict, bounds, prods_TOTbbox,
+                  outputFormat='ENVI', thresh=None):
     """Generate average of rasters.
 
     Currently implemented for:
@@ -307,22 +316,28 @@ def rasterAverage(outname, product_dict, bounds, prods_TOTbbox, outputFormat='EN
 
     # Iterate through all layers
     for i in enumerate(product_dict):
-        arr_file = gdal.Warp('', i[1], options=gdal.WarpOptions(format="MEM", cutlineDSName=prods_TOTbbox, outputBounds=bounds))
-        arr_file_arr = np.ma.masked_where(arr_file.ReadAsArray() == arr_file.GetRasterBand(1).GetNoDataValue(), arr_file.ReadAsArray())
+        arr_file = gdal.Warp('', i[1], options=gdal.WarpOptions(format="MEM",
+                             cutlineDSName=prods_TOTbbox, outputBounds=bounds))
+        arr_file_arr = np.ma.masked_where(arr_file.ReadAsArray() == \
+            arr_file.GetRasterBand(1).GetNoDataValue(), arr_file.ReadAsArray())
         ### Iteratively update average raster file
         if os.path.exists(outname):
             arr_file = gdal.Open(outname,gdal.GA_Update)
-            arr_file = arr_file.GetRasterBand(1).WriteArray(arr_file_arr+arr_file.ReadAsArray())
+            arr_file = arr_file.GetRasterBand(1).WriteArray( \
+                arr_file_arr+arr_file.ReadAsArray())
         else:
             # If looping through first raster file, nothing to sum so just save to file
-            renderVRT(outname, arr_file_arr, geotrans=arr_file.GetGeoTransform(), drivername=outputFormat, \
-               gdal_fmt=arr_file_arr.dtype.name, proj=arr_file.GetProjection(), \
-               nodata=arr_file.GetRasterBand(1).GetNoDataValue())
+            renderVRT(outname, arr_file_arr,
+                     geotrans=arr_file.GetGeoTransform(),
+                     drivername=outputFormat,
+                     gdal_fmt=arr_file_arr.dtype.name,
+                     proj=arr_file.GetProjection(),
+                     nodata=arr_file.GetRasterBand(1).GetNoDataValue())
         arr_file = arr_file_arr = None
 
     # Take average of raster sum
-    arr_file = gdal.Open(outname,gdal.GA_Update)
-    arr_mean = arr_file.ReadAsArray()/len(product_dict)
+    arr_file = gdal.Open(outname, gdal.GA_Update)
+    arr_mean = arr_file.ReadAsArray() / len(product_dict)
 
     # Mask using specified raster threshold
     if thresh:


### PR DESCRIPTION
Found bug in way lat/lon metadata arrays were initiated. Specifically, incorrect imposed dimensions translated into an apparent offset over overlapping regions when frames were extracted separately as so:
![Screenshot 2023-05-16 at 2 43 42 AM](https://github.com/aria-tools/ARIA-tools/assets/13227405/7508479a-8463-4fd2-8dc2-52de03abf243)


When the dimensions are appropriately set [here](https://github.com/aria-tools/ARIA-tools/blob/sss_metafix/tools/ARIAtools/extractProduct.py#L1265-L1272), this inconsistency goes away:
![Screenshot 2023-05-16 at 2 44 01 AM](https://github.com/aria-tools/ARIA-tools/assets/13227405/3b113fce-8542-4c1c-9faa-d17d40a73257)


And as a sanity check, this artifact is NOT inherited from the GUNWs, which show seamless overlap:
![Screenshot 2023-05-16 at 2 43 05 AM](https://github.com/aria-tools/ARIA-tools/assets/13227405/4d91381c-0859-4d7d-aca7-8936c54089db)