### PR TITLE
No longer extract ancillary layers by default through ariaTSsetup

### DIFF
--- a/tests/regression/run_tssetup_test.py
+++ b/tests/regression/run_tssetup_test.py
@@ -54,7 +54,8 @@ def main():
 
     exec_string = (
         'ariaTSsetup.py -f "golden_test_inputs/tssetup/products/*.nc" '
-        '-tm HRRR -d golden_test_inputs/tssetup/DEM/glo_90.dem '
+        '-l "solidEarthTide,ionosphere,troposphereTotal" -tm HRRR '
+        '-d golden_test_inputs/tssetup/DEM/glo_90.dem '
         '-w test_outputs/tssetup/')
     if not args.old:
         exec_string += ' --log-level %s' % args.log_level

--- a/tools/ARIAtools/util/vrt.py
+++ b/tools/ARIAtools/util/vrt.py
@@ -436,7 +436,7 @@ def layerCheck(
             layers = [i.replace(' ', '') for i in layers]
         if 'troposphereTotal' in layers and \
                 set(RAIDER_TROPO_LAYERS).issubset(all_valid_layers) and \
-                model_names != []:
+                (model_names != [] or is_nisar_file):
             tropo_total = True
 
     # differentiate between extract and TS pipeline

--- a/tools/ARIAtools/util/vrt.py
+++ b/tools/ARIAtools/util/vrt.py
@@ -435,7 +435,8 @@ def layerCheck(
             layers = list(layers.split(','))
             layers = [i.replace(' ', '') for i in layers]
         if 'troposphereTotal' in layers and \
-                set(RAIDER_TROPO_LAYERS).issubset(all_valid_layers):
+                set(RAIDER_TROPO_LAYERS).issubset(all_valid_layers) and \
+                model_names != []:
             tropo_total = True
 
     # differentiate between extract and TS pipeline
@@ -466,8 +467,6 @@ def layerCheck(
     # TS pipeline
     TS_LAYERS_DUP = ['unwrappedPhase', 'coherence', 'incidenceAngle',
                      'lookAngle', 'azimuthAngle', 'bPerpendicular']
-
-    ts_defaults = ['ionosphere', 'solidEarthTide']
     if extract_or_ts == 'tssetup':
         if layers:
             # remove layers already generated in default TS workflow
@@ -475,16 +474,6 @@ def layerCheck(
 
         else:
             layers = []
-
-        # add additional layers for default workflow
-        ts_defaults = list(
-            set.intersection(*map(set, [ts_defaults, all_valid_layers])))
-
-        if ts_defaults != []:
-            tropo_total = True
-            for i in ts_defaults:
-                if i not in layers:
-                    layers.append(i)
 
     # pass intersection of valid layers and track invalid requests
     layer_reject = list(


### PR DESCRIPTION
Following convo with @mgovorcin and @dbekaert , adjust behavior of `ariaTSsetup.py` to no longer extract ancillary layers (i.e. 'solidEarthTide,ionosphere,troposphereTotal') by default. They now have to be explicitly specified in the commandline.

To test out these changes, refer to the following minimum working example:
1. Download a subset of version 3 products over southern California: `ariaDownload.py --num_threads 16 -b '33.4 34.5 -119.0 -117.4'  -s 20190101  -e 20190216 -t 64 --version 3_0_1 -o Download`

2. Test out default behavior of `ariaTSsetup.py` (i.e. layers 'solidEarthTide,ionosphere,troposphereTotal' should be missing from the specified output directory `-w ts_default`): `ariaTSsetup.py -f "products/*.nc" -b '33.6 34.3 -118.5 -117.5' -mo 5800 --verbose -of ENVI -w ts_output --log-level debug`

3. Explicitly specify extraction of ancillary layers (i.e. layers 'solidEarthTide,ionosphere,troposphereTotal' should be found in specified output directory `-w ts_output_ancillarylyrs`): `ariaTSsetup.py -f "products/*.nc" -b '33.6 34.3 -118.5 -117.5' -mo 5800 --verbose -l 'solidEarthTide,ionosphere,troposphereTotal' -tm HRRR -of ENVI -w ts_output_ancillarylyrs --log-level debug`


Note the `-mo 5800` should be specified here to reject short IFGs that do not meet the defined spatial threshold of coverage (i.e. 5800 km^2) WRT to the specified bbox. See a relevant discussion on this [here](https://github.com/aria-tools/ARIA-tools/issues/416).