### PR TITLE
Add standard layers to ariaTSsetup.py

### DIFF
--- a/tools/ARIAtools/constants.py
+++ b/tools/ARIAtools/constants.py
@@ -34,8 +34,8 @@ ARIA_LAYERS += ARIA_INTERNAL_CORRECTIONS
 ARIA_LAYERS += ARIA_TROPO_MODELS
 
 ARIA_STANDARD_LAYERS = [
-    'unwrappedPhase', 'coherence', 'incidenceAngle', 'lookAngle',
-    'azimuthAngle', 'bPerpendicular']
+    'unwrappedPhase', 'coherence', 'incidenceAngle', 'azimuthAngle',
+    'bPerpendicular']
 
 ARIA_STACK_DEFAULTS = ['unwrappedPhase',
                        'coherence',

--- a/tools/ARIAtools/constants.py
+++ b/tools/ARIAtools/constants.py
@@ -34,7 +34,8 @@ ARIA_LAYERS += ARIA_INTERNAL_CORRECTIONS
 ARIA_LAYERS += ARIA_TROPO_MODELS
 
 ARIA_STANDARD_LAYERS = [
-    'unwrappedPhase', 'coherence', 'incidenceAngle', 'azimuthAngle']
+    'unwrappedPhase', 'coherence', 'incidenceAngle', 'lookAngle',
+    'azimuthAngle', 'bPerpendicular']
 
 ARIA_STACK_DEFAULTS = ['unwrappedPhase',
                        'coherence',

--- a/tools/ARIAtools/constants.py
+++ b/tools/ARIAtools/constants.py
@@ -33,6 +33,9 @@ ARIA_LAYERS += ARIA_EXTERNAL_CORRECTIONS
 ARIA_LAYERS += ARIA_INTERNAL_CORRECTIONS
 ARIA_LAYERS += ARIA_TROPO_MODELS
 
+ARIA_STANDARD_LAYERS = [
+    'unwrappedPhase', 'coherence', 'incidenceAngle', 'azimuthAngle']
+
 ARIA_STACK_DEFAULTS = ['unwrappedPhase',
                        'coherence',
                        'connectedComponents',

--- a/tools/ARIAtools/util/vrt.py
+++ b/tools/ARIAtools/util/vrt.py
@@ -474,12 +474,11 @@ def layerCheck(
             layers = [i.replace(' ', '') for i in layers]
 
     # TS pipeline
-    TS_LAYERS_DUP = ['unwrappedPhase', 'coherence', 'incidenceAngle',
-                     'lookAngle', 'azimuthAngle', 'bPerpendicular']
     if extract_or_ts == 'tssetup':
         if layers:
             # remove layers already generated in default TS workflow
-            layers = [i for i in layers if i not in TS_LAYERS_DUP]
+            layers = [i for i in layers if i not in
+                      ARIAtools.constants.ARIA_STANDARD_LAYERS]
 
         else:
             layers = []

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -33,7 +33,8 @@ import ARIAtools.util.dem
 import ARIAtools.extractProduct
 
 from ARIAtools.constants import ARIA_EXTERNAL_CORRECTIONS, \
-    ARIA_TROPO_MODELS, ARIA_STACK_DEFAULTS, ARIA_STACK_OUTFILES
+    ARIA_TROPO_MODELS, ARIA_STACK_DEFAULTS, ARIA_STACK_OUTFILES, \
+    ARIA_STANDARD_LAYERS
 
 osgeo.gdal.UseExceptions()
 
@@ -398,6 +399,10 @@ def main():
     LOGGER.info(
         'Thread count specified for gdal multiprocessing = %s' % (
             args.num_threads))
+
+    if args.layers.lower() == 'standard':
+        LOGGER.debug("Using standard layers: %s" % ARIA_STANDARD_LAYERS)
+        args.layers = ','.join(ARIA_STANDARD_LAYERS)
 
     # if user bbox was specified, file(s) not meeting imposed spatial
     # criteria are rejected.

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -59,7 +59,7 @@ def create_parser():
         default=None,
         help='Path to director(ies) or tar file(s) containing GACOS products.')
     parser.add_argument(
-        '-l', '--layers', dest='layers', default=None,
+        '-l', '--layers', dest='layers', default='standard',
         help='Specify layers to extract as a comma deliminated list bounded '
              'by single quotes. Allowed keys are: "unwrappedPhase", '
              '"coherence", "amplitude", "bPerpendicular", "bParallel", '


### PR DESCRIPTION
Here we add the option to specify 'standard' to extract a standard set of layers, which is set to a constant `ARIA_STANDARD_LAYERS` defined in `ARIAtools/constants.py`. If the string specified in the layers command line argument is standard we replace it with those standard layers.