### PR TITLE
Update integration test and environment to reflect archive migration

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   - affine
   - arm_pyart
-  - asf_search
+  - asf_search>=10.0.4
   - dask
   - dem_stitcher>=2.5.8
   - gdal>=3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 affine
 arm_pyart
-asf_search
+asf_search>=10.0.4
 dask
 dem_stitcher>=2.5.8
 gdal>=3.7.0

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,8 +12,8 @@ ariaDownload.py -t 124 -w products --ifg 20180420_20180315 -v -o count
 ariaDownload.py -t 124 -w products --ifg 20180420_20180315 -v -o url
 
 cd products
-wget --no-clobber --load-cookies /tmp/cookies.txt --save-cookies /tmp/cookies.txt --keep-session-cookies https://grfn.asf.alaska.edu/door/download/S1-GUNW-A-R-124-tops-20180420_20180315-043105-00157W_00020N-PP-74e7-v2_0_6.nc
-wget --no-clobber --load-cookies /tmp/cookies.txt --save-cookies /tmp/cookies.txt --keep-session-cookies https://grfn.asf.alaska.edu/door/download/S1-GUNW-A-R-124-tops-20180420_20180315-043040-00157W_00018N-PP-3f11-v2_0_6.nc
+wget --no-clobber --load-cookies /tmp/cookies.txt --save-cookies /tmp/cookies.txt --keep-session-cookies https://cumulus.asf.earthdatacloud.nasa.gov/ARIA/SENTINEL-1_INTERFEROGRAMS/S1-GUNW-A-R-124-tops-20180420_20180315-043105-00157W_00020N-PP-74e7-v2_0_6/S1-GUNW-A-R-124-tops-20180420_20180315-043105-00157W_00020N-PP-74e7-v2_0_6.nc
+wget --no-clobber --load-cookies /tmp/cookies.txt --save-cookies /tmp/cookies.txt --keep-session-cookies https://cumulus.asf.earthdatacloud.nasa.gov/ARIA/SENTINEL-1_INTERFEROGRAMS/S1-GUNW-A-R-124-tops-20180420_20180315-043040-00157W_00018N-PP-3f11-v2_0_6/S1-GUNW-A-R-124-tops-20180420_20180315-043040-00157W_00018N-PP-3f11-v2_0_6.nc
 cd ../
 
 #extraction of 3D metadata layer


### PR DESCRIPTION
Following the [announced](https://www.earthdata.nasa.gov/about/earthdata-cloud-evolution) migration of the GUNW archive, I'm pushing tweaks to the integration tests and environment to capture this update.

I confirmed products can be downloaded as expected through `ariaDownload.py` since the code directly calls `asf_search`.