### PR TITLE
Update env to reflect dem_stitcher fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - arm_pyart
   - asf_search
   - dask
-  - dem_stitcher>=2.5.0
+  - dem_stitcher>=2.5.8
   - gdal>=3.7.0
   - h5py
   - joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ affine
 arm_pyart
 asf_search
 dask
-dem_stitcher>=2.5.0
+dem_stitcher>=2.5.8
 gdal>=3.7.0
 h5py
 joblib


### PR DESCRIPTION
Some of the source-datasets accessed by `dem_stitcher` have been moved. The latest `2.5.8` release of `dem_stitcher` resolves [this](https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/pull/99), and thus our environment files must accordingly be updated.