### PR TITLE
Bug fix for flipped reference and secondary dates in correction layers

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -742,8 +742,8 @@ def prep_metadatalayers(
             if not os.path.exists(date_dir):
                 os.mkdir(date_dir)
 
-            ref_outname = os.path.join(date_dir, ifg.split('_')[0])
-            sec_outname = os.path.join(date_dir, ifg.split('_')[1])
+            ref_outname = os.path.join(date_dir, ifg.split('_')[1])
+            sec_outname = os.path.join(date_dir, ifg.split('_')[0])
             ref_str = 'reference/' + layer
             sec_str = 'secondary/' + layer
             sec_metadata_arr = [


### PR DESCRIPTION
The reference and secondary dates are flipped for troposphere and solid Earth tide corrections. This fix switches the dates allowing them to be extracted with the correct sign.