### PR TITLE
Modify bperp data reading to ignore NaN values

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1047,8 +1047,8 @@ def extract_bperp_dict(products, num_threads):
         # 1. Open explicitly
         ds = osgeo.gdal.Open(frame, osgeo.gdal.GA_ReadOnly)
         
-        # 2. Read data
-        res = ds.ReadAsArray().mean()
+        # 2. Read data and take mean, but ignore NaN values
+        res = np.nanmean(arr)
         
         # 3. CRITICAL: Close the file explicitly
         ds = None 

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1048,6 +1048,7 @@ def extract_bperp_dict(products, num_threads):
         ds = osgeo.gdal.Open(frame, osgeo.gdal.GA_ReadOnly)
         
         # 2. Read data and take mean, but ignore NaN values
+        arr = ds.ReadAsArray()
         res = np.nanmean(arr)
         
         # 3. CRITICAL: Close the file explicitly


### PR DESCRIPTION
Updated the data reading process to use np.nanmean to ignore NaN values.