### PR TITLE
Remove b perp from tssetup

### DIFF
--- a/tests/regression/validate_test.py
+++ b/tests/regression/validate_test.py
@@ -37,7 +37,6 @@ ENVI_FILES['tssetup'] = {
     'incidenceAngle': 'incidenceAngle/20230829_20230724',
     'ionosphere_20230829_20230724': 'ionosphere/20230829_20230724',
     'ionosphere_20230829_20230817': 'ionosphere/20230829_20230817',
-    'lookAngle': 'lookAngle/20230829_20230724',
     'solidEarthTide_20230829_20230724': 'solidEarthTide/20230829_20230724',
     'solidEarthTide_20230829_20230817': 'solidEarthTide/20230829_20230817',
     'troposphereTotal_HRRR_20230829_20230817':

--- a/tests/regression/validate_test.py
+++ b/tests/regression/validate_test.py
@@ -30,8 +30,6 @@ ENVI_FILES['extract'] = {
 }
 ENVI_FILES['tssetup'] = {
     'azimuthAngle': 'azimuthAngle/20230829_20230724',
-    'bPerpendicular_20230829_20230724': 'bPerpendicular/20230829_20230724',
-    'bPerpendicular_20230829_20230817': 'bPerpendicular/20230829_20230817',
     'connectedComponents_20230829_20230724':
         'connectedComponents/20230829_20230724',
     'connectedComponents_20230829_20230817':

--- a/tools/ARIAtools/constants.py
+++ b/tools/ARIAtools/constants.py
@@ -34,8 +34,7 @@ ARIA_LAYERS += ARIA_INTERNAL_CORRECTIONS
 ARIA_LAYERS += ARIA_TROPO_MODELS
 
 ARIA_STANDARD_LAYERS = [
-    'unwrappedPhase', 'coherence', 'incidenceAngle', 'azimuthAngle',
-    'bPerpendicular']
+    'unwrappedPhase', 'coherence', 'incidenceAngle', 'azimuthAngle']
 
 ARIA_STACK_DEFAULTS = ['unwrappedPhase',
                        'coherence',

--- a/tools/ARIAtools/constants.py
+++ b/tools/ARIAtools/constants.py
@@ -33,8 +33,10 @@ ARIA_LAYERS += ARIA_EXTERNAL_CORRECTIONS
 ARIA_LAYERS += ARIA_INTERNAL_CORRECTIONS
 ARIA_LAYERS += ARIA_TROPO_MODELS
 
-ARIA_STANDARD_LAYERS = [
-    'unwrappedPhase', 'coherence', 'incidenceAngle', 'azimuthAngle']
+ARIA_STANDARD_INTF_LAYERS = ['unwrappedPhase', 'coherence']
+ARIA_STANDARD_GEOM_LAYERS = ['incidenceAngle', 'azimuthAngle']
+ARIA_STANDARD_LAYERS = ARIA_STANDARD_INTF_LAYERS + ARIA_STANDARD_GEOM_LAYERS
+
 
 ARIA_STACK_DEFAULTS = ['unwrappedPhase',
                        'coherence',

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -700,9 +700,10 @@ def generate_diff(ref_outname, sec_outname, outname, key, OG_key, tropo_total,
 
     return
 
+
 def extract_bperp_dict(products, num_threads):
     """Extracts bPerpendicular mean over frames for each product in products"""
-    def read_and_average_bperp(filename):
+    def read_and_average_bperp(frame):
         """Helper function for dask multiprocessing"""
         return osgeo.gdal.Open(frame).ReadAsArray().mean()
 
@@ -714,6 +715,7 @@ def extract_bperp_dict(products, num_threads):
 
         mean_bperp_by_frames = dask.compute(
             jobs, num_workers=int(num_threads), scheduler='threads')[0]
+
         LOGGER.debug('Pair name: %s, bPerpendicular %s' % (
             product['pair_name'][0], mean_bperp_by_frames))
         bperp_dict[product['pair_name'][0]] = float(

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -700,6 +700,26 @@ def generate_diff(ref_outname, sec_outname, outname, key, OG_key, tropo_total,
 
     return
 
+def extract_bperp_dict(products, num_threads):
+    """Extracts bPerpendicular mean over frames for each product in products"""
+    def read_and_average_bperp(filename):
+        """Helper function for dask multiprocessing"""
+        return osgeo.gdal.Open(frame).ReadAsArray().mean()
+
+    bperp_dict = {}
+    for product in products:
+        jobs = []
+        for frame in product['bPerpendicular']:
+            jobs.append(dask.delayed(read_and_average_bperp)(frame))
+
+        mean_bperp_by_frames = dask.compute(
+            jobs, num_workers=int(num_threads), scheduler='threads')[0]
+        LOGGER.debug('Pair name: %s, bPerpendicular %s' % (
+            product['pair_name'][0], mean_bperp_by_frames))
+        bperp_dict[product['pair_name'][0]] = float(
+            np.mean(mean_bperp_by_frames))
+    return bperp_dict
+
 
 def handle_epoch_layers(
         layers, product_dict, proj, lyr_path, user_lyrs, map_lyrs, key,

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -34,6 +34,7 @@ import ARIAtools.util.log
 import ARIAtools.util.mask
 import ARIAtools.util.misc
 import ARIAtools.util.vrt
+import ARIAtools.constants
 
 from ARIAtools.constants import ARIA_EXTERNAL_CORRECTIONS, \
     ARIA_TROPO_MODELS, ARIA_STACK_DEFAULTS, ARIA_STACK_OUTFILES, \
@@ -532,10 +533,8 @@ def main():
     }
 
     # export unwrappedPhase
-    layers = ['unwrappedPhase', 'coherence']
-    LOGGER.info(
-        'Extracting unwrapped phase, coherence, and connected components for '
-        'each interferogram pair')
+    layers = ARIAtools.constants.ARIA_STANDARD_INTF_LAYERS
+    LOGGER.info('Extracting %s for each interferogram pair' % layers)
     ref_arr_record = ARIAtools.extractProduct.export_products(
         standardproduct_info.products[1], tropo_total=False, layers=layers,
         rankedResampling=args.rankedResampling, multiproc_method='threads',
@@ -549,10 +548,10 @@ def main():
                 for item in list(set(d[key])):
                     extract_dict[key].append(item)
 
-    layers = ['incidenceAngle', 'lookAngle', 'azimuthAngle']
+    layers = ARIAtools.constants.ARIA_STANDARD_GEOM_LAYERS
     LOGGER.info(
-        'Extracting single incidence angle, look angle and azimuth angle '
-        'files valid over common interferometric grid')
+        'Extracting single %s '
+        'files valid over common interferometric grid' % layers)
     prod_arr_record = ARIAtools.extractProduct.export_products(
         [extract_dict], tropo_total=False, layers=layers,
         multiproc_method='gnu_parallel', **export_dict)

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -535,16 +535,6 @@ def main():
     # Track consistency of dimensions
     ARIAtools.util.vrt.dim_check(ref_arr_record, prod_arr_record)
 
-    layers = ['bPerpendicular']
-    LOGGER.info(
-        'Extracting perpendicular baseline grids for each interferogram pair')
-    prod_arr_record = ARIAtools.extractProduct.export_products(
-        standardproduct_info.products[1], tropo_total=False, layers=layers,
-        multiproc_method='gnu_parallel', **export_dict)
-
-    # Track consistency of dimensions
-    ARIAtools.util.vrt.dim_check(ref_arr_record, prod_arr_record)
-
     # Extracting other layers, if specified
     (layers, args.tropo_total, model_names) = ARIAtools.util.vrt.layerCheck(
         standardproduct_info.products[1], args.layers, args.nc_version,

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -535,6 +535,15 @@ def main():
     # Track consistency of dimensions
     ARIAtools.util.vrt.dim_check(ref_arr_record, prod_arr_record)
 
+    # Extract bPerp to json file
+    for product in standardproduct_info.products[1]:
+        bperp0 = osgeo.gdal.Open(
+            product['bPerpendicular'][0]).ReadAsArray().mean()
+        bperp1 = osgeo.gdal.Open(
+            product['bPerpendicular'][1]).ReadAsArray().mean()
+        LOGGER.info('Pair name: %s, bPerpendicular %s %s' % (
+            product['pair_name'], bperp0, bperp1))
+
     # Extracting other layers, if specified
     (layers, args.tropo_total, model_names) = ARIAtools.util.vrt.layerCheck(
         standardproduct_info.products[1], args.layers, args.nc_version,

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -419,7 +419,7 @@ def main():
         extract_bperp_layer = 'bPerpendicular' in args.layers
         if extract_bperp_layer:
             # Remove bPerpendicular from args.layers
-            layers = args.layers.split(',')
+            layers = [layer.strip() for layer in args.layers.split(',')]
             layers.pop(layers.index('bPerpendicular'))
             args.layers = ','.join(layers)
 


### PR DESCRIPTION
Here we remove the extraction by default of bPerpendicular instead extracting the average over frames into a JSON file.  If the user explicitly requests bPerpendicular we will extract it.

For a case with 54 GUNWs, I found a runtime of 29:06.43 with the full bPerp layer extraction and 8:37.83 with just the mean JSON extraction.  The JSON extraction of bPerp is done in parallel as well with dask.delayed and threads.