### PR TITLE
Add support for NISAR sample product v4.0.4

### DIFF
--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -496,10 +496,10 @@ class Product:
             version = basename.split('_')[-1][:-3]
             version = '.'.join(version)
             nc_version_check = [version]
-            if not basename.endswith('_J_001.h5'):
+            if not basename.endswith('_M_P_J_001.h5'):
                 LOGGER.warning(
-                    'input file %s rejected because it downloaded from asf '
-                    'and not a supported version', fname)
+                    'input file %s is an older, unsupported '
+                    'version of the NISAR sample product', fname)
                 return []
 
         else:
@@ -1013,13 +1013,15 @@ class Product:
         for i in enumerate(layerkeys):
             datalyr_dict[i[1]] = fname + '":' + sdskeys[i[0]]
 
-        # Rewrite tropo and iono keys
+        # Rewrite tropo, iono, and SET keys
         datalyr_dict['ionosphere'] = datalyr_dict.pop(
             'ionospherePhaseScreen')
         datalyr_dict['troposphereHydrostatic'] = datalyr_dict.pop(
             'hydrostaticTroposphericPhaseScreen')
         datalyr_dict['troposphereWet'] = datalyr_dict.pop(
             'wetTroposphericPhaseScreen')
+        datalyr_dict['solidEarthTide'] = datalyr_dict.pop(
+            'slantRangeSolidEarthTidesPhase')
 
         return [rdrmetadata_dict, datalyr_dict]
 

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -496,7 +496,7 @@ class Product:
             version = basename.split('_')[-1][:-3]
             version = '.'.join(version)
             nc_version_check = [version]
-            if not basename.endswith('_P_F_J_001.h5'):
+            if not basename.endswith('_J_001.h5'):
                 LOGGER.warning(
                     'input file %s rejected because it downloaded from asf '
                     'and not a supported version', fname)
@@ -922,7 +922,7 @@ class Product:
             # get slant range info
             rdr_slant_range = hdf_gunw[
                 '/science/LSAR/GUNW/metadata/' +
-                'radarGrid/slantRange'][()].flatten()
+                'radarGrid/referenceSlantRange'][()].flatten()
             min_range = min(rdr_slant_range)
             max_range = max(rdr_slant_range)
             rdr_slant_range_spac = hdf_gunw['/science/LSAR/GUNW/grids/' +
@@ -970,7 +970,6 @@ class Product:
         # track and add additional correction layers, if they exist
         sdskeys_addlyrs = [
             lyr_pref + 'slantRangeSolidEarthTidesPhase',
-            lyr_pref + 'alongTrackSolidEarthTidesPhase',
             lyr_pref + 'hydrostaticTroposphericPhaseScreen',
             lyr_pref + 'wetTroposphericPhaseScreen'
         ]
@@ -1001,7 +1000,6 @@ class Product:
             'ionospherePhaseScreenUncertainty', 'bPerpendicular', 'bParallel',
             'incidenceAngle', 'losUnitVectorX', 'losUnitVectorY',
             'elevationAngle', 'slantRangeSolidEarthTidesPhase',
-            'alongTrackSolidEarthTidesPhase',
             'hydrostaticTroposphericPhaseScreen', 'wetTroposphericPhaseScreen']
 
         # Setup datalyr_dict


### PR DESCRIPTION
You could test out extraction of supported layers with the following command after downloading the sample product:
`ariaExtract.py -f "products/*h5" -l 'unwrappedPhase,troposphereTotal,ionosphere' -w NISAR_v404 -of ISCE -d Download -m Download`

Note these proposed changes are not backwards compatible with the previous sample products.