### PR TITLE
Push changes to dummy-proof tropo options

### DIFF
--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -370,7 +370,7 @@ class Product:
                             'as it is not one of the '
                             'following valid models: %s' % (
                                 i, ', '.join(
-                                ARIAtools.constants.ARIA_TROPO_INTERNAL)
+                                    ARIAtools.constants.ARIA_TROPO_INTERNAL)
                             )
                         )
                         LOGGER.error(error_msg)

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -9,7 +9,6 @@
 import os
 import re
 import glob
-import copy
 import logging
 import datetime
 import itertools
@@ -269,13 +268,6 @@ class Product:
         else:
             self.num_threads = int(num_threads)
 
-        # set variables to check for tropo extract logic
-        self.tropo_models = tropo_models
-        self.tropo_extract = False
-        if layers is not None:
-            if 'troposphere' in layers:
-                self.tropo_extract = True
-
         # Determine if file input is single file, a list, or wildcard
         # If list of files
         if len([str(val) for val in filearg.split(',')]) > 1:
@@ -352,14 +344,48 @@ class Product:
         if len(self.files) == 0:
             raise Exception('No file match found')
 
+        # exit if user does not specify a valid tropo model name
+        self.tropo_models = tropo_models
+        fname = self.files[0]
+        basename = os.path.basename(fname)
+        if self.tropo_models is not None:
+            if basename.startswith('S1_'):
+                if isinstance(self.tropo_models, str):
+                    if self.tropo_models.lower() == 'all':
+                        self.tropo_models = (
+                            ARIAtools.constants.ARIA_TROPO_INTERNAL
+                        )
+                    else:
+                        self.tropo_models = list(
+                            self.tropo_models.split(',')
+                        )
+                        self.tropo_models = [
+                            i.replace(' ', '')
+                            for i in self.tropo_models]
+                for i in self.tropo_models:
+                    if i not in ARIAtools.constants.ARIA_TROPO_INTERNAL:
+                        error_msg = 'User-requested tropo model ' \
+                                    '%s will not be generated ' \
+                                    'as it is not one of the ' \
+                                    'following valid models: %s' % \
+                                    (i, ', '.join(
+                                     ARIAtools.constants.ARIA_TROPO_INTERNAL)
+                                    )
+                        LOGGER.error(error_msg)
+                        raise Exception(error_msg)
+
+        # set variables to check for tropo extract logic
+        self.tropo_extract = False
+        if layers is not None:
+            if 'troposphere' in layers:
+                self.tropo_extract = True
+
         # If specified workdir doesn't exist, create it
         if not os.path.exists(workdir):
             os.mkdir(workdir)
 
         # find native projection, if specified
         if self.projection.lower() == 'native':
-            fname = self.files[0]
-            basename = os.path.basename(fname)
             if basename.startswith('NISAR_'):
                 record_proj = []
                 pol_dict = {}
@@ -721,25 +747,6 @@ class Product:
                 for i in meta.split():
                     if '/science/grids/corrections/external/troposphere/' in i:
                         model_name.append(i.split('/')[-3])
-
-                # exit if user does not specify a valid tropo model name
-                if self.tropo_models is not None:
-                    if self.tropo_models.lower() != 'all':
-                        VALID_TROPO_MODELS = copy.deepcopy(
-                            ARIAtools.constants.ARIA_TROPO_INTERNAL)
-                        self.tropo_models = list(self.tropo_models.split(','))
-                        self.tropo_models = [
-                            i.replace(' ', '')
-                            for i in self.tropo_models]
-                        for i in self.tropo_models:
-                            if i not in VALID_TROPO_MODELS:
-                                error_msg = 'User-requested tropo model ' \
-                                            '%s will not be generated ' \
-                                            'as it is not one of the ' \
-                                            'following valid models: %s' % \
-                                            (i, ', '.join(VALID_TROPO_MODELS))
-                                LOGGER.error(error_msg)
-                                raise Exception(error_msg)
 
                 # exit if user wishes to extract a tropo layer
                 # but no valid tropo model name is specified by user

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -364,13 +364,15 @@ class Product:
                             for i in self.tropo_models]
                 for i in self.tropo_models:
                     if i not in ARIAtools.constants.ARIA_TROPO_INTERNAL:
