### PR TITLE
Skip re-download of DEM and mask if already found

### DIFF
--- a/tools/ARIAtools/util/dem.py
+++ b/tools/ARIAtools/util/dem.py
@@ -110,10 +110,6 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
             demfile_expanded, aria_dem,
             options=osgeo.gdal.WarpOptions(**gdal_warp_kwargs))
 
-    # Delete temporary dem-stitcher directory
-    if os.path.exists(f'{dem_name}_tiles'):
-        shutil.rmtree(f'{dem_name}_tiles')
-
     # Define lat/lon arrays for fullres layers
     gt = ds_aria_expanded.GetGeoTransform()
     xs, ys = ds_aria_expanded.RasterXSize, ds_aria_expanded.RasterYSize

--- a/tools/ARIAtools/util/mask.py
+++ b/tools/ARIAtools/util/mask.py
@@ -110,7 +110,8 @@ def prep_mask(
                                transform=affine.Affine(*reference_gt)) as dst:
                 rasterio.warp.reproject(
                     source=dat_arr, destination=rasterio.band(dst, 1),
-                    src_transform=dat_prof['transform'], src_crs=dat_prof['crs'],
+                    src_transform=dat_prof['transform'],
+                    src_crs=dat_prof['crs'],
                     dst_transform=reference_gt, dst_crs=crs,
                     resampling=resampling_mode)
 


### PR DESCRIPTION
Skip re-downloading a DEM if `--demfile=download` and glo_90_uncropped.vrt exists; and skip downloading and formatting a water mask if the <mask_name>.msk file exists.