### PR TITLE
Clarify tropo extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ export VSI_CACHE=YES
 
 The ARIA-tools scripts are highly modulized in Python and therefore allows for building your own processing workflow. Below, we show how to call some of the functionality. For detailed documentation, examples, and Jupyter notebooks see the [ARIA-tools-docs repository](https://github.com/aria-tools/ARIA-tools-docs). We welcome the community to contribute other examples on how to leverage the ARIA-tools (see [here](https://github.com/aria-tools/ARIA-tools/blob/master/CONTRIBUTING.md) for instructions).
 
-* NOTE, currently ARIA-tools does not support deduplication (we are working to add it soon though), so for each commandline input please make sure to specify a fresh output directory with the `--workdir` option.
+* NOTE, Currently we support processing of tropospheric estimates derived from the HRRR weather model for v3.0.1 products spanning the continental United States, and adjacent regions of Canada and Mexico.
 
 ### Commandline download of GUNW Products
 GUNW products can be downloaded through the commandline using the *ariaDownload.py* program, which wraps around the ASF DAAC api.

--- a/tools/ARIAtools/constants.py
+++ b/tools/ARIAtools/constants.py
@@ -22,8 +22,7 @@ ARIA_EXTERNAL_CORRECTIONS = ['troposphereHydrostatic',
 ARIA_INTERNAL_CORRECTIONS = ['ionosphere']
 
 ARIA_TROPO_INTERNAL = ['ERA5',
-                       'GMAO',
-                       'HRES',
+                    #    'HRES', # HRES model currently not available
                        'HRRR']
 
 ARIA_TROPO_MODELS = ARIA_TROPO_INTERNAL

--- a/tools/ARIAtools/util/vrt.py
+++ b/tools/ARIAtools/util/vrt.py
@@ -368,9 +368,9 @@ def layerCheck(
             set.intersection(*map(set, [model_names, tropo_models])))
         for i in tropo_models:
             if i not in model_names:
-                LOGGER.warning(
-                    f'User-requested tropo model {i} will not be generated as '
-                    'it does not exist in any of the input products')
+                LOGGER.warning('%s tropo model not found in product', i)
+            else:
+                LOGGER.info('Generating tropo model %s', i)
     else:
         model_names = []
 

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -45,17 +45,16 @@ def createParser():
              'directory where script is launched.')
     parser.add_argument(
         '-l', '--layers', dest='layers', default=None,
-        help='Specify layers to extract as a comma deliminated list bounded '
-             'by single quotes. Allowed keys are: "unwrappedPhase", '
+        help='Specify the layers to extract as a comma-separated list enclosed '
+             'in single quotes. Allowed values include: "unwrappedPhase", '
              '"coherence", "amplitude", "bPerpendicular", "bParallel", '
              '"incidenceAngle", "lookAngle", "azimuthAngle", "ionosphere", '
              '"troposphereWet", "troposphereHydrostatic", "troposphereTotal", '
-             '"solidEarthTide". If "all" specified, then all layers are '
-             'extracted. If blank, will only extract bounding box.')
+             '"solidEarthTide". If left blank, only the bounding box will be extracted.')
     parser.add_argument(
-        '-tm', '--tropo_models', dest='tropo_models', type=str, default=None,
-        help='Provide list ofweather models you wish to extract. Refer to '
-             'ARIA_TROPO_MODELS for list of supported models')
+        '-tm', '--tropo_models', dest='tropo_models', type=str, default='all',
+        help='Specify the weather model(s) to extract. '
+             'The default is "all", which extracts all models in the product.')
     parser.add_argument(
         '-d', '--demfile', dest='demfile', type=str, default=None,
         help='DEM file. To download new DEM, specify "Download".')
@@ -140,7 +139,9 @@ def main():
         'warning': logging.WARNING, 'error': logging.ERROR}[args.log_level]
     logging.basicConfig(level=log_level, format=ARIAtools.util.log.FORMAT)
     LOGGER.info('Extract Product Function')
-
+    # Switch tropo models to None if troposphere isn't specified
+    if args.layers == None or 'tropo' not in args.layers:
+        args.tropo_models = None
     # Check whether all necessary inputs were specified.
     # some products require a DEM to extract -- if any of those are requested,
     # ensure that a valid DEM is specified

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -61,17 +61,18 @@ def create_parser():
              'directory where script is launched.')
     parser.add_argument(
         '-l', '--layers', dest='layers', default='standard',
-        help='Specify layers to extract as a comma deliminated list bounded '
-             'by single quotes. Allowed keys are: "unwrappedPhase", '
+        help='Specify the layers to extract as a comma-separated list enclosed '
+             'in single quotes. Allowed values include: "unwrappedPhase", '
              '"coherence", "amplitude", "bPerpendicular", "bParallel", '
              '"incidenceAngle", "lookAngle", "azimuthAngle", "ionosphere", '
              '"troposphereWet", "troposphereHydrostatic", "troposphereTotal", '
-             '"solidEarthTide". If "all" specified, then all layers are '
-             'extracted. If blank, will only extract bounding box.')
+             '"solidEarthTide". Use "all" to extract all interferometry and '
+             'geometry layers. Correction layers must be explicitly specified '
+             'to be extracted. If left blank, only the bounding box will be extracted.')
     parser.add_argument(
         '-tm', '--tropo_models', dest='tropo_models', type=str, default='all',
-        help='Provide list of weather models you wish to extract. Refer to '
-             'ARIA_TROPO_INTERNAL for list of supported models')
+        help='Specify the weather model(s) to extract. '
+             'The default is "all", which extracts all models in the product.')
     parser.add_argument(
         '-d', '--demfile', dest='demfile', type=str, default='download',
         help='DEM file. Default is to download new DEM.')

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -69,7 +69,7 @@ def create_parser():
              '"solidEarthTide". If "all" specified, then all layers are '
              'extracted. If blank, will only extract bounding box.')
     parser.add_argument(
-        '-tm', '--tropo_models', dest='tropo_models', type=str, default=None,
+        '-tm', '--tropo_models', dest='tropo_models', type=str, default='all',
         help='Provide list of weather models you wish to extract. Refer to '
              'ARIA_TROPO_INTERNAL for list of supported models')
     parser.add_argument(
@@ -431,6 +431,9 @@ def main():
     if args.layers.lower() == 'standard':
         LOGGER.debug("Using standard layers: %s" % ARIA_STANDARD_LAYERS)
         args.layers = ','.join(ARIA_STANDARD_LAYERS)
+
+    if 'tropo' not in args.layers:
+        args.tropo_models = None
 
     # Establish log file and update with basic parameters
     runlog = ARIAtools.util.runlog.RunLog(args.workdir)


### PR DESCRIPTION
- Default value for `-tm, --tropo_models` is changed to `all` so all existing tropospheric models can be extracted (currently only one model is included in ARIA products)
- Added a switch to if no tropospheric layer is requested for extraction.

This method allows us to preserve existing functionality and leaves room future changes to products.