### PR TITLE
Fix bug when extracting iono and tropo layer

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1195,7 +1195,10 @@ def export_products(
 
             # track valid files
             prev_outname = os.path.abspath(
-                os.path.join(workdir, i, product_dict[1][0][0]))
+                os.path.join(workdir,
+                             i.split('_')[-1],
+                             product_dict[1][0][0])
+            )
             if os.path.exists(prev_outname + '.vrt'):
                 prev_outname_check = copy.deepcopy(prev_outname)
 
@@ -1287,6 +1290,16 @@ def export_products(
             lyr_input_dict['input_iono_files'] = layer
             lyr_input_dict['output_iono'] = outname
             ARIAtools.util.ionosphere.export_ionosphere(**lyr_input_dict)
+
+            # track valid files
+            if os.path.exists(outname + '.vrt'):
+                prev_outname_check = copy.deepcopy(outname)
+
+        # track consistency of dimensions
+        if 'prev_outname_check' in locals():
+            ref_wid, ref_hgt, ref_geotrans, _, _ = \
+                ARIAtools.util.vrt.get_basic_attrs(prev_outname_check + '.vrt')
+            ref_arr = [ref_wid, ref_hgt, ref_geotrans, prev_outname]
 
     # Loop through other user expected layers
     layers = [i for i in layers if i not in ext_corr_lyrs]

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1193,10 +1193,12 @@ def export_products(
             # extract layers
             handle_epoch_layers(**lyr_input_dict)
 
+            # remove leading underscore from model name to get subdir name
+            tag = i.split('_')[-1]
             # track valid files
             prev_outname = os.path.abspath(
                 os.path.join(workdir,
-                             i.split('_')[-1],
+                             tag,
                              product_dict[1][0][0])
             )
             if os.path.exists(prev_outname + '.vrt'):


### PR DESCRIPTION
Addressing issue #420 , where an error is raised when just either the ionosphere and tropo layer are extracted because the dimensions were not properly passed and accounted for.

Specifically, the program checks for internal consistency between the dimensions of all output layers. This information was not initialized and passed for the ionosphere and tropo layers, so when this check is executed the program fails.