### PR TITLE
Prioritize v3 over v2 products

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -645,7 +645,7 @@ def generate_diff(ref_outname, sec_outname, outname, key, OG_key, tropo_total,
 
 def handle_epoch_layers(
         layers, product_dict, lyr_path, key, sec_key, ref_key, tropo_total,
-        workdir, prog_bar, bounds, dem_bounds, prods_TOTbbox, dem, lat, lon,
+        workdir, prog_bar, bounds, arrres, dem_bounds, prods_TOTbbox, dem, lat, lon,
         mask, outputFormat, verbose, multilooking, rankedResampling,
         num_threads):
     """
@@ -790,7 +790,7 @@ def handle_epoch_layers(
             for j in enumerate(record_epochs):
                 # Interpolate/intersect with DEM before cropping
                 finalize_metadata(
-                    j[1][:-4], bounds, dem_bounds, prods_TOTbbox, dem, lat,
+                    j[1][:-4], bounds, arrres, dem_bounds, prods_TOTbbox, dem, lat,
                     lon, hgt_field, prod_ver_list, mask, outputFormat,
                     verbose=verbose)
 
@@ -867,7 +867,7 @@ def export_product_worker(
 
         # Interpolate/intersect with DEM before cropping
         finalize_metadata(
-            outname, bounds, dem_bounds, prods_TOTbbox, dem_expanded,
+            outname, bounds, arrres, dem_bounds, prods_TOTbbox, dem_expanded,
             lat, lon, hgt_field, product, mask, outputFormatPhys,
             verbose=verbose)
 
@@ -1031,6 +1031,7 @@ def export_products(
     # get bounds
     bounds = ARIAtools.util.shp.open_shp(bbox_file).bounds
     lyr_input_dict['bounds'] = bounds
+    lyr_input_dict['arrres'] = arrres
     if dem_expanded is not None:
         dem_gt = dem_expanded.GetGeoTransform()
         dem_bounds = [
@@ -1275,7 +1276,7 @@ def export_products(
     return retval
 
 
-def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem,
+def finalize_metadata(outname, bbox_bounds, arrres, dem_bounds, prods_TOTbbox, dem,
                       lat, lon, hgt_field, prod_list, mask=None,
                       outputFormat='ENVI', verbose=None, num_threads='2'):
     """Interpolate and extract 2D metadata layer.
@@ -1283,9 +1284,9 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem,
     3D layers with a DEM.
     Lat/lon arrays must also be passed for this process.
     """
-    arrshape = [dem.RasterYSize, dem.RasterXSize]
+    #arrshape = [dem.RasterYSize, dem.RasterXSize]
     ref_geotrans = dem.GetGeoTransform()
-    arrres = [abs(ref_geotrans[1]), abs(ref_geotrans[-1])]
+    dem_arrres = [abs(ref_geotrans[1]), abs(ref_geotrans[-1])]
 
     # load layered metadata array
     tmp_name = outname + '.vrt'
@@ -1375,16 +1376,18 @@ def finalize_metadata(outname, bbox_bounds, dem_bounds, prods_TOTbbox, dem,
     data_array_nodata = data_array.GetRasterBand(1).GetNoDataValue()
     gdal_warp_kwargs = {
         'format': outputFormat, 'cutlineDSName': prods_TOTbbox,
-        'outputBounds': bbox_bounds, 'dstNodata': data_array_nodata,
-        'xRes': arrres[0], 'yRes': arrres[1], 'targetAlignedPixels': True,
+        'outputBounds': dem_bounds, 'dstNodata': data_array_nodata,
+        'xRes': dem_arrres[0], 'yRes': dem_arrres[1], 'targetAlignedPixels': True,
         'multithread': True, 'options': [f'NUM_THREADS={num_threads}']}
     warp_options = osgeo.gdal.WarpOptions(**gdal_warp_kwargs)
     osgeo.gdal.Warp(tmp_name + '_temp', tmp_name, options=warp_options)
 
     # Adjust shape
     gdal_warp_kwargs = {
-        'format': outputFormat, 'height': arrshape[0], 'width': arrshape[1],
-        'options': [f'NUM_THREADS={num_threads}']}
+        'format': outputFormat, 'cutlineDSName': prods_TOTbbox,
+        'outputBounds': bbox_bounds, 'dstNodata': data_array_nodata,
+        'xRes': arrres[0], 'yRes': arrres[1], 'targetAlignedPixels': True,
+        'multithread': True, 'options': [f'NUM_THREADS={num_threads}']}
     warp_options = osgeo.gdal.WarpOptions(**gdal_warp_kwargs)
     osgeo.gdal.Warp(outname, tmp_name + '_temp', options=warp_options)
 

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -128,45 +128,50 @@ def remove_scenes(products):
 
                 # Check if IFG dict corresponding to ref prod already exists
                 # and if it does then append values
-                try:
-                    dict_ind = sorted_products.index(next(
-                        item for item in sorted_products
-                        if scene[1]['productBoundingBox'] in
-                        item[1]['productBoundingBox']))
+                dict_item = None
+                for item in sorted_products:
+                    if scene[1]['productBoundingBox'] in \
+                       item[1]['productBoundingBox']:
+                        dict_item = item
+                        break
+                if dict_item is not None:
+                    dict_ind = sorted_products.index(dict_item)
                     dict_1 = package_dict(
                         scene, new_scene, 0, sorted_products, dict_ind)
                     dict_2 = package_dict(
                         scene, new_scene, 1, sorted_products, dict_ind)
                     sorted_products[dict_ind] = [dict_1, dict_2]
-
                 # Match IFG corresponding to reference product NOT found
                 # so initialize dictionary for new IFG
-                except BaseException:
+                else:
                     dict_1 = package_dict(scene, new_scene, 0)
                     dict_2 = package_dict(scene, new_scene, 1)
                     new_dict = [dict_1, dict_2]
                     sorted_products.extend([new_dict])
+
             # If prods correspond to different orbits entirely
             else:
+
                 # Check if IFG dict corresponding to ref prod already exists
                 # and if it does not then pass as new IFG
-                # TODO clean this conditional
-                if [item for item in sorted_products
-                    if scene[1]['productBoundingBox'] in
-                    item[1]['productBoundingBox']] == []:
-
+                track_existing_ifg = []
+                for item in sorted_products:
+                    if scene[1]['productBoundingBox'] in \
+                    item[1]['productBoundingBox']:
+                        track_existing_ifg.append(item)
+                if track_existing_ifg == []:
                     dict_1 = package_dict(scene, scene, 0)
                     dict_2 = package_dict(scene, scene, 1)
                     new_dict = [dict_1, dict_2]
                     sorted_products.extend([new_dict])
-
                 # Check if IFG dict corresponding to ref prod already exists
                 # and if it does not then pass as new IFG
-                # TODO clean this conditional
-                if [item for item in sorted_products
-                        if new_scene[1]['productBoundingBox'] in
-                    item[1]['productBoundingBox']] == []:
-
+                track_existing_ifg = []
+                for item in sorted_products:
+                    if new_scene[1]['productBoundingBox'] in \
+                    item[1]['productBoundingBox']:
+                        track_existing_ifg.append(item)
+                if track_existing_ifg == []:
                     dict_1 = package_dict(new_scene, new_scene, 0)
                     dict_2 = package_dict(new_scene, new_scene, 1)
                     new_dict = [dict_1, dict_2]
@@ -334,7 +339,7 @@ class Product:
 
                 try:
                     bbox = [float(val) for val in bbox.split()]
-                except BaseException:
+                except ValueError:
                     raise Exception(
                         'Cannot understand the --bbox argument. String input '
                         'is incorrect or path does not exist.')
@@ -376,13 +381,13 @@ class Product:
         number, and populate corresponding product dictionary accordingly.
         """
         # Get standard product version from file
-        try:
-            # version accessed differently between URL vs downloaded product
-            version = str(
-                osgeo.gdal.Open(fname).GetMetadataItem('NC_GLOBAL#version'))
-
-        except BaseException:
-            LOGGER.warning('%s is not a supported file type... skipping', fname)
+        # version accessed differently between URL vs downloaded product
+        version = str(
+            osgeo.gdal.Open(fname).GetMetadataItem('NC_GLOBAL#version'))
+        if version == 'None':
+            LOGGER.warning(
+                f'{fname} is not a supported file '
+                'type... skipping')
             return []
 
         # Enforce forward-compatibility of netcdf versions
@@ -818,20 +823,22 @@ class Product:
 
                 # Check if IFG dict corresponding to ref prod already exists
                 # and if it does then append values
-                try:
-                    dict_ind = sorted_products.index(next(
-                        item for item in sorted_products
-                        if scene[1]['productBoundingBox'] in
-                        item[1]['productBoundingBox']))
+                dict_item = None
+                for item in sorted_products:
+                    if scene[1]['productBoundingBox'] in \
+                       item[1]['productBoundingBox']:
+                        dict_item = item
+                        break
+                if dict_item is not None:
+                    dict_ind = sorted_products.index(dict_item)
                     dict_1 = package_dict(
                         scene, new_scene, 0, sorted_products, dict_ind)
                     dict_2 = package_dict(
                         scene, new_scene, 1, sorted_products, dict_ind)
                     sorted_products[dict_ind] = [dict_1, dict_2]
-
                 # Match IFG corresponding to reference product NOT found
                 # so initialize dictionary for new IFG
-                except BaseException:
+                else:
                     dict_1 = package_dict(scene, new_scene, 0)
                     dict_2 = package_dict(scene, new_scene, 1)
                     new_dict = [dict_1, dict_2]
@@ -851,29 +858,29 @@ class Product:
 
             # If prods correspond to different orbits entirely
             else:
+
                 # Check if IFG dict corresponding to ref prod already exists
                 # and if it does not then pass as new IFG
-                # TODO clean this conditional
-                if [item for item in sorted_products
-                    if scene[1]['productBoundingBox'] in
-                    item[1]['productBoundingBox']] == [] \
-                    and scene[0]['pair_name'] not in \
-                        track_rejected_pairs:
-
+                track_existing_ifg = []
+                for item in sorted_products:
+                    if scene[1]['productBoundingBox'] in \
+                    item[1]['productBoundingBox']:
+                        track_existing_ifg.append(item)
+                if track_existing_ifg == [] and \
+                    scene[0]['pair_name'] not in track_rejected_pairs:
                     dict_1 = package_dict(scene, scene, 0)
                     dict_2 = package_dict(scene, scene, 1)
                     new_dict = [dict_1, dict_2]
                     sorted_products.extend([new_dict])
-
                 # Check if IFG dict corresponding to ref prod already exists
                 # and if it does not then pass as new IFG
-                # TODO clean this conditional
-                if [item for item in sorted_products
-                        if new_scene[1]['productBoundingBox'] in
-                    item[1]['productBoundingBox']] == [] \
-                        and new_scene[0]['pair_name'] not in \
-                    track_rejected_pairs:
-
+                track_existing_ifg = []
+                for item in sorted_products:
+                    if new_scene[1]['productBoundingBox'] in \
+                    item[1]['productBoundingBox']:
+                        track_existing_ifg.append(item)
+                if track_existing_ifg == [] and \
+                    new_scene[0]['pair_name'] not in track_rejected_pairs:
                     dict_1 = package_dict(new_scene, new_scene, 0)
                     dict_2 = package_dict(new_scene, new_scene, 1)
                     new_dict = [dict_1, dict_2]

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -125,7 +125,6 @@ def remove_scenes(products):
             # overlaps with reference scene
             if abs(new_scene_t - scene_t) <= ONE_DAY and \
                 abs(new_scene_t_ref - scene_t_ref) <= ONE_DAY:
-                print('inside')
 
                 # Check if IFG dict corresponding to ref prod already exists
                 # and if it does then append values

--- a/tools/ARIAtools/util/url.py
+++ b/tools/ARIAtools/util/url.py
@@ -16,12 +16,12 @@ def url_versions(urls, user_version, wd):
     Uses the the latest if user_version is None else use specified ver.
     """
     if user_version is not None and str(user_version).lower() != 'all':
-        # dummy-proof if version entered as digit, as opposed to 2_X_X
-        if len(user_version) != 5:
-            raise Exception(f'Input version {user_version} not in format 2_X_X'
-                            'as expected')
+        user_version = user_version.lstrip('v')
+        if not user_version[0].isdigit():
+            raise Exception(f'Input version {user_version} not in format X* '
+                            'as expected (e.g., 3, 3_0_0)')
         LOGGER.debug(f'Only using products version: {user_version}')
-        urls_final = [url for url in urls if user_version in url]
+        urls_final = [url for url in urls if f'-v{user_version}' in url]
         if not urls_final:
             raise Exception(
                 f'No products with user specified version: {urls_final}')

--- a/tools/ARIAtools/util/url.py
+++ b/tools/ARIAtools/util/url.py
@@ -6,6 +6,8 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import os
+import logging
+LOGGER = logging.getLogger(__name__)
 
 # Grab older version products if specified.
 def url_versions(urls, user_version, wd):
@@ -15,10 +17,10 @@ def url_versions(urls, user_version, wd):
     """
     if user_version is not None and str(user_version).lower() != 'all':
         # dummy-proof if version entered as digit, as opposed to 2_X_X
-        if len(user_version) == 1:
-            raise Exception('Input version {} not in format 2_X_X'
-                            'as expected'.format(user_version))
-        print(f'Only using products version: {user_version}')
+        if len(user_version) != 5:
+            raise Exception(f'Input version {user_version} not in format 2_X_X'
+                            'as expected')
+        LOGGER.debug(f'Only using products version: {user_version}')
         urls_final = [url for url in urls if user_version in url]
         if not urls_final:
             raise Exception(


### PR DESCRIPTION
For a given IFG, avoid mixing v3 and v2 products such that only v3 products are passed for a given IFG where available.