### PR TITLE
update sequential stitcher

### DIFF
--- a/tools/ARIAtools/sequential_stitching.py
+++ b/tools/ARIAtools/sequential_stitching.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python3
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Author: Marin Govorcin
 # Copyright 2023, by the California Institute of Technology. ALL RIGHTS
 # RESERVED. United States Government Sponsorship acknowledged.
 #
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-import warnings
 import numpy as np
-from numpy.typing import NDArray, ArrayLike
+from numpy.typing import NDArray
 
-from typing import List, Optional, Tuple, Union
-from osgeo import gdal, osr, gdal_array
+from typing import List, Optional, Tuple
+from osgeo import gdal
 from pathlib import Path
+
+
+# import util modules
+from ARIAtools.stitiching_util import (get_GUNW_array, get_GUNW_attr,
+                                       frame_overlap, combine_data_to_single,
+                                       write_GUNW_array, snwe_to_extent,
+                                       _nan_filled_array)
+
 
 from matplotlib import pyplot as plt
 import matplotlib as mpl
@@ -42,19 +49,113 @@ DISCLAIMER : This is development script. Requires some additional clean-up
 and restructuring
 '''
 
-################### STITCHING SUBROUTINES ##################################
-def stitch_2frames(unw_data1 : NDArray, conn_data1 : NDArray, rdict1 : dict,
-                   unw_data2 : NDArray, conn_data2 : NDArray, rdict2 : dict,
-                   correction_method : Optional[str] = 'cycle2pi',
-                   range_correction : Optional[bool] = False,
-                   verbose: Optional[bool] = False) -> \
-                   Tuple[NDArray, NDArray, NDArray, NDArray]:
+#  STITCHING SUBROUTINES
+
+
+def stitch_unwrapped_frames(input_unw_files: List[str],
+                            input_conncomp_files: List[str],
+                            correction_method: Optional[str] = 'cycle2pi',
+                            range_correction: Optional[bool] = True,
+                            direction_N_S: Optional[bool] = False,
+                            verbose: Optional[bool] = False):
+
+    # Get raster attributes [SNWE, latlon_spacing, length, width, nodata]
+    # from each input file
+
+    # Initalize variables
+    unw_attr_dicts = []  # unwrappedPhase
+    conncomp_attr_dicts = []  # connectedComponents
+
+    # We assume that the filename order is the same for unwrappedPhase and
+    # connectedComponent lists
+    temp_snwe_list = []
+
+    for unw_file, conn_file in zip(input_unw_files, input_conncomp_files):
+        unw_attr_dicts.append(get_GUNW_attr(unw_file))
+        conncomp_attr_dicts.append(get_GUNW_attr(conn_file))
+        # get frame bounds, assume are the same for unw and conncomp
+        temp_snwe_list.append(unw_attr_dicts[-1]['SNWE'])
+
+    # get sorted indices for frame bounds, from South to North
+    sorted_ix = np.argsort(np.array(temp_snwe_list)[:, 0], axis=0)
+    # reverse direction of stitching, move from North to South
+    # NOTE: should not make any difference
+    if direction_N_S:
+        sorted_ix = sorted_ix[::-1]
+
+    # Wrap stitching parameters into dict
+    stitching_dict = dict(correction_method=correction_method,
+                          range_correction=range_correction,
+                          verbose=verbose)
+
+    # Loop through sorted frames, and stitch neighboring frames
+    for i, (ix1, ix2) in enumerate(zip(sorted_ix[:-1], sorted_ix[1:])):
+        if verbose:
+            print(
+                'Frame-1:',
+                unw_attr_dicts[ix1]['PATH'].split('"')[1].split('/')[-1])
+            print(
+                'Frame-2:',
+                unw_attr_dicts[ix2]['PATH'].split('"')[1].split('/')[-1])
+
+        # Get numpy masked arrays
+        # Frame1
+        frame1_unw_array = get_GUNW_array(
+            filename=unw_attr_dicts[ix1]['PATH'],
+            nodata=unw_attr_dicts[ix1]['NODATA']
+        )
+        frame1_conn_array = get_GUNW_array(
+            filename=conncomp_attr_dicts[ix1]['PATH'],
+            nodata=conncomp_attr_dicts[ix1]['NODATA']
+        )
+        # Frame2
+        frame2_unw_array = get_GUNW_array(
+            filename=unw_attr_dicts[ix2]['PATH'],
+            nodata=unw_attr_dicts[ix2]['NODATA']
+        )
+        frame2_conn_array = get_GUNW_array(
+            filename=conncomp_attr_dicts[ix2]['PATH'],
+            nodata=conncomp_attr_dicts[ix2]['NODATA']
+        )
+
+        if i == 0:
+            (corr_unw, corr_conn, corr_dict) = stitch_unw2frames(
+                frame1_unw_array,
+                frame1_conn_array,
+                unw_attr_dicts[ix1],
+                frame2_unw_array,
+                frame2_conn_array,
+                unw_attr_dicts[ix2],
+                **stitching_dict)
+        else:
+            (corr_unw, corr_conn, corr_dict) = stitch_unw2frames(
+                corr_unw,
+                corr_conn,
+                corr_dict,
+                frame2_unw_array,
+                frame2_conn_array,
+                unw_attr_dicts[ix2],
+                **stitching_dict)
+
+    # replace nan with 0.0
+    corr_unw = np.nan_to_num(corr_unw.data, nan=0.0)
+    corr_conn = np.nan_to_num(corr_conn.data, nan=-1.0)
+
+    return corr_unw, corr_conn, corr_dict['SNWE']
+
+
+def stitch_unw2frames(unw_data1: NDArray, conn_data1: NDArray, rdict1: dict,
+                      unw_data2: NDArray, conn_data2: NDArray, rdict2: dict,
+                      correction_method: Optional[str] = 'cycle2pi',
+                      range_correction: Optional[bool] = False,
+                      verbose: Optional[bool] = False) -> \
+        Tuple[NDArray, NDArray, dict]:
     """
-    Function to sequentially stitch two frames along the same track. Mean 
-    offset or 2pi integer cycles are estimated for each overlapping connected 
-    components, which after correction are merged into the same component. 
-    Code runs forward and backward, first correcting Northern frame with 
-    respect to Southern, and then the opposite if corrected components 
+    Function to sequentially stitch two frames along the same track. Mean
+    offset or 2pi integer cycles are estimated for each overlapping connected
+    components, which after correction are merged into the same component.
+    Code runs forward and backward, first correcting Northern frame with
+    respect to Southern, and then the opposite if corrected components
     overlap with multiple components in Southern frame.
 
     Parameters
@@ -64,23 +165,23 @@ def stitch_2frames(unw_data1 : NDArray, conn_data1 : NDArray, rdict1 : dict,
     conn_data1 : array
         array containing connected components in Frame-1 (South)
     rdict1 : dict
-        dict containing raster metadata [SNWE, latlon_spacing, nodata etc..] 
+        dict containing raster metadata [SNWE, latlon_spacing, nodata etc..]
         for Frame-1 (South)
     unw_data2 : array
         array containing unwrapped phase in Frame-2 (North)
     conn_data2 : array
         array containing connected components in Frame-2 (North)
     rdict2 : dict
-        dict containing raster metadata [SNWE, latlon_spacing, nodata etc..] 
+        dict containing raster metadata [SNWE, latlon_spacing, nodata etc..]
         for Frame-2 (North)
-    correction_method : str 
-        method to correct offset between overlapping connected components. 
+    correction_method : str
+        method to correct offset between overlapping connected components.
         Available options:
          "meanoff" - mean offset between components
-         "cycle2pi" - 2pi integer cycles between components 
+         "cycle2pi" - 2pi integer cycles between components
     verbose : bool
         print info messages [True/False]
-                                            
+
     Returns
     -------
     unw_data1 : array
@@ -92,153 +193,133 @@ def stitch_2frames(unw_data1 : NDArray, conn_data1 : NDArray, rdict1 : dict,
     conn_data2 : array
         corrected array containing connected components in Frame-2 (North)
 
-    TODO: combine corrected array in this function, return only the stitched 
-          unwrapped Phase and connectedComponent
     """
 
     # Adjust connected Component in Frame 2 to start
     # with last component number in Frame-1
+
     conn_data2 = conn_data2 + np.nanmax(conn_data1)
-    conn_data2[conn_data2==np.nanmax(conn_data1)] = 0.0
+    conn_data2[conn_data2 == np.nanmax(conn_data1)] = 0.0
 
-    ###### GET FRAME OVERLAP ##########
-    box_1, box_2  = frame_overlap(rdict1['SNWE'], 
-                               rdict2['SNWE'],
-                               [rdict1['LAT_SPACING'], rdict1['LON_SPACING']],
-                               [rdict2['LAT_SPACING'], rdict2['LON_SPACING']])
+    # GET FRAME OVERLAP
+    box_1, box_2 = frame_overlap(
+        rdict1['SNWE'], rdict2['SNWE'],
+        [rdict1['LAT_SPACING'], rdict1['LON_SPACING']],
+        [rdict2['LAT_SPACING'], rdict2['LON_SPACING']])
 
-    ###### LOOP OVER COMPONENTS WITHIN THE OVERLAP ########## 
+    # LOOP OVER COMPONENTS WITHIN THE OVERLAP
     # Get connected component pairs
     if verbose:
         print('\nGetting overlapping components')
-        
-    conn_pairs, conn_reverse = get_overlapping_conn(conn_data1[box_1],
-                                                    conn_data2[box_2])
 
     # Forward correction
+    conn_pairs = get_overlapping_conn(conn_data1[box_1],
+                                      conn_data2[box_2])
+
     for pair in conn_pairs:
-        diff, cycles2pi, range_corr = _integer_2pi_cycles(unw_data1[box_1],
-                                            conn_data1[box_1],
-                                            np.float32(pair[1]),
-                                            unw_data2[box_2],
-                                            conn_data2[box_2],
-                                            np.float32(pair[0]), 
-                                            range_correction=range_correction,
-                                            print_msg=verbose)
+        diff, cycles2pi, range_corr = _integer_2pi_cycles(
+            unw_data1[box_1],
+            conn_data1[box_1],
+            np.float32(pair[1]),
+            unw_data2[box_2],
+            conn_data2[box_2],
+            np.float32(pair[0]),
+            range_correction=range_correction,
+            print_msg=verbose)
 
         # Correction methods: mean difference, 2pi integer cycles
         if correction_method == 'cycle2pi':
             correction = cycles2pi
         elif correction_method == 'meandiff':
-            correction = diff 
+            correction = diff
         else:
             raise ValueError(f'Wrong correction method {correction_method}, ',
-                           f'Select one of available: "cycle2pi", "meandiff"')
-        
-        if correction:
-            # add range correction 
-            if range_correction: correction += range_corr
+                             'Select one of available: "cycle2pi", "meandiff"')
 
-            unw_data2[conn_data2 == np.float32(pair[0])] += \
-                correction
-            conn_data2[conn_data2 == np.float32(pair[0])] = \
-                np.float32(pair[1])
+        # add range correction
+        if range_correction:
+            correction += range_corr
+        ik = conn_data2 == np.float32(pair[0])
+        unw_data2[ik] += correction
+        conn_data2[ik] = np.float32(pair[1])
 
-            #  Correct reverse pairs as we updated connected components
-            if conn_reverse.any():
-                conn_reverse[conn_reverse[:,0] == pair[0], 0] = \
-                    np.float32(pair[1])
-        else:
-            if verbose:
-                print('SKIPPED!:', correction, pair, '\n')
-    
     # Backward correction
+    conn_reverse = get_overlapping_conn(conn_data2[box_2],
+                                        conn_data1[box_1])
+
+    # Keep only different componentes in pairing
+    ik = np.where(conn_reverse[:, 0] != conn_reverse[:, 1])
+    conn_reverse = conn_reverse[ik]
+
     for pair in conn_reverse:
-        diff, cycles2pi, range_corr = _integer_2pi_cycles(unw_data1[box_1],
-                                            conn_data1[box_1],
-                                            np.float32(pair[1]),
-                                            unw_data2[box_2],
-                                            conn_data2[box_2],
-                                            np.float32(pair[0]), 
-                                            range_correction=range_correction,
-                                            print_msg=verbose)
-        
+        diff, cycles2pi, range_corr = _integer_2pi_cycles(
+            unw1=unw_data1[box_1],
+            concom1=conn_data1[box_1],
+            ix1=np.float32(pair[0]),
+            unw2=unw_data2[box_2],
+            concom2=conn_data2[box_2],
+            ix2=np.float32(pair[1]),
+            range_correction=range_correction,
+            print_msg=verbose)
+
         # Correction methods: mean difference, 2pi integer cycles
         if correction_method == 'cycle2pi':
             correction = cycles2pi
         elif correction_method == 'meanoff':
-            correction = diff 
+            correction = diff
         else:
             raise ValueError(f'Wrong correction method {correction_method}, ',
-                            f'Select one of available: "cycle2pi", "meanoff"')
-        if correction:
-            # add range correction
-            if range_correction: correction += range_corr
+                             'Select one of available: "cycle2pi", "meanoff"')
 
-            unw_data1[conn_data1 == np.float32(pair[1])] -= \
-                correction
-            conn_data1[conn_data1 == np.float32(pair[1])] = \
-                np.float32(pair[0])
-                
-    return unw_data1, unw_data2, conn_data1, conn_data2
+        # add range correction
+        if range_correction:
+            correction += range_corr
+
+        ik = conn_data1 == np.float32(pair[0])
+        unw_data1[ik] -= correction
+        conn_data1[ik] = np.float32(pair[1])
+
+    # Update connected component frame 2 naming
+    idx1 = np.max(conn_data1)
+    idx = np.unique(conn_data2[conn_data2 > idx1]).compressed()
+    conn_data2 = update_connect_components(conn_data2, idx, idx1+1)
+
+    # Combine corrected unwrappedPhase and connectedComponents arrays
+    comb_snwe = [rdict1['SNWE'], rdict2['SNWE']]
+    comb_latlon = [[rdict1['LAT_SPACING'], rdict1['LON_SPACING']],
+                   [rdict2['LAT_SPACING'], rdict2['LON_SPACING']]]
+
+    (combined_unwrap,
+     combined_snwe,
+     combined_latlon_spacing) = combine_data_to_single(
+        [_nan_filled_array(unw_data1),
+         _nan_filled_array(unw_data2)],
+        comb_snwe, comb_latlon,
+        method='mean')
+    combined_conn, _, _ = combine_data_to_single(
+        [_nan_filled_array(conn_data1),
+         _nan_filled_array(conn_data2)],
+        comb_snwe, comb_latlon,
+        method='min')
+    # combined dict
+    combined_dict = dict(SNWE=combined_snwe,
+                         LAT_SPACING=combined_latlon_spacing[0],
+                         LON_SPACING=combined_latlon_spacing[1])
+
+    combined_unwrap = np.ma.masked_invalid(combined_unwrap)
+    np.ma.set_fill_value(combined_unwrap, 0.)
+    combined_conn = np.ma.masked_invalid(combined_conn)
+    np.ma.set_fill_value(combined_conn, -1.)
+
+    return combined_unwrap, combined_conn, combined_dict
 
 
-def stitch_2frames_metadata(unw_data1 : NDArray, rdict1 : dict,
-                  unw_data2 : NDArray, rdict2 : dict,
-                  verbose: Optional[bool] = False) -> Tuple[NDArray, NDArray]:
-    """Sequential stitching function implementation from `stitch_2frames`
-    for metadata layers
-
-    Parameters
-    ----------
-    unw_data1 : array
-        array containing unwrapped phase in Frame-1 (South)
-    rdict1 : dict
-        dict containing raster metadata [SNWE, latlon_spacing, nodata etc..] 
-        for Frame-1 (South)
-    unw_data2 : array
-        array containing unwrapped phase in Frame-2 (North)
-    rdict2 : dict
-        dict containing raster metadata [SNWE, latlon_spacing, nodata etc..] 
-        for Frame-2 (North)
-    verbose : bool
-        print info messages [True/False]
-                                            
-    Returns
-    -------
-    unw_data1 : array
-        corrected array containing unwrapped phase in Frame-1 (South)
-    unw_data2 : array
-        corrected array containing unwrapped phase in Frame-2 (North)
-
-    TODO: combine corrected array in this function, return only the 
-          stitched unwrapped Phase
+def get_overlapping_conn(conn1: NDArray,
+                         conn2: NDArray) -> Tuple[NDArray, NDArray]:
     """
-
-    ###### GET FRAME OVERLAP ##########
-    box_1, box_2  = frame_overlap(rdict1['SNWE'], 
-                               rdict2['SNWE'],
-                               [rdict1['LAT_SPACING'], rdict1['LON_SPACING']],
-                               [rdict2['LAT_SPACING'], rdict2['LON_SPACING']],
-                               [-0.1,0.1])
-
-    ###### EXAMINE THE OVERLAP ##########
-    for i in range(unw_data1.shape[0]):
-        diff = _metadata_offset(unw_data1[i][box_1],
-                            unw_data2[i][box_2], 
-                            print_msg=verbose)
-        
-        unw_data2[i] += diff
-                
-    return unw_data1, unw_data2
-
-
-def get_overlapping_conn(conn1 : NDArray, 
-                         conn2 : NDArray) -> Tuple[NDArray, NDArray]:
-    """
-    Get forward and backward pairs of overlapping connected components with 
+    Get forward and backward pairs of overlapping connected components with
     the number of overlaping pixels.
-    Return [connectComponent-Fram2, connectComponent-Frame1, number of pixels]
+    Return [connectComponent-Frame2, connectComponent-Frame1, number of pixels]
 
     Parameters
     ----------
@@ -255,88 +336,79 @@ def get_overlapping_conn(conn1 : NDArray,
         backward pairs of overlapping components
     """
 
-    conn_union = np.empty((0,3), dtype=np.int32)
+    conn_union = np.empty((0, 3), dtype=np.int32)
 
     # Get unique components
-    concomp1 = np.unique(conn1)
-    concomp2 = np.unique(conn2)
+    if np.ma.is_masked(conn1):
+        concomp1 = np.unique(conn1).compressed()
+    else:
+        concomp1 = np.unique(conn1)
+
+    if np.ma.is_masked(conn2):
+        concomp2 = np.unique(conn2).compressed()
+    else:
+        concomp2 = np.unique(conn2)
 
     # Loop through them and connect size and number of overlapping data
     for ix2 in concomp2:
         for ix1 in concomp1:
-            if ~np.isnan(ix1) and ~np.isnan(ix2):
-                data1 = conn1.copy()
-                data2 = conn2.copy() 
+            # Skip 0 component combination with other components
+            if not ix1 == 0 and not ix2 == 0:
+                idx = np.where((conn1 == ix1) & (conn2 == ix2))[0]
+                if np.count_nonzero(idx) > 0:
+                    carray = np.array([ix2, ix1, np.count_nonzero(idx)],
+                                      dtype=np.int32, ndmin=2)
 
-                # Use selected component data, mask other components
-                data1[data1!=ix1] =np.nan
-                data2[data2!=ix2] =np.nan
-                # Number of overlapping points
-                npoints_overlap = np.nansum(~np.isnan(data1 - data2))
+                    conn_union = np.concatenate((conn_union, carray), axis=0)
 
-                if npoints_overlap > 0: 
-                    # Array : conn-label Frame-2, conn-label Frame-1
-                    # points overlap
-                    connecting_array = np.array([ix2, ix1, npoints_overlap],
-                                                dtype=np.int32)
-                    # Skip 0 component combination with other components
-                    if not ix1==0.0 and not ix2==0.0:
-                        conn_union = np.concatenate((conn_union,
-                                             np.atleast_2d(connecting_array)),
-                                             axis=0)
-                    # Get 0 components in both frames 
-                    elif ix1==0.0 and ix2==0.0:
-                        conn_union = np.concatenate((conn_union,
-                                             np.atleast_2d(connecting_array)),
-                                             axis=0)
+            # Get 0 components in both frames
+            elif ix1 == 0 and ix2 == 0:
+                idx = np.where((conn1 == ix2) & (conn2 == ix1))[0]
+                if np.count_nonzero(idx) > 0:
+                    carray = np.array([ix2, ix1, np.count_nonzero(idx)],
+                                      dtype=np.int32, ndmin=2)
 
+                    conn_union = np.concatenate((conn_union, carray), axis=0)
 
-    # Find components to correct in Frame 2 
-    comp2correct = np.unique(conn_union[:,0])
+    # Find components to correct in Frame 2
+    conn_pairs = np.empty((0, 3), dtype=np.int32)
 
-    conn_pairs = np.empty((0,3), dtype=np.int32)
-    conn_pairs_reverse = np.empty((0,3), dtype=np.int32)
-    
-    for component in comp2correct:
+    for k in np.unique(conn_union[:, 0]):
+        ik = conn_union[:, 0] == k
         # find number of times components is referenced
-        count = np.sum(~np.isnan(np.where(conn_union[:,0] == component)[0]))
-        
+        count = np.sum(conn_union[:, 0] == k)
+
         if count > 1:
-        #find the one with most points in overlap
-            max_points = np.max(conn_union[np.where(conn_union[:,0] == \
-                                component)[0], 2])
-            # store it for forward stitching
-            ix = np.where(conn_union[:,2] == max_points)[0]
-            conn_pairs = np.concatenate((conn_pairs, 
-                                         np.atleast_2d(conn_union[ix,:])),
-                                         axis=0)
-            
-            # store it for backward stitching
-            iy = np.where((conn_union[:,0] == component) & \
-                          (conn_union[:,2] != max_points))[0]
-            conn_pairs_reverse = np.concatenate((conn_pairs_reverse,
-                                            np.atleast_2d(conn_union[iy, :])),
-                                            axis=0)
+            max_points = np.max(conn_union[ik][:, 2])
+            # Select the one with the most points
+            ik = np.where((conn_union[:, 0] == k) &
+                          (conn_union[:, 2] == max_points))[0]
+            # Select first if there are more pairs with same num of points
+            ik = np.array(ik[0], ndmin=1) if ik.shape[0] > 1 else ik
 
-        # If count is 1 store the connecting component pair
-        else:
-            ik = np.where(conn_union[:,0] == component)[0]
-            conn_pairs = np.concatenate((conn_pairs,
-                                        np.atleast_2d(conn_union[ik,:])),
-                                        axis=0) 
+        conn_pairs = np.concatenate((conn_pairs, conn_union[ik]), axis=0)
 
-    return conn_pairs, conn_pairs_reverse
+    return conn_pairs
 
 
-def _integer_2pi_cycles(unw1 : NDArray, concom1 : NDArray, ix1 : np.float32,
-                        unw2 : NDArray, concom2 : NDArray, ix2 : np.float32,
-                        range_correction : Optional[bool] = False,
-                        print_msg : Optional[bool] = False) -> \
-                                    Tuple[np.float32, np.float32, np.float32]:
+def update_connect_components(conncomp_array: NDArray,
+                              unique_components: NDArray,
+                              renumber_from: int = 21) -> NDArray:
+    c = conncomp_array.copy()
+    for ix, component in enumerate(unique_components):
+        c[conncomp_array == component] = renumber_from + ix
+    return conncomp_array
+
+
+def _integer_2pi_cycles(unw1: NDArray, concom1: NDArray, ix1: np.float32,
+                        unw2: NDArray, concom2: NDArray, ix2: np.float32,
+                        range_correction: Optional[bool] = False,
+                        print_msg: Optional[bool] = False) -> \
+        Tuple[np.float32, np.float32, np.float32]:
     """
     Get mean difference of unwrapped Phase values for overlapping
     connected components as 2pi int cycles
-    
+
     Parameters
     ----------
     unw1 : array
@@ -345,16 +417,16 @@ def _integer_2pi_cycles(unw1 : NDArray, concom1 : NDArray, ix1 : np.float32,
         array containing connected components in Frame-1 (South)
     ix1 : float
         connected component lablein Frame-1 (South), (1...n, 0 is unrealiable)
-        
+
     unw2 : array
         array containing unwrapped phase in Frame-2 (North)
     concom2 : array
         array containing connected components in Frame-2 (North)
     ix2 : float
-        connected component label in Frame-2 (North), 
+        connected component label in Frame-2 (North),
         (1...n, 0 is unrealiable)
     range_correction: bool
-        calculate range correction due to small non 2-pi shift caused by 
+        calculate range correction due to small non 2-pi shift caused by
         ESD different between frames
 
     Returns
@@ -366,20 +438,14 @@ def _integer_2pi_cycles(unw1 : NDArray, concom1 : NDArray, ix1 : np.float32,
     range_corr : float
         correction for non 2-pi shift between overlapping component
         in two frames
-    """  
-    # Not sure if copy() is needed, left it here to avoid overwriting array
-    # due to numpy referencing
-    # TODO: use np.where to find the component in the data and keep overlap
+    """
+    # find the component in the data and keep overlap
     # dimensions for comparison
-    data1 = unw1.copy()
-    data2 = unw2.copy()
-    
-    data1[concom1 != ix1] = np.nan
-    data2[concom2 != ix2] = np.nan
+    idx = np.where((concom1 == ix1) & (concom2 == ix2))
 
-    diff_value = np.nanmean(data1 - data2)
-    std_value = np.nanstd(data1 - data2)
-    n_points = np.sum(~np.isnan(data1 - data2))
+    n_points = np.count_nonzero(unw1[idx] - unw2[idx])
+    diff_value = np.nanmean(unw1[idx] - unw2[idx])
+    std_value = np.nanstd(unw1[idx] - unw2[idx])
 
     # Number of 2pi integer jumps
     num_jump = (np.abs(diff_value) + np.pi) // (2.*np.pi)
@@ -387,35 +453,34 @@ def _integer_2pi_cycles(unw1 : NDArray, concom1 : NDArray, ix1 : np.float32,
     if diff_value < 0:
         num_jump *= -1
 
-    correction2pi = 2.* np.pi *num_jump
+    correction2pi = 2. * np.pi * num_jump
 
     # Get range_correction if selected
     if range_correction:
-        range_corr = _range_correction(data1, data2)
+        range_corr = _range_correction(unw1[idx], unw2[idx])
     else:
-       range_corr = 0 
+        range_corr = 0
 
-    if n_points != 0:
-        if print_msg:
-            print(f'  Frame-1 component: {ix1} - Frame-2 component: {ix2}\n'
-                f'   Number of points: {n_points}\n'
-                f'   Mean diff: {diff_value:.2f}, std: {std_value:.2f} rad\n'
-                f'   Number of 2pi cycles: {num_jump}\n'
-                f'   Correction2pi: {correction2pi:.2f}')
-            if range_correction: print(f'Range Corr: {range_corr:.2f} \n',
-                   f'2piCorr + RangeCorr: {correction2pi + range_corr:.2f}\n')
+    if print_msg:
+        print(
+            f'  Frame-1 component: {ix1} - Frame-2 component: {ix2}\n'
+            f'   Number of points: {n_points}\n'
+            f'   Mean diff: {diff_value:.2f}, std: {std_value:.2f} rad\n'
+            f'   Number of 2pi cycles: {num_jump}\n'
+            f'   Correction2pi: {correction2pi:.2f}')
+        if range_correction:
+            print(
+                f'Range Corr: {range_corr:.2f} \n',
+                f'2piCorr + RangeCorr: {correction2pi + range_corr:.2f}\n')
 
-        return diff_value, correction2pi, range_corr
-    else:
-        print(f' {np.sum(~np.isnan(data1))}: {np.sum(~np.isnan(data2))}\n'
-              f' Number of points: {n_points}')
-        return None, None, None
+    return diff_value, correction2pi, range_corr
 
-def _range_correction(unw1 : NDArray,
-                      unw2 : NDArray) -> np.float32:
+
+def _range_correction(unw1: NDArray,
+                      unw2: NDArray) -> np.float32:
     """
-    Calculate range correction due to small non 2-pi shift caused by ESD 
-    different between frames. If ESD is not used, this correction 
+    Calculate range correction due to small non 2-pi shift caused by ESD
+    different between frames. If ESD is not used, this correction
     can be skipped
 
     Parameters
@@ -424,35 +489,88 @@ def _range_correction(unw1 : NDArray,
         array containing unwrapped phase in Frame-1 (South)
     unw2 : array
         array containing unwrapped phase in Frame-2 (North)
-    
+
     Returns
     -------
     range_corr : float
-        correction for non 2-pi shift 
+        correction for non 2-pi shift
     """
 
-    # Wrap unwrapped Phase in Frame-1 and Frame-2 
-    unw1_wrapped = np.mod(unw1,(2*np.pi))-np.pi
-    unw2_wrapped = np.mod(unw2,(2*np.pi))-np.pi
+    # Wrap unwrapped Phase in Frame-1 and Frame-2
+    unw1_wrapped = np.mod(unw1, (2*np.pi))-np.pi
+    unw2_wrapped = np.mod(unw2, (2*np.pi))-np.pi
 
     # Get the difference between wrapped images
-    arr =unw1_wrapped - unw2_wrapped
+    arr = unw1_wrapped - unw2_wrapped
     arr -= np.round(arr/(2*np.pi))*2*np.pi
     range_corr = np.angle(np.nanmean(np.exp(1j*arr)))
 
     return range_corr
 
 
-def _metadata_offset(unw1 : NDArray, unw2 : NDArray,
-                     print_msg : Optional[bool] = False) -> Tuple[np.float32]:
+# Stitching routines for another layers
+
+def stitch_2frames_metadata(
+        unw_data1: NDArray, rdict1: dict,
+        unw_data2: NDArray, rdict2: dict,
+        verbose: Optional[bool] = False) -> Tuple[NDArray, NDArray]:
+    """Sequential stitching function implementation from `stitch_2frames`
+    for metadata layers
+
+    Parameters
+    ----------
+    unw_data1 : array
+        array containing unwrapped phase in Frame-1 (South)
+    rdict1 : dict
+        dict containing raster metadata [SNWE, latlon_spacing, nodata etc..]
+        for Frame-1 (South)
+    unw_data2 : array
+        array containing unwrapped phase in Frame-2 (North)
+    rdict2 : dict
+        dict containing raster metadata [SNWE, latlon_spacing, nodata etc..]
+        for Frame-2 (North)
+    verbose : bool
+        print info messages [True/False]
+
+    Returns
+    -------
+    unw_data1 : array
+        corrected array containing unwrapped phase in Frame-1 (South)
+    unw_data2 : array
+        corrected array containing unwrapped phase in Frame-2 (North)
+
+    TODO: combine corrected array in this function, return only the
+          stitched unwrapped Phase
+    """
+
+    # GET FRAME OVERLAP
+    box_1, box_2 = frame_overlap(
+        rdict1['SNWE'], rdict2['SNWE'],
+        [rdict1['LAT_SPACING'], rdict1['LON_SPACING']],
+        [rdict2['LAT_SPACING'], rdict2['LON_SPACING']],
+        [-0.1, 0.1])
+
+    # EXAMINE THE OVERLAP
+    for i in range(unw_data1.shape[0]):
+        diff = _metadata_offset(unw_data1[i][box_1],
+                                unw_data2[i][box_2],
+                                print_msg=verbose)
+
+        unw_data2[i] += diff
+
+    return unw_data1, unw_data2
+
+
+def _metadata_offset(unw1: NDArray, unw2: NDArray,
+                     print_msg: Optional[bool] = False) -> Tuple[np.float32]:
     """
     Get mean difference of metadata layers
-    
+
     Parameters
     ----------
     unw1 : array
         array containing unwrapped phase in Frame-1 (South)
-        
+
     unw2 : array
         array containing unwrapped phase in Frame-2 (North)
 
@@ -460,20 +578,21 @@ def _metadata_offset(unw1 : NDArray, unw2 : NDArray,
     -------
     diff_value : float
         mean offset between overlapping area in two frames
-    """  
+    """
     # Not sure if copy() is needed, left it here to avoid overwriting array
     # due to numpy referencing
     # TODO: use np.where to find the component in the data and keep overlap
     # dimensions for comparison
     data1 = unw1.copy()
     data2 = unw2.copy()
-    
+
     diff_value = np.nanmean(data1 - data2)
     n_points = np.sum(~np.isnan(data1 - data2))
 
     if n_points != 0:
         if print_msg:
-            print(f'   Number of points: {n_points}\n'
+            print(
+                f'   Number of points: {n_points}\n'
                 f'   Mean diff: {diff_value:.2f}\n')
 
         return diff_value
@@ -482,47 +601,47 @@ def _metadata_offset(unw1 : NDArray, unw2 : NDArray,
               f' Number of points: {n_points}')
         return None
 
+# MAIN
 
-########################### MAIN #############################################
 
-def product_stitch_sequential(input_unw_files : List[str],
-                             input_conncomp_files : List[str],
-                             arrres : List[float],
-                             output_unw : Optional[str] = './unwMerged',
-                             output_conn : Optional[str] = './connCompMerged',
-                             output_format : Optional[str] = 'ENVI',
-                             bounds : Optional[tuple] = None, 
-                             clip_json : Optional[str] = None,
-                             mask_file : Optional[str] = None,
-                             # [meandiff, cycle2pi]
-                             correction_method : Optional[str] = 'cycle2pi',
-                             range_correction : Optional[bool] = True,
-                             verbose : Optional[bool] = False,
-                             save_fig : Optional[bool] = False,
-                             overwrite : Optional[bool] = True) -> None:
+def product_stitch_sequential(input_unw_files: List[str],
+                              input_conncomp_files: List[str],
+                              arrres: List[float],
+                              output_unw: Optional[str] = './unwMerged',
+                              output_conn: Optional[str] = './connCompMerged',
+                              output_format: Optional[str] = 'ENVI',
+                              bounds: Optional[tuple] = None,
+                              clip_json: Optional[str] = None,
+                              mask_file: Optional[str] = None,
+                              # [meandiff, cycle2pi]
+                              correction_method: Optional[str] = 'cycle2pi',
+                              range_correction: Optional[bool] = True,
+                              verbose: Optional[bool] = False,
+                              save_fig: Optional[bool] = False,
+                              overwrite: Optional[bool] = True) -> None:
     """
-    Sequential stitching of frames along the track. Starts from the Southern 
-    frame and goes towards the North. Stitching is perform with forward and 
-    backward corrections of overlapping components between two neighboring 
-    frames. The stitched track is stored locally, and then cropped to meet 
-    the defined ARIAtools bounding box and masked with a water-mask 
+    Sequential stitching of frames along the track. Starts from the Southern
+    frame and goes towards the North. Stitching is perform with forward and
+    backward corrections of overlapping components between two neighboring
+    frames. The stitched track is stored locally, and then cropped to meet
+    the defined ARIAtools bounding box and masked with a water-mask
     if selected.
 
     Parameters
     ----------
     input_unw_files : list
-        list of S1 files with Unw Phase (multiple frames along same track) 
+        list of S1 files with Unw Phase (multiple frames along same track)
         ARIA GUNW:
         'NETCDF:"%path/S1-GUNW-*.nc":/science/grids/data/unwrappedPhase'
     input_conncomp_files : list
-        list of S1 files with Connected Components of unwrapped phase 
-        (multiple frames along same track) 
-        ARIA GUNW: 
+        list of S1 files with Connected Components of unwrapped phase
+        (multiple frames along same track)
+        ARIA GUNW:
         'NETCDF:"%path/S1-GUNW-*.nc":/science/grids/data/connectedComponents'
     output_unw : str
         str pointing to path and filename of output stitched Unwrapped Phase
     output_conn : str
-        str pointing to path and filename of output stitched 
+        str pointing to path and filename of output stitched
         Connected Components
     output_format : str
         output format used for gdal writer [e.g., Gtiff ENVI], default is ENVI
@@ -531,14 +650,14 @@ def product_stitch_sequential(input_unw_files : List[str],
     clip_json : str
         path to /productBoundingBox.json producted by ariaExtract.py
     mask_file : str
-        path to water mask file, example: 
+        path to water mask file, example:
         %aria_extract_path/mask/watermask.msk.vrt
     correction_method : str
-        correction method for overlapping components, available options: 
-         meanoff - mean offset between components 
-         cycle2pi - 2pi integer cycles between components 
+        correction method for overlapping components, available options:
+         meanoff - mean offset between components
+         cycle2pi - 2pi integer cycles between components
     range_correction : bool
-        use correction for non 2-pi shift in overlapping components 
+        use correction for non 2-pi shift in overlapping components
         [True/False]
     verbose : bool
         print info messages [True/False]
@@ -546,8 +665,8 @@ def product_stitch_sequential(input_unw_files : List[str],
         save figure with stitched outputs [True/False]
     overwrite : bool
         overwrite stitched products [True/False]
-                                       
-    NOTE: Move cropping (gdal.Warp to bounds and clip_json) and masking 
+
+    NOTE: Move cropping (gdal.Warp to bounds and clip_json) and masking
           to ariaExtract.py to make this function modular for other use
     """
 
@@ -569,124 +688,32 @@ def product_stitch_sequential(input_unw_files : List[str],
                       input_unw_files)
         gdal.BuildVRT(str(temp_conn_out.with_suffix('.vrt')),
                       input_conncomp_files)
-    
+
     else:
-        # Get raster attributes [SNWE, latlon_spacing, length, width. nodata]
-        # from each input file
-
-        # Initalize variables
-        unw_attr_dicts = []  # unwrappedPhase
-        conncomp_attr_dicts = [] # connectedComponents
-    
-        # We assume that the filename order is the same for unwrappedPhase and
-        # connectedComponent lists 
-        temp_snwe_list = []
-        temp_latlon_spacing_list = []
-
-        for unw_file, conn_file in zip(input_unw_files, input_conncomp_files):
-            unw_attr_dicts.append(get_GUNW_attr(unw_file))
-            conncomp_attr_dicts.append(get_GUNW_attr(conn_file))
-            # get frame bounds, assume are the same for unw and conncomp
-            temp_snwe_list.append(unw_attr_dicts[-1]['SNWE'])
-            temp_latlon_spacing_list.append([unw_attr_dicts[-1]['LAT_SPACING'], 
-                                        unw_attr_dicts[-1]['LON_SPACING']])
-
-        # get sorted indices for frame bounds, from South to North
-        # Sequential stitching starts from the most south frame and moves 
-        # forward to next one in the North direction
-        # TODO: add option to reverse direction of stitching
-        sorted_ix = np.argsort(np.array(temp_snwe_list)[:,0], axis=0)
-
-        # Loop through attributes
-        snwe_list = [temp_snwe_list[ii] for ii in sorted_ix]
-        latlon_spacing_list = [temp_latlon_spacing_list[ii] for ii in sorted_ix]
-    
-        # Loop through sorted frames, and stitch neighboring frames
-        for i, (ix1, ix2) in enumerate(zip(sorted_ix[:-1], sorted_ix[1:])):
-            if verbose:
-                print('Frame-1:',
-                     unw_attr_dicts[ix1]['PATH'].split('"')[1].split('/')[-1])
-                print('Frame-2:',
-                     unw_attr_dicts[ix2]['PATH'].split('"')[1].split('/')[-1])
-            # Frame1
-            frame1_unw_array = get_GUNW_array(unw_attr_dicts[ix1]['PATH'])
-            frame1_conn_array = get_GUNW_array( \
-                                    conncomp_attr_dicts[ix1]['PATH'])
-            # Frame2
-            frame2_unw_array = get_GUNW_array(unw_attr_dicts[ix2]['PATH'])
-            frame2_conn_array = get_GUNW_array( \
-                                    conncomp_attr_dicts[ix2]['PATH'])
-
-            # Mask nodata values
-            frame1_unw_array[frame1_unw_array == \
-                             unw_attr_dicts[ix1]['NODATA']] = np.nan
-            frame1_conn_array[frame1_conn_array == \
-                             conncomp_attr_dicts[ix1]['NODATA']] = np.nan
-            frame2_unw_array[frame2_unw_array == \
-                             unw_attr_dicts[ix2]['NODATA']] = np.nan
-            frame2_conn_array[frame2_conn_array == \
-                             conncomp_attr_dicts[ix2]['NODATA']] = np.nan
-
-            if i == 0:
-                (corr_uw1, corr_unw2,
-                 corr_conn1, corr_conn2) = stitch_2frames(frame1_unw_array,
-                                          frame1_conn_array,
-                                          unw_attr_dicts[ix1],
-                                          frame2_unw_array,
-                                          frame2_conn_array,
-                                          unw_attr_dicts[ix2],
-                                          correction_method=correction_method,
-                                          range_correction=range_correction,
-                                          verbose=verbose)
-                # Store corrected values
-                corrected_unw_arrays = [corr_uw1, corr_unw2]
-                corrected_conn_arrays = [corr_conn1, corr_conn2]
-            else:
-                (corr_uw1, corr_unw2,
-                 corr_conn1, corr_conn2) = stitch_2frames( \
-                                          corrected_unw_arrays[-1],
-                                          corrected_conn_arrays[-1],
-                                          unw_attr_dicts[ix1],
-                                          frame2_unw_array,
-                                          frame2_conn_array,
-                                          unw_attr_dicts[ix2], 
-                                          correction_method=correction_method,
-                                          range_correction=range_correction,
-                                          verbose=verbose)
-
-                # Overwrite the last element in corrected arrays
-                # TODO: check how to do this without using del
-                del corrected_unw_arrays[-1], corrected_conn_arrays[-1] 
-                corrected_unw_arrays.extend([corr_uw1, corr_unw2])
-                corrected_conn_arrays.extend([corr_conn1, corr_conn2])      
-
-        # Combine corrected unwrappedPhase and connectedComponents arrays
-        combined_unwrap, combined_snwe, _ = combine_data_to_single( \
-                                                         corrected_unw_arrays,
-                                                         snwe_list,
-                                                         latlon_spacing_list,
-                                                         method='mean')
-        combined_conn, _, _ = combine_data_to_single(corrected_conn_arrays,
-                                                     snwe_list,
-                                                     latlon_spacing_list,
-                                                     method='min')
-
-        # replace nan with 0.0
-        combined_unwrap = np.nan_to_num(combined_unwrap, nan=0.0)
-        combined_conn = np.nan_to_num(combined_conn, nan=-1.0)
+        (combined_unwrap,
+         combined_conn,
+         combined_snwe) = stitch_unwrapped_frames(
+            input_unw_files,
+            input_conncomp_files,
+            correction_method=correction_method,
+            range_correction=range_correction,
+            direction_N_S=False,
+            verbose=verbose)
 
         # Write
         # write stitched unwrappedPhase
-        write_GUNW_array(temp_unw_out, combined_unwrap, combined_snwe,
-                     format=output_format, verbose=verbose,
-                     update_mode=overwrite, add_vrt=True, nodata=0.0)
-    
-        # write stitched connectedComponents 
-        write_GUNW_array(temp_conn_out, combined_conn, combined_snwe,
-                     format=output_format, verbose=verbose,
-                     update_mode=overwrite, add_vrt=True, nodata=-1.0)
+        write_GUNW_array(
+            temp_unw_out, combined_unwrap, combined_snwe,
+            format=output_format, verbose=verbose,
+            update_mode=overwrite, add_vrt=True, nodata=0.0)
 
-    # Crop 
+        # write stitched connectedComponents
+        write_GUNW_array(
+            temp_conn_out, combined_conn, combined_snwe,
+            format=output_format, verbose=verbose,
+            update_mode=overwrite, add_vrt=True, nodata=-1.0)
+
+    # Crop
     [print(f'Cropping to {bounds}') if verbose and bounds else None]
     if overwrite:
         [print(f'Removing {output_unw}, {output_conn}') if verbose else None]
@@ -698,67 +725,63 @@ def product_stitch_sequential(input_unw_files : List[str],
     #       Also, it looks like it is important to close gdal.Warp
     #       gdal.Warp/Translate add 6 seconds to runtime
 
-    for output, input in zip([output_unw, output_conn], \
+    for output, input in zip([output_unw, output_conn],
                              [temp_unw_out, temp_conn_out]):
-        # Crop if selected 
-        ds = gdal.Warp(str(output), 
+        # Crop if selected
+        ds = gdal.Warp(str(output),
                        str(input.with_suffix('.vrt')),
                        format=output_format,
                        cutlineDSName=clip_json,
                        xRes=arrres[0], yRes=arrres[1],
                        targetAlignedPixels=True,
-                       #cropToCutline = True,
+                       # cropToCutline = True,
                        outputBounds=bounds
-                    )
+                       )
         ds = None
         # Update VRT
-        [print(f'Writing {output}, {output.with_suffix(".vrt")}') 
+        [print(f'Writing {output}, {output.with_suffix(".vrt")}')
          if verbose else None]
         gdal.Translate(str(output.with_suffix('.vrt')),
                        str(output), format="VRT")
         # Remove temp files
-        [ii.unlink() for ii in [input, input.with_suffix('.vrt'), 
-                                input.with_suffix('.hdr'), 
+        [ii.unlink() for ii in [input, input.with_suffix('.vrt'),
+                                input.with_suffix('.hdr'),
                                 input.with_suffix('.aux.xml')] if ii.exists()]
 
         # Mask
         if mask_file:
-            if verbose:
-                print(f'Mask {output} with {mask_file.GetDescription()}')
-
             mask_array = mask_file.ReadAsArray()
             array = get_GUNW_array(str(output.with_suffix('.vrt')))
 
             if output == output_conn:
                 # Mask connected components
-                array[array==-1.0] = np.nan
+                array[array == -1.0] = np.nan
                 update_array = mask_array * array
                 update_array = np.nan_to_num(update_array, nan=-1.0)
-                #update_array[np.isnan(update_array)] = -1.0
+                # update_array[np.isnan(update_array)] = -1.0
             else:
                 update_array = mask_array * array
 
-            update_file=gdal.Open(str(output), gdal.GA_Update)
-            update_file=update_file.GetRasterBand(1).WriteArray(update_array)
-            update_file=None
+            update_file = gdal.Open(str(output), gdal.GA_Update)
+            update_file = update_file.GetRasterBand(1).WriteArray(update_array)
+            update_file = None
 
     # Plot stitched
-    # NOTE: saving output figure adds 4 seconds 
+    # NOTE: saving output figure adds 4 seconds
     if save_fig:
         plot_GUNW_stitched(str(output_unw.with_suffix('.vrt')),
                            str(output_conn.with_suffix('.vrt')))
 
     # Remove temp files
-    [ii.unlink() for ii in [temp_unw_out, 
-                            temp_unw_out] if ii.exists()]              
-
-    return
+    [ii.unlink() for ii in [temp_unw_out,
+                            temp_unw_out] if ii.exists()]
 
 
-def product_stitch_sequential_metadata(input_meta_files : List[str],
-                              output_meta : Optional[str]  = './unwMerged',
-                              output_format : Optional[str] = 'ENVI',
-                              verbose : Optional[bool] = False) -> None:
+def product_stitch_sequential_metadata(
+        input_meta_files: List[str],
+        output_meta: Optional[str] = './tempMerged',
+        output_format: Optional[str] = 'ENVI',
+        verbose: Optional[bool] = False) -> None:
     """
     Sequential stitching of frames implementation from
     `product_stitch_sequential` for metadata layers
@@ -775,7 +798,7 @@ def product_stitch_sequential_metadata(input_meta_files : List[str],
         output format used for gdal writer [Gtiff, ENVI, VRT], default is ENVI
     verbose : bool
         print info messages [True/False]
-                                       
+
     NOTE: Move cropping (gdal.Warp to bounds and clip_json) and masking to
           ariaExtract.py to make this function modular for other use
     """
@@ -788,7 +811,7 @@ def product_stitch_sequential_metadata(input_meta_files : List[str],
 
     # Outputs
     output_meta = Path(output_meta).absolute()
-    
+
     # Get raster attributes [SNWE, latlon_spacing, length, width. nodata]
     # from each input file
 
@@ -800,19 +823,19 @@ def product_stitch_sequential_metadata(input_meta_files : List[str],
     for meta_file in input_meta_files:
         meta_attr_dicts.append(get_GUNW_attr(meta_file))
         temp_snwe_list.append(meta_attr_dicts[-1]['SNWE'])
-        temp_latlon_spacing_list.append([meta_attr_dicts[-1]['LAT_SPACING'], 
+        temp_latlon_spacing_list.append([meta_attr_dicts[-1]['LAT_SPACING'],
                                         meta_attr_dicts[-1]['LON_SPACING']])
 
     # get sorted indices for frame bounds, from South to North
-    # Sequential stitching starts from the most south frame and moves 
+    # Sequential stitching starts from the most south frame and moves
     # forward to next one in the North direction
     # TODO: add option to reverse direction of stitching
-    sorted_ix = np.argsort(np.array(temp_snwe_list)[:,0], axis=0)
+    sorted_ix = np.argsort(np.array(temp_snwe_list)[:, 0], axis=0)
 
     # Loop through attributes
     snwe_list = [temp_snwe_list[ii] for ii in sorted_ix]
     latlon_spacing_list = [temp_latlon_spacing_list[ii] for ii in sorted_ix]
-    
+
     # Loop through sorted frames, and stitch neighboring frames
     for i, (ix1, ix2) in enumerate(zip(sorted_ix[:-1], sorted_ix[1:])):
         if verbose:
@@ -821,32 +844,32 @@ def product_stitch_sequential_metadata(input_meta_files : List[str],
             print('Frame-2:',
                   meta_attr_dicts[ix2]['PATH'].split('"')[1].split('/')[-1])
         # Frame1
-        frame1_meta_array = get_GUNW_array(meta_attr_dicts[ix1]['PATH']) 
+        frame1_meta_array = get_GUNW_array(meta_attr_dicts[ix1]['PATH'])
         # Frame2
-        frame2_meta_array = get_GUNW_array(meta_attr_dicts[ix2]['PATH']) 
+        frame2_meta_array = get_GUNW_array(meta_attr_dicts[ix2]['PATH'])
 
         # Mask nodata values
-        frame1_meta_array[frame1_meta_array == \
+        frame1_meta_array[frame1_meta_array ==
                           meta_attr_dicts[ix1]['NODATA']] = np.nan
-        frame2_meta_array[frame2_meta_array == \
+        frame2_meta_array[frame2_meta_array ==
                           meta_attr_dicts[ix2]['NODATA']] = np.nan
 
         if i == 0:
-            (corr_meta1, corr_meta2) = stitch_2frames_metadata( \
-                                           frame1_meta_array,
-                                           meta_attr_dicts[ix1],
-                                           frame2_meta_array,
-                                           meta_attr_dicts[ix2],
-                                           verbose=verbose)
+            (corr_meta1, corr_meta2) = stitch_2frames_metadata(
+                frame1_meta_array,
+                meta_attr_dicts[ix1],
+                frame2_meta_array,
+                meta_attr_dicts[ix2],
+                verbose=verbose)
             # Store corrected values
             corrected_meta_arrays = [corr_meta1, corr_meta2]
         else:
-            (corr_meta1, corr_meta2) = stitch_2frames_metadata( \
-                                           corrected_meta_arrays[-1],
-                                           meta_attr_dicts[ix1],
-                                           frame2_meta_array,
-                                           meta_attr_dicts[ix2],
-                                           verbose=verbose)
+            (corr_meta1, corr_meta2) = stitch_2frames_metadata(
+                corrected_meta_arrays[-1],
+                meta_attr_dicts[ix1],
+                frame2_meta_array,
+                meta_attr_dicts[ix2],
+                verbose=verbose)
 
             # Overwrite the last element in corrected arrays
             # TODO: check how to do this without using del
@@ -854,394 +877,22 @@ def product_stitch_sequential_metadata(input_meta_files : List[str],
             corrected_meta_arrays.extend([corr_meta1, corr_meta2])
 
     # Combine corrected unwrappedPhase arrays
-    combined_meta, combined_snwe, _ = combine_data_to_single( \
-                                           corrected_meta_arrays, snwe_list, 
-                                           latlon_spacing_list, method='mean',
-                                           latlon_step=[-0.1,0.1])
+    combined_meta, combined_snwe, _ = combine_data_to_single(
+        corrected_meta_arrays, snwe_list,
+        latlon_spacing_list, method='mean',
+        latlon_step=[-0.1, 0.1])
 
     # replace nan with 0.0
     combined_meta = np.nan_to_num(combined_meta, nan=0.0)
 
-    # Write 
+    # Write
     # create temp files
     meta_out = output_meta.parent / (output_meta.name)
     # write stitched metadata product
-    write_GUNW_array(meta_out, combined_meta, combined_snwe, 
-                     format=output_format, verbose=verbose, 
+    write_GUNW_array(meta_out, combined_meta, combined_snwe,
+                     format=output_format, verbose=verbose,
                      add_vrt=True, nodata=0.0)
 
-
-    return
-
-
-############################################################################
-#################### READ/WRITE GDAL UTILITIES #############################
-def get_GUNW_attr(filename : Union[str, Path]) -> dict:
-    """
-    Use GDAl to get raster metadata
-    
-    Parameters
-    ----------
-    filename : str
-        path to raster 
-
-    Returns
-    -------
-    raster_attr : dict
-        raster attribute dict 
-        [path, nodata, len, wid, snwe, lon_spacing, lat_spacing, projection]
-    """
-
-    # Use GDAL to read GUNW netcdf
-    ds = gdal.Open(filename, gdal.GA_ReadOnly)
-
-    # Get GUNW Raster attributes
-    nodata = ds.GetRasterBand(1).GetNoDataValue()
-
-    # Get raster geographical information
-    transform = ds.GetGeoTransform()
-    xsize = ds.RasterXSize
-    ysize = ds.RasterYSize
-    snwe = [transform[3] + ysize * transform[5], transform[3],
-            transform[0], transform[0] + xsize * transform[1]]
-    lon_spacing = transform[1]
-    lat_spacing = transform[5]
-    
-    projection = ds.GetProjection()
-
-    # wrap raster info in dict
-    raster_attr = {'PATH'   : filename,
-                   'NODATA' : nodata,
-                   'LENGTH' : ysize,
-                   'WIDTH'  : xsize,
-                   'SNWE'   : snwe,
-                   'LON_SPACING' : lon_spacing,
-                   'LAT_SPACING' : lat_spacing,
-                   'PROJECTION' : projection}
-
-    # close
-    ds = None
-
-    return raster_attr
-
-def get_GUNW_array(filename : Union[str, Path],
-                   subset : Optional[tuple] = None) -> NDArray:
-    """
-    Use GDAl to get raster data [as array]
-
-    Parameters
-    ----------
-    filename : str
-        path to raster
-    subset : slice
-        subset created with np.s_ TODO: insert tuple of (x1,x2, y1,y2)
-        and then convert to slice with np.s_
-
-    Returns
-    -------
-    data : array
-        raster data 2D array [length x width]
-    """
-    
-    # Use GDAL to read GUNW netcdf
-    ds = gdal.Open(filename, gdal.GA_ReadOnly)
-
-    data =  ds.ReadAsArray()
-    # close
-    ds = None
-
-    # Subset array
-    if subset:
-        data = data[subset]
-
-    return data
-
-def write_GUNW_array(output_filename: Union[str, Path], 
-                     array:np.ndarray, 
-                     snwe:list,
-                     nodata: Optional[str] = 'NAN',
-                     format : Optional[str] ='ENVI',
-                     epsg : Optional[int]= 4326,
-                     add_vrt : Optional[bool] = True, 
-                     verbose : Optional[bool] = False,
-                     update_mode : Optional[bool] = True) -> None:
-    """
-    Use GDAl to write raster 
-
-    Parameters
-    ----------
-    output_filename : str
-        path to raster
-    array : array
-        numpy array of raster to be written
-    snwe  : list
-        (South, North, West, East) bounds of raster to be written
-    nodata : str
-        value or nan for NODATA (used for VRT creation)
-    format : str
-        output raster format, default is ENVI
-    epsg : int
-        projection epsg, default is 4326 for WGS84
-    add_vrt : bool
-        flag to create VRT for output raster [True/False] 
-    verbose : bool
-        print info messages [True/False]
-    update_mode : bool
-        flag to overwrite the existing files [True/False]
-    """
-
-    array_type = gdal_array.NumericTypeCodeToGDALTypeCode(array.dtype)
-
-    # Output path
-    output = Path(output_filename).absolute()
-    output_vrt = output.with_suffix('.vrt') 
-
-    if update_mode:
-        [print(f'Remove {output}') if verbose else None]
-        output.unlink(missing_ok=True)
-        if add_vrt:
-            [print(f'Remove {output_vrt}') if verbose else None]
-            output_vrt.unlink(missing_ok=True)
-    
-    # Get lat, lon pixel spacing
-    num_bands = 1
-    if len(array.shape) > 2:
-        num_bands = array.shape[0]
-        x_step = (snwe[3] - snwe[2]) / array.shape[2]
-        y_step = (snwe[0] - snwe[1]) / array.shape[1]
-    else:
-        x_step = (snwe[3] - snwe[2]) / array.shape[1]
-        y_step = (snwe[0] - snwe[1]) / array.shape[0]
-
-    # Geotransform  
-    geo = (snwe[2], x_step, 0, snwe[1], 0, y_step)   
-    srs = osr.SpatialReference()
-    srs.ImportFromEPSG(epsg) # get projection
-    
-    # Write
-    driver = gdal.GetDriverByName(format)
-    if len(array.shape) > 2:
-        out_ds = driver.Create(str(output),
-                           array.shape[2],
-                           array.shape[1], 
-                           array.shape[0], 
-                           array_type)
-    else:
-        out_ds = driver.Create(str(output), 
-                           array.shape[1], 
-                           array.shape[0], 
-                           1, 
-                           array_type)
-    
-    out_ds.SetProjection(srs.ExportToWkt())
-    out_ds.SetGeoTransform(geo)
-
-    if verbose:
-        print(f'Writing {output}')
-
-    for i in range(num_bands):
-        band = out_ds.GetRasterBand(i+1)
-        if num_bands > 1:
-            band.WriteArray(array[i])
-        else:
-            band.WriteArray(array)
-        band.FlushCache()
-        band.ComputeStatistics(False)
-
-    # Close
-    out_ds = None
-
-    if add_vrt:
-        # Build virtual VRT  
-        vrt = gdal.BuildVRT(str(output_vrt), str(output), srcNodata=nodata)
-        vrt.FlushCache()
-        vrt = None      
-
-# Extract overlap bounds
-def frame_overlap(snwe1 : list,
-                  snwe2 : list,
-                  latlon_step1 : list,
-                  latlon_step2 : list,
-                  latlon_step: Optional[list] = [-0.000833334, 0.000833334] \
-                  ) -> Tuple[tuple, tuple]:
-    """
-    Parameters
-    ----------
-    Use raster metadata to find overlap between two Images
-    snwe1 : list
-        [South, North, West, East] bounds of Image-1
-    snwe2 : list
-        [South, North, West, East] bounds of Image-2
-    latlon_step1 : list
-        latitude and longitude pixel spacing of Image-1
-    latlon_step2 : list
-        latitude and longitude pixel spacing of Image-2
-
-    Returns
-    -------
-    subset1 : np.slice
-        Intersection subset [y1:y2, x1:x2] for the Image-1
-    subset2 : np.slice
-        Intersection subset [y1:y2, x1:x2] for the Image-2
-    """ 
-
-    snwe = np.vstack([snwe1, snwe2])
-    #Find overlap bounds
-    overlap_snwe = [np.max(snwe[:,0]), np.min(snwe[:,1]), 
-                    np.max(snwe[:,2]), np.min(snwe[:,3])]
-    
-    # Georeferenced space to image coordinate space
-    # Frame-1
-    x1, y1 = lalo2xy(overlap_snwe[1], overlap_snwe[2], snwe1, latlon_step1)
-    # Frame-2
-    x2, y2 = lalo2xy(overlap_snwe[1], overlap_snwe[2], snwe2, latlon_step2)
-
-    # Overlap bounds - force overlaps to have same dimensions
-    # latlon_spacing sometimes diff at 13th decimal
-    length = int(round((overlap_snwe[0] - overlap_snwe[1]) / latlon_step[0]))
-    width  = int(round((overlap_snwe[3] - overlap_snwe[2]) / latlon_step[1]))
-
-    subset1 = np.s_[y1:y1 + length, x1:x1 + width]
-    subset2 = np.s_[y2:y2 + length, x2:x2 + width]
-
-    return subset1, subset2
-
-def lalo2xy(lat : np.float32, 
-            lon: np.float32, 
-            data_snwe : list, 
-            latlon_step :list, 
-            rounding_method : Optional[str] = 'floor') \
-                              -> Tuple[np.int16, np.int16]:
-    """
-    Georeferenced coordinates to image space coordinates. 
-    GDAL raster starting point is the upper left corner.
-
-    Parameters
-    ----------
-    lat : float
-        search latitude 
-    lon : float
-        search longitude
-    data_snwe : list
-        [South, North, West, East] bounds of raster
-        North (y0) and West(x0) as reference point
-    latlon_step : list
-        pixel spacing [latitude_spacing, longitude_spacing]                              
-    rounding_method : str
-        rounding method, default is 'floor' other option is 'around'
-        Read notes below. TODO. test different rounding routines
-
-    Returns
-    -------
-    x : int
-        coordinate in image space (x-axis/columns, direction of width) 
-        from x0 (top up column)
-    y : int
-        coordinate in image space (y-axis/rows, direction of length) 
-        from y0 (top left row)
-    """
-
-    # np.floor works better with points and raster - Need to check why
-    # but with two rasters sometimes one pixel is missing or is redundant
-    if rounding_method == 'floor':
-        x = int(np.floor((lon - data_snwe[2]) / latlon_step[1] + 0.01))
-        y = int(np.floor((lat - data_snwe[1]) / latlon_step[0] + 0.01))
-    
-    # np.around works better with two rasters
-    # test it out, I think it has something to how numpy floor is
-    # rounding negative values
-    # example np.around(-125.2) = -125 np.floor(-125.2) = -126
-    # np.around(125.6) = 126, np.floor(125.6) = 125
-    elif rounding_method == 'around': 
-        x = int(np.around((lon - data_snwe[2]) / latlon_step[1] + 0.01))
-        y = int(np.around((lat - data_snwe[1]) / latlon_step[0] + 0.01))
-
-    return x, y
-
-def combine_data_to_single(data_list : list, 
-                           snwe_list : list, 
-                           latlon_step_list : list,
-                           method : Optional[str] = 'mean',
-                           latlon_step: Optional[list] = \
-                                        [-0.000833334, 0.000833334]) \
-                           -> Tuple[NDArray, NDArray, list]:
-    """
-    Merge multiple arrays to one array. Combine them in ndarray, then apply 
-    function along the n_layers axis
-
-    Parameters
-    ----------
-    data_list : list
-        list of arrays containing raster values
-    snwe_list : list
-        list of arrays containing snwe (extent) values
-    latlon_step_list : list
-        list of arrays containing pixel spacing in lat and lon direction 
-        for each dataset
-    method : str
-        method to merge overlapping pixes, use mean, min, max etc..
-        TODO: need to refine this part of code
-                                        
-    Returns
-    -------
-    comb_data : ndarray 
-        combined data [n_frames, length, width] 
-    SNWE : array
-        extent of the combined data
-    latlon_step : array
-        pixel spacing in lat, lon of combined data
-    
-    """
-    # Get the maximum extent of all data
-    n = len(data_list)
-    snwe_all = np.squeeze([snwe for snwe in snwe_list])
-    
-    SNWE = np.array([np.min(snwe_all[:,0]), np.max(snwe_all[:,1]),
-                     np.min(snwe_all[:,2]), np.max(snwe_all[:,3])]).T
-           
-    length = abs(int(np.around((SNWE[1] - SNWE[0]) / latlon_step[0] + 0.01)))
-    width = abs(int(np.around((SNWE[2] - SNWE[3]) / latlon_step[1] + 0.01)))
-    
-    # create combined data array
-    # handle if 3D metadata layer
-    if len(data_list[0].shape) > 2:
-        comb_data = np.empty((n, data_list[0].shape[0], length, width),
-                             dtype=np.float64) * np.nan
-    else:
-        comb_data = np.empty((n, length, width), dtype=np.float64) * np.nan
-    for i, data in enumerate(data_list):
-        x, y = np.abs(lalo2xy(SNWE[1], SNWE[2], snwe_list[i],
-                              latlon_step_list[i], 'around'))
-        # handle if 3D metadata layer
-        if len(data.shape) > 2:
-            comb_data[i, 0:data.shape[0], y:y+data.shape[1], \
-                      x: x+data.shape[2]] = data
-        else:
-            comb_data[i, y:y+data.shape[0], x: x+data.shape[1]] = data
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=RuntimeWarning)
-        # combine using numpy
-        if method =='mean':
-            comb_data = np.nanmean(comb_data, axis=0)
-        elif method =='median': 
-            comb_data = np.nanmedian(comb_data, axis=0)
-        elif method =='min': 
-            comb_data = np.nanmin(comb_data, axis=0)
-        elif method =='max': 
-            comb_data = np.nanmax(comb_data, axis=0)    
-
-    return comb_data, SNWE,  latlon_step
-
-#################### PLOTTING UTILITIES ######################################
-
-def snwe_to_extent(snwe: list) -> list:
-    '''
-    Convert SNWE to extent for matplotlib plotting
-    '''
-    extent = [snwe[2], snwe[3], snwe[0], snwe[1]]
-    
-    return extent
 
 def plot_GUNW_stitched(stiched_unw_filename: str,
                        stiched_conn_filename: str) -> None:
@@ -1259,12 +910,12 @@ def plot_GUNW_stitched(stiched_unw_filename: str,
 
     # create the new map
     cmap = mpl.colors.LinearSegmentedColormap.from_list(
-    'Custom cmap', cmaplist, cmap.N)
-    #bounds = np.linspace(0, 256, 257)
+        'Custom cmap', cmaplist, cmap.N)
+    # bounds = np.linspace(0, 256, 257)
 
     output_dir = Path(stiched_unw_filename).absolute()
     output_fig = output_dir.parent / 'stitched.png'
-    output_fig.unlink(missing_ok=True) 
+    output_fig.unlink(missing_ok=True)
 
     # Load Data
     stitched_unw = get_GUNW_array(stiched_unw_filename)
@@ -1272,33 +923,33 @@ def plot_GUNW_stitched(stiched_unw_filename: str,
     stitched_attr = get_GUNW_attr(stiched_unw_filename)
 
     # ConnComp discrete colormap
-    #bounds = np.linspace(0, int(np.nanmax(stitched_conn)),
+    # bounds = np.linspace(0, int(np.nanmax(stitched_conn)),
     #                      int(np.nanmax(stitched_conn)+1))
     bounds = np.linspace(0, 30, 31)
     norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
-    
+
     # Mask
-    stitched_unw[stitched_unw==0.0] = np.nan
-    stitched_conn[stitched_conn==-1.0] = np.nan
+    stitched_unw[stitched_unw == 0.0] = np.nan
+    stitched_conn[stitched_conn == -1.0] = np.nan
 
     # Common plot options
-    plot_kwargs = {'extent' : snwe_to_extent(stitched_attr['SNWE']),
-                   'interpolation' : 'nearest'}
+    plot_kwargs = {'extent': snwe_to_extent(stitched_attr['SNWE']),
+                   'interpolation': 'nearest'}
 
     # Figure
-    fig, axs = plt.subplots(1,3, dpi=300, sharey=True)
+    fig, axs = plt.subplots(1, 3, dpi=300, sharey=True)
     # Re-wrapped
-    im1=axs[0].imshow(np.mod(stitched_unw, 4*np.pi),
-                      cmap='jet', **plot_kwargs)
-    im2=axs[1].imshow(stitched_unw * (0.0556 / (6*np.pi)), cmap='jet', 
-                      clim=[-0.2, 0.2], **plot_kwargs) # Unwrapped
+    im1 = axs[0].imshow(np.mod(stitched_unw, 4*np.pi),
+                        cmap='jet', **plot_kwargs)
+    im2 = axs[1].imshow(stitched_unw * (0.0556 / (6*np.pi)), cmap='jet',
+                        clim=[-0.2, 0.2], **plot_kwargs)  # Unwrapped
     # Connected Components
-    im3=axs[2].imshow(stitched_conn, cmap=cmap, norm=norm, **plot_kwargs)
+    im3 = axs[2].imshow(stitched_conn, cmap=cmap, norm=norm, **plot_kwargs)
 
     for im, ax, label, txt, in zip([im1, im2, im3],
-                                    axs, 
-                                    ['rad','m','#'],
-                                    ['Re-wrapped phase w 20 rad',
+                                   axs,
+                                   ['rad', 'm', '#'],
+                                   ['Re-wrapped phase w 20 rad',
                                     'Unwrapped phase [m]',
                                     'Connected Components']):
         fig.colorbar(im, ax=ax, location='bottom', shrink=0.8, label=label)

--- a/tools/ARIAtools/stitiching_util.py
+++ b/tools/ARIAtools/stitiching_util.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+import numpy as np
+import warnings
+from numpy.typing import NDArray
+
+from typing import Optional, Tuple, Union
+from osgeo import gdal, osr, gdal_array
+from pathlib import Path
+
+#  READ/WRITE GDAL UTILITIES
+
+
+def get_GUNW_attr(filename: Union[str, Path]) -> dict:
+    """
+    Use GDAl to get raster metadata
+
+    Parameters
+    ----------
+    filename : str
+        path to raster
+
+    Returns
+    -------
+    raster_attr : dict
+        raster attribute dict
+        [path, nodata, len, wid, snwe, lon_spacing, lat_spacing, projection]
+    """
+
+    # Use GDAL to read GUNW netcdf
+    ds = gdal.Open(filename, gdal.GA_ReadOnly)
+
+    # Get GUNW Raster attributes
+    nodata = ds.GetRasterBand(1).GetNoDataValue()
+
+    # Get raster geographical information
+    transform = ds.GetGeoTransform()
+    xsize = ds.RasterXSize
+    ysize = ds.RasterYSize
+    snwe = [transform[3] + ysize * transform[5], transform[3],
+            transform[0], transform[0] + xsize * transform[1]]
+    lon_spacing = transform[1]
+    lat_spacing = transform[5]
+
+    projection = ds.GetProjection()
+
+    # wrap raster info in dict
+    raster_attr = {'PATH': filename,
+                   'NODATA': nodata,
+                   'LENGTH': ysize,
+                   'WIDTH': xsize,
+                   'SNWE': snwe,
+                   'LON_SPACING': lon_spacing,
+                   'LAT_SPACING': lat_spacing,
+                   'PROJECTION': projection}
+
+    # close
+    ds = None
+
+    return raster_attr
+
+
+def get_GUNW_array(filename: Union[str, Path],
+                   nodata: Optional[float] = None,
+                   subset: Optional[tuple] = None) -> NDArray:
+    """
+    Use GDAl to get raster data [as array]
+
+    Parameters
+    ----------
+    filename : str
+        path to raster
+    subset : slice
+        subset created with np.s_ TODO: insert tuple of (x1,x2, y1,y2)
+        and then convert to slice with np.s_
+
+    Returns
+    -------
+    data : array
+        raster data 2D array [length x width]
+    """
+
+    # Use GDAL to read GUNW netcdf
+    ds = gdal.Open(filename, gdal.GA_ReadOnly)
+
+    data = ds.ReadAsArray()
+    # close
+    ds = None
+
+    # Subset array
+    if subset:
+        data = data[subset]
+
+    if nodata is not None:
+        return np.ma.masked_equal(data, nodata)
+    else:
+        return data
+
+
+def write_GUNW_array(output_filename: Union[str, Path],
+                     array: np.ndarray,
+                     snwe: list,
+                     nodata: Optional[str] = 'NAN',
+                     format: Optional[str] = 'ENVI',
+                     epsg: Optional[int] = 4326,
+                     add_vrt: Optional[bool] = True,
+                     verbose: Optional[bool] = False,
+                     update_mode: Optional[bool] = True) -> None:
+    """
+    Use GDAl to write raster
+
+    Parameters
+    ----------
+    output_filename : str
+        path to raster
+    array : array
+        numpy array of raster to be written
+    snwe  : list
+        (South, North, West, East) bounds of raster to be written
+    nodata : str
+        value or nan for NODATA (used for VRT creation)
+    format : str
+        output raster format, default is ENVI
+    epsg : int
+        projection epsg, default is 4326 for WGS84
+    add_vrt : bool
+        flag to create VRT for output raster [True/False]
+    verbose : bool
+        print info messages [True/False]
+    update_mode : bool
+        flag to overwrite the existing files [True/False]
+    """
+
+    array_type = gdal_array.NumericTypeCodeToGDALTypeCode(array.dtype)
+
+    # Output path
+    output = Path(output_filename).absolute()
+    output_vrt = output.with_suffix('.vrt')
+
+    if update_mode:
+        [print(f'Remove {output}') if verbose else None]
+        output.unlink(missing_ok=True)
+        if add_vrt:
+            [print(f'Remove {output_vrt}') if verbose else None]
+            output_vrt.unlink(missing_ok=True)
+
+    # Get lat, lon pixel spacing
+    num_bands = 1
+    if len(array.shape) > 2:
+        num_bands = array.shape[0]
+        x_step = (snwe[3] - snwe[2]) / array.shape[2]
+        y_step = (snwe[0] - snwe[1]) / array.shape[1]
+    else:
+        x_step = (snwe[3] - snwe[2]) / array.shape[1]
+        y_step = (snwe[0] - snwe[1]) / array.shape[0]
+
+    # Geotransform
+    geo = (snwe[2], x_step, 0, snwe[1], 0, y_step)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(epsg)  # get projection
+
+    # Write
+    driver = gdal.GetDriverByName(format)
+    if len(array.shape) > 2:
+        out_ds = driver.Create(
+            str(output),
+            array.shape[2],
+            array.shape[1],
+            array.shape[0],
+            array_type)
+    else:
+        out_ds = driver.Create(
+            str(output),
+            array.shape[1],
+            array.shape[0],
+            1,
+            array_type)
+
+    out_ds.SetProjection(srs.ExportToWkt())
+    out_ds.SetGeoTransform(geo)
+
+    if verbose:
+        print(f'Writing {output}')
+
+    for i in range(num_bands):
+        band = out_ds.GetRasterBand(i+1)
+        if num_bands > 1:
+            band.WriteArray(array[i])
+        else:
+            band.WriteArray(array)
+        band.FlushCache()
+        band.ComputeStatistics(False)
+
+    # Close
+    out_ds = None
+
+    if add_vrt:
+        # Build virtual VRT
+        vrt = gdal.BuildVRT(str(output_vrt), str(output), srcNodata=nodata)
+        vrt.FlushCache()
+        vrt = None
+
+
+def snwe_to_extent(snwe: list) -> list:
+    '''
+    Convert SNWE to extent for matplotlib plotting
+    '''
+    extent = [snwe[2], snwe[3], snwe[0], snwe[1]]
+
+    return extent
+
+
+def _nan_filled_array(masked_array):
+    masked_array.fill_value = np.nan
+    return masked_array.filled()
+
+
+def lalo2xy(lat: np.float32,
+            lon: np.float32,
+            data_snwe: list,
+            latlon_step: list,
+            rounding_method: Optional[str] = 'floor') \
+        -> Tuple[np.int16, np.int16]:
+    """
+    Georeferenced coordinates to image space coordinates.
+    GDAL raster starting point is the upper left corner.
+
+    Parameters
+    ----------
+    lat : float
+        search latitude
+    lon : float
+        search longitude
+    data_snwe : list
+        [South, North, West, East] bounds of raster
+        North (y0) and West(x0) as reference point
+    latlon_step : list
+        pixel spacing [latitude_spacing, longitude_spacing]
+    rounding_method : str
+        rounding method, default is 'floor' other option is 'around'
+        Read notes below. TODO. test different rounding routines
+
+    Returns
+    -------
+    x : int
+        coordinate in image space (x-axis/columns, direction of width)
+        from x0 (top up column)
+    y : int
+        coordinate in image space (y-axis/rows, direction of length)
+        from y0 (top left row)
+    """
+
+    # np.floor works better with points and raster - Need to check why
+    # but with two rasters sometimes one pixel is missing or is redundant
+    if rounding_method == 'floor':
+        x = int(np.floor((lon - data_snwe[2]) / latlon_step[1] + 0.01))
+        y = int(np.floor((lat - data_snwe[1]) / latlon_step[0] + 0.01))
+
+    # np.around works better with two rasters
+    # test it out, I think it has something to how numpy floor is
+    # rounding negative values
+    # example np.around(-125.2) = -125 np.floor(-125.2) = -126
+    # np.around(125.6) = 126, np.floor(125.6) = 125
+    elif rounding_method == 'around':
+        x = int(np.around((lon - data_snwe[2]) / latlon_step[1] + 0.01))
+        y = int(np.around((lat - data_snwe[1]) / latlon_step[0] + 0.01))
+
+    return x, y
+
+
+# Extract overlap bounds
+def frame_overlap(snwe1: list,
+                  snwe2: list,
+                  latlon_step1: list,
+                  latlon_step2: list,
+                  latlon_step: Optional[list] = [-0.000833334, 0.000833334]
+                  ) -> Tuple[tuple, tuple]:
+    """
+    Parameters
+    ----------
+    Use raster metadata to find overlap between two Images
+    snwe1 : list
+        [South, North, West, East] bounds of Image-1
+    snwe2 : list
+        [South, North, West, East] bounds of Image-2
+    latlon_step1 : list
+        latitude and longitude pixel spacing of Image-1
+    latlon_step2 : list
+        latitude and longitude pixel spacing of Image-2
+
+    Returns
+    -------
+    subset1 : np.slice
+        Intersection subset [y1:y2, x1:x2] for the Image-1
+    subset2 : np.slice
+        Intersection subset [y1:y2, x1:x2] for the Image-2
+    """
+
+    snwe = np.vstack([snwe1, snwe2])
+    # Find overlap bounds
+    overlap_snwe = [np.max(snwe[:, 0]), np.min(snwe[:, 1]),
+                    np.max(snwe[:, 2]), np.min(snwe[:, 3])]
+
+    # Georeferenced space to image coordinate space
+    # Frame-1
+    x1, y1 = lalo2xy(overlap_snwe[1], overlap_snwe[2], snwe1, latlon_step1)
+    # Frame-2
+    x2, y2 = lalo2xy(overlap_snwe[1], overlap_snwe[2], snwe2, latlon_step2)
+
+    # Overlap bounds - force overlaps to have same dimensions
+    # latlon_spacing sometimes diff at 13th decimal
+    length = int(round((overlap_snwe[0] - overlap_snwe[1]) / latlon_step[0]))
+    width = int(round((overlap_snwe[3] - overlap_snwe[2]) / latlon_step[1]))
+
+    subset1 = np.s_[y1:y1 + length, x1:x1 + width]
+    subset2 = np.s_[y2:y2 + length, x2:x2 + width]
+
+    return subset1, subset2
+
+
+def combine_data_to_single(data_list: list,
+                           snwe_list: list,
+                           latlon_step_list: list,
+                           method: Optional[str] = 'mean',
+                           latlon_step: Optional[list] =
+                           [-0.000833334, 0.000833334]) \
+        -> Tuple[NDArray, NDArray, list]:
+    """
+    Merge multiple arrays to one array. Combine them in ndarray, then apply
+    function along the n_layers axis
+
+    Parameters
+    ----------
+    data_list : list
+        list of arrays containing raster values
+    snwe_list : list
+        list of arrays containing snwe (extent) values
+    latlon_step_list : list
+        list of arrays containing pixel spacing in lat and lon direction
+        for each dataset
+    method : str
+        method to merge overlapping pixes, use mean, min, max etc..
+        TODO: need to refine this part of code
+
+    Returns
+    -------
+    comb_data : ndarray
+        combined data [n_frames, length, width]
+    SNWE : array
+        extent of the combined data
+    latlon_step : array
+        pixel spacing in lat, lon of combined data
+
+    """
+    # Get the maximum extent of all data
+    n = len(data_list)
+    snwe_all = np.squeeze([snwe for snwe in snwe_list])
+
+    SNWE = np.array([np.min(snwe_all[:, 0]), np.max(snwe_all[:, 1]),
+                     np.min(snwe_all[:, 2]), np.max(snwe_all[:, 3])]).T
+
+    length = abs(int(np.around((SNWE[1] - SNWE[0]) / latlon_step[0] + 0.01)))
+    width = abs(int(np.around((SNWE[2] - SNWE[3]) / latlon_step[1] + 0.01)))
+
+    # create combined data array
+    # handle if 3D metadata layer
+    if len(data_list[0].shape) > 2:
+        comb_data = np.empty((n, data_list[0].shape[0], length, width),
+                             dtype=np.float64) * np.nan
+    else:
+        comb_data = np.empty((n, length, width), dtype=np.float64) * np.nan
+    for i, data in enumerate(data_list):
+        x, y = np.abs(lalo2xy(SNWE[1], SNWE[2], snwe_list[i],
+                              latlon_step_list[i], 'around'))
+        # handle if 3D metadata layer
+        if len(data.shape) > 2:
+            comb_data[i, 0:data.shape[0], y:y+data.shape[1],
+                      x: x+data.shape[2]] = data
+        else:
+            comb_data[i, y:y+data.shape[0], x: x+data.shape[1]] = data
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        # combine using numpy
+        if method == 'mean':
+            comb_data = np.nanmean(comb_data, axis=0)
+        elif method == 'median':
+            comb_data = np.nanmedian(comb_data, axis=0)
+        elif method == 'min':
+            comb_data = np.nanmin(comb_data, axis=0)
+        elif method == 'max':
+            comb_data = np.nanmax(comb_data, axis=0)
+
+    return comb_data, SNWE,  latlon_step

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -12,6 +12,8 @@ Specifically, extract unwrapped interferogram, coherence, perp baseline,
 LOS file(s), and (where available) tropospheric correction layers.
 """
 
+from ARIAtools.ARIA_global_variables import ARIA_EXTERNAL_CORRECTIONS, \
+    ARIA_TROPO_MODELS, ARIA_STACK_DEFAULTS, ARIA_STACK_OUTFILES
 import os
 import glob
 import logging
@@ -38,8 +40,6 @@ gdal.PushErrorHandler('CPLQuietErrorHandler')
 log = logging.getLogger(__name__)
 
 # Import TS-related global variables
-from ARIAtools.ARIA_global_variables import ARIA_EXTERNAL_CORRECTIONS, \
-    ARIA_TROPO_MODELS, ARIA_STACK_DEFAULTS, ARIA_STACK_OUTFILES
 
 
 def create_parser():
@@ -258,7 +258,7 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
     print(f'Number of {stack_layer} files discovered: ', len(int_list))
     dlist = sorted(int_list)
     # get dates
-    aria_dates = [os.path.basename(i).split('.vrt')[0] for i in \
+    aria_dates = [os.path.basename(i).split('.vrt')[0] for i in
                   int_list]
 
     # only perform following checks if a differential layer
@@ -289,7 +289,7 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
     else:
         # get az times for each date
         aztime_list = len(aria_dates) * \
-                      [aria_prod.products[0][0]['azimuthZeroDopplerMidTime']]
+            [aria_prod.products[0][0]['azimuthZeroDopplerMidTime']]
 
     # get UTC times
     utc_time = extract_utc_time(aria_dates, aztime_list)
@@ -328,7 +328,7 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
             try:
                 acq = utc_time[dates]
             except:
-                log.debug('Skipping %s; it likely exists in the %s, ' \
+                log.debug('Skipping %s; it likely exists in the %s, '
                           'but was not specified in the product list',
                           dates, os.path.dirname(data[1]))
                 continue
@@ -473,10 +473,10 @@ def main(inps=None):
     print('\nExtracting unwrapped phase, coherence, '
           'and connected components for each interferogram pair')
     ref_arr_record = export_products(standardproduct_info.products[1],
-                               tropo_total=False,
-                               layers=layers,
-                               rankedResampling=inps.rankedResampling,
-                               **export_dict)
+                                     tropo_total=False,
+                                     layers=layers,
+                                     rankedResampling=inps.rankedResampling,
+                                     **export_dict)
 
     # Remove pairing and pass combined dictionary of all layers
     extract_dict = defaultdict(list)
@@ -490,9 +490,9 @@ def main(inps=None):
     print('\nExtracting single incidence angle, look angle and azimuth angle '
           'files valid over common interferometric grid')
     prod_arr_record = export_products([extract_dict],
-                        tropo_total=False,
-                        layers=layers,
-                        **export_dict)
+                                      tropo_total=False,
+                                      layers=layers,
+                                      **export_dict)
     # Track consistency of dimensions
     dim_check(ref_arr_record, prod_arr_record)
 
@@ -500,9 +500,9 @@ def main(inps=None):
     print('\nExtracting perpendicular baseline grids for each '
           'interferogram pair')
     prod_arr_record = export_products(standardproduct_info.products[1],
-                        tropo_total=False,
-                        layers=layers,
-                        **export_dict)
+                                      tropo_total=False,
+                                      layers=layers,
+                                      **export_dict)
     # Track consistency of dimensions
     dim_check(ref_arr_record, prod_arr_record)
 
@@ -522,10 +522,10 @@ def main(inps=None):
             print('\nExtracting, %s for each applicable '
                   'interferogram pair' % ('troposphereTotal'))
         prod_arr_record = export_products(standardproduct_info.products[1],
-                            tropo_total=inps.tropo_total,
-                            model_names=model_names,
-                            layers=layers,
-                            **export_dict)
+                                          tropo_total=inps.tropo_total,
+                                          model_names=model_names,
+                                          layers=layers,
+                                          **export_dict)
         # Track consistency of dimensions
         dim_check(ref_arr_record, prod_arr_record)
 


### PR DESCRIPTION
- moved gdal read/write functions to sequential_util.py
- did clean up of the code using lint
- fixed bookeeping of connected component while going forward/backward
- introduced option to reverse the direction of frame stitching, from North to South (default is South to North)

Test script:
```from pathlib import Path
from ARIAtools.sequential_stitching import  stitch_unwrapped_frames as stitch

# Get directory & nc files
ncdir = Path('/u/trappist-r0/govorcin/02_ACCESS_ARIA/unw_stitching/CA_GUNWS/A064')
ifg_pair = '20190411_20180317'

unw_list = []
conn_list = []
for i in (ncdir / 'products').glob(f'*{ifg_pair}*'):
    unw_list.append(f'NETCDF:"{i}":/science/grids/data/unwrappedPhase')
    conn_list.append(f'NETCDF:"{i}":/science/grids/data/connectedComponents')

# Get stitched data
stitched_unwPhase, stitched_connComponent, snwe = stitch(unw_list, conn_list, verbose=False, direction_N_S=False)
```

![image](https://github.com/aria-tools/ARIA-tools/assets/26017189/3b790656-295c-46c0-a3c6-6f89398dc9c6)



