### PR TITLE
Pass mask for SET and tropo layers

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -882,6 +882,16 @@ def handle_epoch_layers(
                     dem, lat, lon, hgt_field, prod_ver_list, is_nisar_file,
                     outputFormat, verbose=verbose)
 
+                # Apply mask (if specified)
+                if mask is not None:
+                    update_file = osgeo.gdal.Open(
+                        j[1][:-4], osgeo.gdal.GA_Update)
+                    mask_arr = mask.ReadAsArray() * \
+                        osgeo.gdal.Open(j[1][:-4] + '.vrt').ReadAsArray()
+                    update_file.GetRasterBand(1).WriteArray(mask_arr)
+                    update_file = None
+                    mask_arr = None
+
                 # Track consistency of dimensions
                 if j[0] == 0:
                     ref_wid, ref_hgt, ref_geotrans, _, _ = \


### PR DESCRIPTION
SET and tropo layers weren’t getting masked if a valid mask was specified.

E.g. see the final SET output here:
![Screenshot 2024-07-23 at 12 02 48 PM](https://github.com/user-attachments/assets/ab516f24-d138-44c7-93b3-19393b50c965)

After implementing this patch, the layers are masked as intended:
![Screenshot 2024-07-23 at 12 02 23 PM](https://github.com/user-attachments/assets/a131dd04-6911-461c-b479-d673f08de0c5)


You can verify this with the following test:

# access data
wget https://gunw-development-testing.s3.us-west-2.amazonaws.com/unavco_2024/S1-GUNW-A-R-124-tops-20180502_20180408-043026-00157W_00018N-PP-9909-v3_0_1.nc .
wget https://gunw-development-testing.s3.us-west-2.amazonaws.com/unavco_2024/S1-GUNW-A-R-124-tops-20180502_20180408-043052-00157W_00019N-PP-7296-v3_0_1.nc .

# extract SET and tropo layers and apply mask
ariaExtract.py -f "*.nc" -l 'troposphereTotal,solidEarthTide' -w test_corrections -tm ERA5 -d Download -m Download