### PR TITLE
Sort pairs by latitude

### DIFF
--- a/tools/ARIAtools/ARIAProduct.py
+++ b/tools/ARIAtools/ARIAProduct.py
@@ -398,6 +398,16 @@ class ARIA_standardproduct:
                 + basename.split('-')[7][2:4] + ':' \
                 + basename.split('-')[7][4:] + '.0'
 
+            # assign latitude to assist with sorting
+            rdrmetadata_dict['centerLatitude'] =  \
+                basename.split('-')[8].split('_')[1]
+            if rdrmetadata_dict['centerLatitude'][-1] == 'S':
+                rdrmetadata_dict['centerLatitude'] = -1 * \
+                    int(rdrmetadata_dict['centerLatitude'][:-1])
+            else:
+                rdrmetadata_dict['centerLatitude'] = \
+                    int(rdrmetadata_dict['centerLatitude'][:-1])
+
             #hardcoded keys for a given sensor
             if basename.split('-')[0] == 'S1':
                 rdrmetadata_dict['missionID'] = 'Sentinel-1'
@@ -750,10 +760,12 @@ class ARIA_standardproduct:
         else:
             self.products += self.__readproduct__(self.files[0])
 
-        # Sort by pair and start time.
+        # Sort by pair, start time, and latitude
         self.products = [i for i in self.products if i != []]
-        self.products = sorted(self.products, key=lambda k:
-                    (k[0]['pair_name'], k[0]['azimuthZeroDopplerMidTime']))
+        self.products = sorted(self.products, key=lambda i:
+                    (i[0]['pair_name'],
+                     i[0]['azimuthZeroDopplerMidTime'],
+                     i[0]['centerLatitude']))
         self.products = list(self.products)
 
         # Exit if products from different sensors were mixed


### PR DESCRIPTION
The dictionary is sorted by `azimuthZeroDopplerMidTime` (see [here](https://github.com/aria-tools/ARIA-tools/blob/dev/tools/ARIAtools/ARIAProduct.py#L756)), which is derived from just the [filename](https://github.com/aria-tools/ARIA-tools/blob/dev/tools/ARIAtools/ARIAProduct.py#L395) to save time from cracking the product open.

But in some cases it’s the same value for adjacent frames (e.g. `S1-GUNW-A-R-033-tops-20170217_20150815-225114-00076W_00040N-PP-413c-v3_0_0.nc` and `S1-GUNW-A-R-033-tops-20170217_20150815-225114-00076W_00041N-PP-d372-v3_0_0.nc`) and the frames are then flipped around in sorting, leading to a false positive in that the program rejects these pairs due to an apparent gap.

@bbuzz31 you can confirm this patch now avoids this behavior by appropriately passing all of the "2017" pairs in the subdirectory you shared by running the following command:
> ariaExtract.py -f '/u/leffe-data2/buzzanga/data/VLM/Sentinel1/EastCoast/track_033/products_track033/*2017*.nc' -of ISCE -b ../bbox_selected.GeoJSON -verbose -w test_all