### PR TITLE
Fix URL option

### DIFF
--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -155,7 +155,7 @@ def get_url_ifg(scenes):
     return urls, ifgs
 
 
-def fmt_dst(inps):
+def fmt_dst(args):
     """Format the save name"""
     ext = '.kmz' if args.output == 'Kml' else '.txt'
 
@@ -247,7 +247,7 @@ class Downloader(object):
         #                    'Revert to an older version of ARIAtools')
 
         elif self.args.output == 'Url':
-            dst = fmt_dst(inps)
+            dst = fmt_dst(self.args)
             with open(dst, 'w') as fh:
                 for url in urls:
                     print(url, sep='\n', file=fh)


### PR DESCRIPTION
When running this command:
`ariaDownload.py --bbox "34.6 34.8 -118.1 -117.9" --track 71 --output Url --start 20211214 --end 20220102`

Vestigial 'inps' variable lead to a crash:
```
/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/dev_ARIA-tools/bin/ariaDownload.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('ARIAtools==1.1.6')
Traceback (most recent call last):
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/dev_ARIA-tools/bin/ariaDownload.py", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/dev_ARIA-tools/ARIA-tools/tools/bin/ariaDownload.py", line 332, in <module>
    main()
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/dev_ARIA-tools/ARIA-tools/tools/bin/ariaDownload.py", line 329, in main
    Downloader(args)()
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/dev_ARIA-tools/ARIA-tools/tools/bin/ariaDownload.py", line 250, in __call__
    dst = fmt_dst(inps)
                  ^^^^
NameError: name 'inps' is not defined. Did you mean: 'input'?
```