### PR TITLE
Update download call to be compatible with asf_search update

### DIFF
--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -346,7 +346,7 @@ class Downloader(object):
         if self.args.mission.upper() == 'S1':
             dct_kw = dict(
                 collections=["C2859376221-ASF", "C1261881077-ASF"],
-                dataset=asf_search.DATASET.ARIA_S1_GUNW,
+                dataset=asf_search.constants.ARIA_S1_GUNW,
                 processingLevel=asf_search.constants.GUNW_STD,
                 relativeOrbit=tracks, flightDirection=flight_direction,
                 intersectsWith=bbox, start=start, end=end)


### PR DESCRIPTION
Addresses issue #443 

Now `asf_search.constants` is leveraged, as opposed to `asf_search.DATASET`, to be compatible with the latest `asf_search` increment `v8.0.1`. This is backwards compatible with older versions.

@rzinke , @ehavazli, can you please confirm this PR works on your end? Thanks