-                        error_msg = 'User-requested tropo model ' \
-                                    '%s will not be generated ' \
-                                    'as it is not one of the ' \
-                                    'following valid models: %s' % \
-                                    (i, ', '.join(
-                                     ARIAtools.constants.ARIA_TROPO_INTERNAL)
-                                    )
+                        error_msg = (
+                            'User-requested tropo model '
+                            '%s will not be generated '
+                            'as it is not one of the '
+                            'following valid models: %s' % (
+                                i, ', '.join(
+                                ARIAtools.constants.ARIA_TROPO_INTERNAL)
+                            )
+                        )
                         LOGGER.error(error_msg)
                         raise Exception(error_msg)
 

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -9,6 +9,7 @@
 import os
 import re
 import glob
+import copy
 import logging
 import datetime
 import itertools
@@ -720,6 +721,25 @@ class Product:
                 for i in meta.split():
                     if '/science/grids/corrections/external/troposphere/' in i:
                         model_name.append(i.split('/')[-3])
+
+                # exit if user does not specify a valid tropo model name
+                if self.tropo_models is not None:
+                    if self.tropo_models.lower() != 'all':
+                        VALID_TROPO_MODELS = copy.deepcopy(
+                            ARIAtools.constants.ARIA_TROPO_INTERNAL)
+                        self.tropo_models = list(self.tropo_models.split(','))
+                        self.tropo_models = [
+                            i.replace(' ', '')
+                            for i in self.tropo_models]
+                        for i in self.tropo_models:
+                            if i not in VALID_TROPO_MODELS:
+                                error_msg = 'User-requested tropo model ' \
+                                            '%s will not be generated ' \
+                                            'as it is not one of the ' \
+                                            'following valid models: %s' % \
+                                            (i, ', '.join(VALID_TROPO_MODELS))
+                                LOGGER.error(error_msg)
+                                raise Exception(error_msg)
 
                 # exit if user wishes to extract a tropo layer
                 # but no valid tropo model name is specified by user

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -183,7 +183,8 @@ def main():
         args.imgfile, bbox=args.bbox, projection=args.projection,
         workdir=args.workdir, num_threads=args.num_threads,
         url_version=args.version, nc_version=args.nc_version,
-        verbose=args.verbose)
+        verbose=args.verbose, tropo_models=args.tropo_models,
+        layers=args.layers)
 
     # Perform initial layer, product, and correction sanity checks
     args.layers, args.tropo_total, \

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -411,7 +411,8 @@ def main():
         args.imgfile, bbox=args.bbox, projection=args.projection,
         workdir=args.workdir, num_threads=args.num_threads,
         url_version=args.version, nc_version=args.nc_version,
-        verbose=args.verbose)
+        verbose=args.verbose, tropo_models=args.tropo_models,
+        layers=args.layers)
 
     # extract/merge productBoundingBox layers for each pair and update dict,
     # report common track bbox (default is to take common intersection,


### PR DESCRIPTION
Access test products for this case example as so:
```
wget https://gunw-development-testing.s3.us-west-2.amazonaws.com/unavco_2024/S1-GUNW-A-R-124-tops-20180502_20180408-043026-00157W_00018N-PP-9909-v3_0_1.nc .
wget https://gunw-development-testing.s3.us-west-2.amazonaws.com/unavco_2024/S1-GUNW-A-R-124-tops-20180502_20180408-043052-00157W_00019N-PP-7296-v3_0_1.nc .
```

If a user specifies the extraction of a troposphere layer, but neglects to specify an argument for `--tropo_models`, error out early instead of silently failing to extract it.

To test this, run the following command:
```
ariaExtract.py -f "*.nc" -w tropo_test1 -d Download -l troposphereTotal
```

If a user specifies a tropo model, but neglects to specify the extraction of a valid troposphere layer with the '-l' option, error out early instead of silently failing to extract it.

To test this, run the following command:
```
ariaExtract.py -f "*.nc" -w tropo_test2 -d Download --tropo_models ERA5
```

Finally, if a user specifies a tropo model that doesn't exist, catch this early and error out

To test this, run the following command:
```
ariaExtract.py -f "*.nc" -w tropo_test3 -d Download --tropo_models FAKE_MODEL -l troposphereTotal
```