### PR TITLE
Rz extract dedup - hardcode lonlat spacing

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -484,8 +484,8 @@ def merged_productbbox(
     with osgeo.gdal.config_options({"GDAL_NUM_THREADS": num_threads}):
         warp_options = osgeo.gdal.WarpOptions(**gdal_warp_kwargs)
         ds = osgeo.gdal.Warp('', vrt, options=warp_options)
-        arrres = [abs(ds.GetGeoTransform()[1]),
-                  abs(ds.GetGeoTransform()[-1])]
+        arrres = [0.000833334,
+                  0.000833334]
         ds = None
 
     # warp again with fixed transform and bounds

--- a/tools/ARIAtools/util/mask.py
+++ b/tools/ARIAtools/util/mask.py
@@ -110,7 +110,8 @@ def prep_mask(
                                transform=affine.Affine(*reference_gt)) as dst:
                 rasterio.warp.reproject(
                     source=dat_arr, destination=rasterio.band(dst, 1),
-                    src_transform=dat_prof['transform'], src_crs=dat_prof['crs'],
+                    src_transform=dat_prof['transform'],
+                    src_crs=dat_prof['crs'],
                     dst_transform=reference_gt, dst_crs=crs,
                     resampling=resampling_mode)
 


### PR DESCRIPTION
Hard coded lon lat pixel resolution values to 0.000833334 degrees. This was done in a single place: lines 487-488 in the `extractProduct.py` module, `mergedproductbbox` function. To the best of my understanding, the parameters coded here should propagate throughout the `ariaTSsetup.py` bin file, in which mergedproductbbox returns the pixels resolution, and that returned value is passed to calls to the `export_products` function.

This change is made as part of a larger ARIA-tools forward processing deduplication effort.