### PR TITLE
Handle missing correction layer dates in stack VRT generation

### DIFF
--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -248,15 +248,32 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
     if (domain_name in ARIA_EXTERNAL_CORRECTIONS or
         domain_name in ARIA_TROPO_MODELS):
         aria_indiv_dates = []
+        rejected_dates = []
         for aria_date in aria_dates:
             dates = aria_date.split('_')
+            # check reference date
             dt1_fname = os.path.join(workdir, stack_layer, dates[0] + '.vrt')
             if os.path.exists(dt1_fname):
                 aria_indiv_dates += [dates[0]]
+            else:
+                rejected_dates += [dates[0]]
+
+            # check secondary date
             dt2_fname = os.path.join(workdir, stack_layer, dates[1] + '.vrt')
             if os.path.exists(dt2_fname):
                 aria_indiv_dates += [dates[1]]
+            else:
+                rejected_dates += [dates[0]]
+
         aria_dates = sorted(list(set(aria_indiv_dates)))
+        rejected_dates = sorted(list(set(rejected_dates)))
+
+        # report rejected dates
+        if rejected_dates != []:
+            LOGGER.warning(
+                'The following %d date(s) lack %s layers: %s',
+                 len(rejected_dates), domain_name, ", ".join(rejected_dates)
+            )
 
     # Find files
     int_list = [os.path.join(workdir, stack_layer, aria_date + '.vrt')

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -215,10 +215,6 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
                    workdir='./', ref_tropokey=None, ref_dlist=None):
     """Generate time series stack."""
     os.environ['GDAL_PAM_ENABLED'] = 'YES'
-    # Progress bar
-    prog_bar = ARIAtools.util.misc.ProgressBar(
-        maxValue=len(aria_prod.products[1]), print_msg='Creating stack: ')
-
     # Set up single stack file
     stack_dir = os.path.join(workdir, 'stack')
     if not os.path.exists(stack_dir):
@@ -254,7 +250,12 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
         aria_indiv_dates = []
         for aria_date in aria_dates:
             dates = aria_date.split('_')
-            aria_indiv_dates += dates
+            dt1_fname = os.path.join(workdir, stack_layer, dates[0] + '.vrt')
+            if os.path.exists(dt1_fname):
+                aria_indiv_dates += [dates[0]]
+            dt2_fname = os.path.join(workdir, stack_layer, dates[1] + '.vrt')
+            if os.path.exists(dt2_fname):
+                aria_indiv_dates += [dates[1]]
         aria_dates = sorted(list(set(aria_indiv_dates)))
 
     # Find files
@@ -263,6 +264,10 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
     dlist = sorted(int_list)
     LOGGER.info(
         'Number of %s files discovered: %d' % (stack_layer, len(int_list)))
+
+    # Progress bar
+    prog_bar = ARIAtools.util.misc.ProgressBar(
+        maxValue=len(int_list), print_msg='Creating stack: ')
 
     # only perform following checks if a differential layer
     b_perp = []

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -245,6 +245,7 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
     # get dates
     aria_dates = \
         sorted([prod['pair_name'][0] for prod in aria_prod.products[0]])
+
     if (domain_name in ARIA_EXTERNAL_CORRECTIONS or
         domain_name in ARIA_TROPO_MODELS):
         aria_indiv_dates = []
@@ -263,7 +264,7 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
             if os.path.exists(dt2_fname):
                 aria_indiv_dates += [dates[1]]
             else:
-                rejected_dates += [dates[0]]
+                rejected_dates += [dates[1]]
 
         aria_dates = sorted(list(set(aria_indiv_dates)))
         rejected_dates = sorted(list(set(rejected_dates)))
@@ -657,6 +658,7 @@ def main():
     # prepare additional stacks for other layers
     layers += ARIA_STACK_DEFAULTS
     layers.remove('unwrappedPhase')
+    layers = sorted(list(set(layers)))
 
     remove_lyrs = []
     for i in layers:
@@ -675,6 +677,7 @@ def main():
     stack_dict = {'workdir': args.workdir, 'ref_dlist': ref_dlist}
     for layer in layers:
         if layer in ARIA_STACK_OUTFILES.keys():
+            print('layer', layer)
 
             # iterate through model dirs if necessary
             if 'tropo' in layer:


### PR DESCRIPTION
When running `ariaTSsetup.py` over a CA frame, I got the following error:
```
Traceback (most recent call last):
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/ARIA-tools_dev/tools/bin/ariaTSsetup.py", line 681, in <module>
    main()
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/ARIA-tools_dev/tools/bin/ariaTSsetup.py", line 670, in main
    generate_stack(
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/ARIA-tools_dev/tools/bin/ariaTSsetup.py", line 314, in generate_stack
    ARIAtools.util.vrt.get_basic_attrs(dlist[0])
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/ARIA-tools_dev/tools/ARIAtools/util/vrt.py", line 456, in get_basic_attrs
    data_set = osgeo.gdal.Open(fname)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/envs/ARIA-tools_dev/lib/python3.12/site-packages/osgeo/gdal.py", line 8817, in Open
    return _gdal.Open(*args)
           ^^^^^^^^^^^^^^^^^
RuntimeError: /u/duvel-d0/ssangha/CA_SCEC/D042/frame1/ARIA-tools/solidEarthTide/dates/20201105.vrt: No such file or directory
```


After digging a bit, I found out this is because there is a mix of different IFGs which exclusively were either of version 2 or 3. SET layers are only available for the latter, but when generating the stack VRT files, the program assumed they were available for all products. I tweaked the logic to capture such cases and only pass cases for which these layers actually exist.


To replicate my tests, you can run the following:
```
ariaDownload.py --track 42 --output Download -b '35.31979 38.43824 -122.53671 -119.55469' 
ariaTSsetup.py -f "products/*00035N*.nc" --num_threads 6 --layers "solidEarthTide" -w output_prods
```