### PR TITLE
asf_search logging level set to ERROR

### DIFF
--- a/tools/ARIAtools/util/log.py
+++ b/tools/ARIAtools/util/log.py
@@ -17,6 +17,7 @@ FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 for logger in ['botocore', 'urllib3', 'rasterio', 'asyncio']:
     logging.getLogger(logger).setLevel(logging.WARNING)
 
+logging.getLogger("asf_search").setLevel("ERROR")
 
 # Inspired by
 # https://stackoverflow.com/questions/384076/how-can-i-color-python-logging-output


### PR DESCRIPTION
Change logging level of `asf_search` package to `ERROR` to avoid outputs like:
```
ariaDownload.py --track 42 --output Download -b '35.31979 38.43824 -122.53671 -119.55469' 

2025-02-11 10:38:29,363 - asf_search - INFO - SEARCH: Using search opts {
    "intersectsWith": "POLYGON ((-122.5367099999999994 38.4382400000000004, -122.5367099999999994 35.3197899999999976, -119.5546899999999937 35.3197899999999976, -119.5546899999999937 38.4382400000000004, -122.5367099999999994 38.4382400000000004))",
    "processingLevel": [
        "GUNW_STD"
    ],
    "relativeOrbit": [
        42
    ],
    "start": "2009-12-31T00:00:00Z",
    "end": "2100-01-02T00:00:00Z",
    "collections": [
        "C2859376221-ASF",
        "C1261881077-ASF"
    ],
    "dataset": [
        "ARIA S1 GUNW"
    ]
}
2025-02-11 10:38:29,366 - asf_search - INFO - SEARCH: Using cmr endpoint: "https://cmr.earthdata.nasa.gov/search/granules.umm_json"
2025-02-11 10:38:29,366 - asf_search - INFO - SUBQUERY 1: Beginning subquery with opts: {
    "intersectsWith": "POLYGON ((-122.5367099999999994 38.4382400000000004, -122.5367099999999994 35.3197899999999976, -119.5546899999999937 35.3197899999999976, -119.5546899999999937 38.4382400000000004, -122.5367099999999994 38.4382400000000004))",
    "relativeOrbit": [
        42
    ],
    "start": "2009-12-31T00:00:00Z",
    "end": "2100-01-02T00:00:00Z",
    "collections": [
        "C1225776654-ASF",
        "C1261881077-ASF",
        "C1595422627-ASF",
        "C2859376221-ASF"
    ]
}
2025-02-11 10:38:30,152 - asf_search - INFO - Query Time Elapsed 0.785362958908081
2025-02-11 10:38:30,208 - asf_search - INFO - Page Processing Time 1.0013580322265625e-05
2025-02-11 10:38:30,866 - asf_search - INFO - Query Time Elapsed 0.6584758758544922
2025-02-11 10:38:30,935 - asf_search - INFO - Page Processing Time 1.0013580322265625e-05
2025-02-11 10:38:31,501 - asf_search - INFO - Query Time Elapsed 0.5654981136322021
2025-02-11 10:38:31,570 - asf_search - INFO - Page Processing Time 1.0967254638671875e-05
2025-02-11 10:38:32,157 - asf_search - INFO - Query Time Elapsed 0.5865380764007568
2025-02-11 10:38:32,208 - asf_search - INFO - Page Processing Time 6.9141387939453125e-06
2025-02-11 10:38:32,713 - asf_search - INFO - Query Time Elapsed 0.5048770904541016
2025-02-11 10:38:32,777 - asf_search - INFO - Page Processing Time 7.867813110351562e-06
2025-02-11 10:38:33,260 - asf_search - INFO - Query Time Elapsed 0.4832639694213867
2025-02-11 10:38:33,353 - asf_search - INFO - Page Processing Time 7.3909759521484375e-06
```