### PR TITLE
Add missing gdal libraries to the environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,8 @@ dependencies:
   - gdal>=3.7.0
   - h5py
   - joblib
+  - libgdal-hdf5
+  - libgdal-netcdf
   - matplotlib
   - netcdf4
   - numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ dem_stitcher>=2.5.8
 gdal>=3.7.0
 h5py
 joblib
+libgdal-hdf5
+libgdal-netcdf
 matplotlib
 netcdf4
 numpy


### PR DESCRIPTION
Add `libgdal-hdf5` and `libgdal-netcdf` to the environment explicitly.