### PR TITLE
requirements: comment out dependencies for notebooks

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - python>=3.8
   - asf_search
   - cartopy
+  - dem_stitcher>=2.5.0
   - gdal>=3.4.1
   - h5py
   - joblib
@@ -29,6 +30,5 @@ dependencies:
   #for ARIA-tools-docs
   - jupyterlab
   - jupyter_contrib_nbextensions
-  - dem_stitcher>=2.5.0
   - pip:
     - rise

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 python>=3.8
 asf_search
 cartopy
+dem_stitcher>=2.5.0
 gdal>=3.4.1
 h5py
 joblib
@@ -15,7 +16,7 @@ pyproj
 requests
 scipy>1.10.0
 shapely
-jupyterlab
-jupyter_contrib_nbextensions
-dem_stitcher>=2.5.0
-rise
+## notebook dependencies, keep commented out for better compatiability with other codes
+#jupyterlab
+#jupyter_contrib_nbextensions
+#rise


### PR DESCRIPTION
This PR comments out the notebook dependencies in the `requirements.txt` file, so one can easily install ARIA-tools and MintPy in one Python environment. 

Another perspective is that one may run `ARIA-tools` as python tools, without the need of running the notebooks in `ARIA-tools-docs`, having a `requirements.txt` file allows that.