### PR TITLE
Small fix of range correction bug

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1295,7 +1295,12 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem,
     from scipy.interpolate import RegularGridInterpolator
 
     # get final shape
-    arrres = gdal.Open(dem.GetDescription())
+    # MG: add option to pass dem path as string
+    if isinstance(dem, str):
+        arrres = gdal.Open(dem)
+    else:
+        # for gdal instance
+        arrres = gdal.Open(dem.GetDescription())
     arrshape = [arrres.RasterYSize, arrres.RasterXSize]
     ref_geotrans = arrres.GetGeoTransform()
     arrres = [abs(ref_geotrans[1]), abs(ref_geotrans[-1])]

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -82,7 +82,7 @@ def createParser():
                         help='Amplitude threshold below which to mask. Specify "None" to not use amplitude mask. By default "None".')
     parser.add_argument('-nt', '--num_threads', dest='num_threads', default='2', type=str,
                         help='Specify number of threads for multiprocessing operation in gdal. By default "2". Can also specify "All" to use all available threads.')
-    parser.add_argument('-sm', '--stitchMethod', dest='stitchMethodType',  type=str, default='overlap',
+    parser.add_argument('-sm', '--stitchMethod', dest='stitchMethodType',  type=str, default='sequential',
                         help="Method applied to stitch the unwrapped data. Allowed methods are: 'overlap', '2stage', and 'sequential'. 'overlap' - product overlap is minimized, '2stage' - minimization is done on connected components, 'sequential' - sequential minimization of all overlapping connected components.  Default is 'overlap'.")
     parser.add_argument('-of', '--outputFormat', dest='outputFormat', type=str, default='VRT',
                         help='GDAL compatible output format (e.g., "ENVI", "GTiff"). By default files are generated virtually except for "bPerpendicular", "bParallel", "incidenceAngle", "lookAngle","azimuthAngle", "unwrappedPhase" as these are require either DEM intersection or corrections to be applied')

--- a/tools/ARIAtools/tsSetup.py
+++ b/tools/ARIAtools/tsSetup.py
@@ -96,7 +96,7 @@ def create_parser():
                                                     'By default "2". Can also specify "All" to use all '
                                                     'available threads.')
     parser.add_argument('-sm', '--stitchMethod', dest='stitchMethodType',
-                        type=str, default='overlap', help='Method applied to '
+                        type=str, default='sequential', help='Method applied to '
                                                           'stitch the unwrapped data. Allowed methods are: '
                                                           '"overlap", "2stage", and "sequential". "overlap" - '
                                                           'product overlap is minimized, "2stage" - '


### PR DESCRIPTION
Description:
Range correction (mean phase shift from wrapped phase) sometimes gives opposite correction sign (skips the cycle) that affects the calculation of the shift between overlapping regions, e.g. instead of subtracting 3 radians it adds them up.

This happens in few cases, most of the time works well. I am not sure why this happens in the first place (could it be the ESD applied on one frame and another no?)

Solution:
I found it out that n integer of 2pi jumps with range correction most of the times is very close to the median difference. So if the difference between those two is larger than a PI, then I switch the sign of range correction. 

NOTE: still testing if the median difference between connected components is the most robust option for stitching to avoid the above mentioned.

Another changes:
Added check to accept dem and mask input as filename string instead of gdal.object to be able to use dask to run code in parallel.