### PR TITLE
Check DEM provided when extracting layers for which necessary

### DIFF
--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -153,22 +153,21 @@ def main():
                   else layer for layer in layers]
 
         # list of layers requiring DEM for extraction
-        layers_requiring_dem = ['all',
+        LAYERS_REQUIRING_DEM = {'all',
                                 'bPerpendicular',
                                 'bParallel',
                                 'incidenceAngle',
                                 'lookAngle',
                                 'azimuthAngle',
-                                'solidEarthTide']
+                                'solidEarthTide'}
 
         # check that DEM is specified depending on layers requested
-        intersecting_layers = [layer for layer in layers
-                               if layer in layers_requiring_dem]
-        if intersecting_layers != []:
-            assert args.demfile is not None, (
-                'A valid DEM must be specified when extracting any of '
-                f"{' '.join(intersecting_layers)}"
-            )
+        if len(LAYERS_REQUIRING_DEM.intersection(layers)) > 0:
+            if args.demfile is None:
+                error_msg = 'A valid DEM must be specified when extracting ' \
+                            'any of %s' % ', '.join(LAYERS_REQUIRING_DEM)
+                LOGGER.error(error_msg)
+                raise Exception(error_msg)
 
     # if user bbox was specified, file(s) not meeting imposed spatial criteria
     # are rejected.

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -142,6 +142,31 @@ def main():
     logging.basicConfig(level=log_level, format=ARIAtools.util.log.FORMAT)
     LOGGER.info('Extract Product Function')
 
+    # Check whether all necessary inputs were specified.
+    # some products require a DEM to extract -- if any of those are requested,
+    # ensure that a valid DEM is specified
+    if args.layers:
+        # format list of layers
+        layers = list(args.layers.split(','))
+        layers = [i.replace(' ', '') for i in layers]
+        layers = [layer.replace(layer, 'all')
+                  for layer in layers if layer.lower() == 'all']
+
+        # list of layers requiring DEM for extraction
+        layers_requiring_dem = {'all',
+                                'bPerpendicular',
+                                'bParallel',
+                                'incidenceAngle',
+                                'lookAngle',
+                                'azimuthAngle',
+                                'solidEarthTide'}
+
+        # check that DEM is specified depending on layers requested
+        if any(layer in layers_requiring_dem for layer in layers):
+            assert args.demfile is not None, \
+                'A valid DEM must be specified when extracting any of {}'.\
+                    format(' '.join(layer for layer in layers_requiring_dem))
+
     # if user bbox was specified, file(s) not meeting imposed spatial criteria
     # are rejected.
     # Outputs = arrays ['standardproduct_info.products'] containing grouped

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -149,7 +149,7 @@ def main():
         # format list of layers
         layers = list(args.layers.split(','))
         layers = [i.replace(' ', '') for i in layers]
-        layers = ['all' if l.lower() == 'all' else l for l in layers]
+        layers = ['all' if layer.lower() == 'all' else layer for layer in layers]
 
         # list of layers requiring DEM for extraction
         layers_requiring_dem = ['all',
@@ -162,12 +162,12 @@ def main():
 
         # check that DEM is specified depending on layers requested
         intersecting_layers = [layer for layer in layers
-            if layer in layers_requiring_dem]
+                               if layer in layers_requiring_dem]
         if intersecting_layers != []:
             assert args.demfile is not None, (
                 'A valid DEM must be specified when extracting any of '
                 f"{' '.join(intersecting_layers)}"
-                )
+            )
 
     # if user bbox was specified, file(s) not meeting imposed spatial criteria
     # are rejected.

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -149,7 +149,8 @@ def main():
         # format list of layers
         layers = list(args.layers.split(','))
         layers = [i.replace(' ', '') for i in layers]
-        layers = ['all' if layer.lower() == 'all' else layer for layer in layers]
+        layers = ['all' if layer.lower() == 'all'
+                  else layer for layer in layers]
 
         # list of layers requiring DEM for extraction
         layers_requiring_dem = ['all',

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -145,7 +145,7 @@ def main():
     # Check whether all necessary inputs were specified.
     # some products require a DEM to extract -- if any of those are requested,
     # ensure that a valid DEM is specified
-    if args.layers:
+    if args.layers is not None:
         # format list of layers
         layers = list(args.layers.split(','))
         layers = [i.replace(' ', '') for i in layers]

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -156,7 +156,6 @@ def main():
                                 'bPerpendicular',
                                 'bParallel',
                                 'incidenceAngle',
-                                'ionosphere',
                                 'lookAngle',
                                 'azimuthAngle',
                                 'solidEarthTide']

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -149,23 +149,26 @@ def main():
         # format list of layers
         layers = list(args.layers.split(','))
         layers = [i.replace(' ', '') for i in layers]
-        layers = [layer.replace(layer, 'all')
-                  for layer in layers if layer.lower() == 'all']
+        layers = ['all' if l.lower() == 'all' else l for l in layers]
 
         # list of layers requiring DEM for extraction
-        layers_requiring_dem = {'all',
+        layers_requiring_dem = ['all',
                                 'bPerpendicular',
                                 'bParallel',
                                 'incidenceAngle',
+                                'ionosphere',
                                 'lookAngle',
                                 'azimuthAngle',
-                                'solidEarthTide'}
+                                'solidEarthTide']
 
         # check that DEM is specified depending on layers requested
-        if any(layer in layers_requiring_dem for layer in layers):
-            assert args.demfile is not None, \
-                'A valid DEM must be specified when extracting any of {}'.\
-                    format(' '.join(layer for layer in layers_requiring_dem))
+        intersecting_layers = [layer for layer in layers
+            if layer in layers_requiring_dem]
+        if intersecting_layers != []:
+            assert args.demfile is not None, (
+                'A valid DEM must be specified when extracting any of '
+                f"{' '.join(intersecting_layers)}"
+                )
 
     # if user bbox was specified, file(s) not meeting imposed spatial criteria
     # are rejected.


### PR DESCRIPTION
Added function to check that a valid DEM is specified or downloaded when requesting ariaExtract.py to extract 'all' or any of 'bPerpendicular', 'bParallel', 'incidenceAngle', 'lookAngle', 'azimuthAngle', or 'solidEarthTide', for which a DEM is necessary.