### PR TITLE
Clean up dem-setup in ariaTSSetup

### DIFF
--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -429,27 +429,24 @@ def main():
 
     # Download/Load DEM & Lat/Lon arrays, providing bbox,
     # expected DEM shape, and output dir as input.
-    if args.demfile is not None:
-        dem_dict = {
-            'demfilename': args.demfile,
-            'bbox_file': standardproduct_info.bbox_file,
-            'prods_TOTbbox': prods_TOTbbox,
-            'prods_TOTbbox_metadatalyr': prods_TOTbbox_metadatalyr,
-            'proj': proj,
-            'arrres': arrres,
-            'workdir': args.workdir,
-            'outputFormat': args.outputFormat,
-            'num_threads': args.num_threads,
-            'multilooking': args.multilooking,
-            'rankedResampling': args.rankedResampling
-        }
+    dem_dict = {
+        'demfilename': args.demfile,
+        'bbox_file': standardproduct_info.bbox_file,
+        'prods_TOTbbox': prods_TOTbbox,
+        'prods_TOTbbox_metadatalyr': prods_TOTbbox_metadatalyr,
+        'proj': proj,
+        'arrres': arrres,
+        'workdir': args.workdir,
+        'outputFormat': args.outputFormat,
+        'num_threads': args.num_threads,
+        'multilooking': args.multilooking,
+        'rankedResampling': args.rankedResampling
+    }
 
-        # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-        LOGGER.info('Download/cropping DEM')
-        demfile, demfile_expanded, lat, lon = \
-            ARIAtools.util.dem.prep_dem(**dem_dict)
-    else:
-        demfile, demfile_expanded, lat, lon = None, None, None, None
+    # Pass DEM-filename, loaded DEM array, and lat/lon arrays
+    LOGGER.info('Download/cropping DEM')
+    demfile, demfile_expanded, lat, lon = \
+        ARIAtools.util.dem.prep_dem(**dem_dict)
 
     # Load or download mask (if specified).
     if args.mask is not None:


### PR DESCRIPTION
For ariaTSSetup default, if not otherwise specified, a DEM is downloaded. Thus, the conditional beginning with `if args.demfile is not None` is superfluous. I am removing this conditional.