### PR TITLE
Projection mismatch for S1 GUNW ionosphere frames + artifact screening for single frame NISAR extraction

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1571,6 +1571,7 @@ def export_product_worker(
                 bounds=bounds, clip_json=prods_TOTbbox, output_unw=outFilePhs,
                 output_conn=outFileConnComp,
                 output_format=outputFormatPhys,
+                is_nisar_file=is_nisar_file,
                 range_correction=range_correction, save_fig=False,
                 overwrite=True)
 
@@ -1642,7 +1643,7 @@ def export_product_worker(
 
 def export_products(
         full_product_dict, proj, bbox_file, prods_TOTbbox, layers, arrres,
-        is_nisar_file, rankedResampling=False, demfile=None,
+        iono_filter, is_nisar_file, rankedResampling=False, demfile=None,
         demfile_expanded=None, lat=None, lon=None, maskfile=None, outDir='./',
         outputFormat='VRT', verbose=None, num_threads='2', multilooking=None,
         tropo_total=False, model_names=[], multiproc_method='single',
@@ -1898,6 +1899,8 @@ def export_products(
                               bounds=bounds,
                               clip_json=prods_TOTbbox,
                               mask_file=mask,
+                              iono_filter=iono_filter,
+                              is_nisar_file=is_nisar_file,
                               verbose=verbose,
                               overwrite=True)
 

--- a/tools/ARIAtools/util/ionosphere.py
+++ b/tools/ARIAtools/util/ionosphere.py
@@ -151,10 +151,32 @@ def stitch_ionosphere_frames(
                 varname = "connectedComponents"
             ).squeeze()
         else:
-            iono_xr = xr.open_dataset(iono_file, engine="rasterio").squeeze()
+            # Dynamically warp legacy ionosphere to target projection
+            iono_xr = ARIAtools.util.stitch.get_GUNW_array(
+                filename=iono_file,
+                proj=proj,
+                xres=xres,
+                yres=yres,
+                nodata=iono_attr_list[-1]['NODATA'],
+                as_xarray=True,
+                varname="ionosphere"
+            ).squeeze()
+
+            # Retrieve nodata value for legacy connectedComponents
             conn_file = GUNW_LAYERS["connectedComponents"] % filename
-            mask_xr = xr.open_dataset(
-                conn_file, engine="rasterio"
+            conn_np = osgeo.gdal.Open(conn_file)
+            conn_nodata = conn_np.GetRasterBand(1).GetNoDataValue()
+            conn_np = None
+
+            # Dynamically warp legacy mask to target projection
+            mask_xr = ARIAtools.util.stitch.get_GUNW_array(
+                filename=conn_file,
+                proj=proj,
+                xres=xres,
+                yres=yres,
+                nodata=conn_nodata,
+                as_xarray=True,
+                varname="connectedComponents"
             ).squeeze()
 
         mask = np.bool_(mask_xr.connectedComponents.data != 0)

--- a/tools/ARIAtools/util/ionosphere.py
+++ b/tools/ARIAtools/util/ionosphere.py
@@ -102,6 +102,8 @@ def stitch_ionosphere_frames(
     xres: Optional[float] = None,
     yres: Optional[float] = None,
     direction_N_S: typing.Optional[bool] = True,
+    iono_filter: typing.Optional[bool] = True,
+    is_nisar_file: typing.Optional[bool] = True,
 ):
 
     # Initalize variables for raster attributes
@@ -109,17 +111,14 @@ def stitch_ionosphere_frames(
     iono_xr_list = []
     mask_xr_list = []
 
-    # track if product stack is NISAR GUNW or not
-    is_nisar_file = False
-    track_fileext = input_iono_files[0].split(":")[1]
-    if len(track_fileext.split(".h5")) > 1:
-        is_nisar_file = True
-        # Get polarization
+    # Get polarization
+    if is_nisar_file:
         pol_dict = {}
         pol_dict["SV"] = "VV"
         pol_dict["SH"] = "HH"
         pol_dict["HHNA"] = "HH"
-        basename = os.path.basename(track_fileext)
+        strp_fname = input_iono_files[0].split(":")[1]
+        basename = os.path.basename(strp_fname)
         file_pol = pol_dict[basename.split("_")[10]]
 
     # Loop through files
@@ -134,8 +133,10 @@ def stitch_ionosphere_frames(
         # 1. Fetch NISAR mask if applicable
         nisar_mask = None
         if is_nisar_file:
-            nisar_mask = ARIAtools.util.stitch.get_binary_nisar_mask_from_path(
-                iono_file
+            nisar_mask = (
+                ARIAtools.util.stitch.get_binary_nisar_mask_from_path(
+                    iono_file
+                )
             )
             conn_file = NISAR_GUNW_LAYERS["connectedComponents"] % (
                 filename, file_pol
@@ -172,11 +173,11 @@ def stitch_ionosphere_frames(
             mask=nisar_mask,
         ).squeeze()
 
-        # 5. Create final mask isolating reliable areas (!= 0)
-        mask = np.bool_(mask_xr.connectedComponents.data != 0)
+        # 5. Create final mask isolating reliable areas (!= 0, -1)
+        mask = ~np.isin(mask_xr.connectedComponents.data, [0, -1])
         mask_xr["connectedComponents"].values = mask
         mask_xr = mask_xr.rename_vars({"connectedComponents": "mask"})
-        
+
         # Interpolate to iono grid
         mask_xr = mask_xr.interp_like(iono_xr)
 
@@ -231,17 +232,22 @@ def stitch_ionosphere_frames(
         )
 
     # Step 3: Fit quadratic surface
+    combined_iono_arr = combined_iono[0].copy()
     # Mask combined_iono before surface fitting
-    combined_iono_msk = combined_iono[0].copy()
     mask = ~np.nan_to_num(combined_mask[0], 0).astype(np.bool_)
-    combined_iono_msk[mask] = np.nan
+    combined_iono_arr[mask] = np.nan
+    if (
+        (iono_filter and is_nisar_file)
+        or not is_nisar_file
+    ):
+        # Get surface
+        surface = fit_surface(combined_iono_arr)
+        surface = np.ma.masked_array(surface, mask=np.isnan(combined_iono[0]))
+        combined_iono_arr = surface.filled(fill_value=0.0)
+        del surface
+        
 
-    # Get surface
-    surface = fit_surface(combined_iono_msk)
-    surface = np.ma.masked_array(surface, mask=np.isnan(combined_iono[0]))
-    surface = surface.filled(fill_value=0.0)
-
-    return surface, combined_iono[1], combined_iono[2]
+    return combined_iono_arr, combined_iono[1], combined_iono[2]
 
 
 # MAIN
@@ -256,6 +262,8 @@ def export_ionosphere(
     bounds: typing.Optional[tuple] = None,
     clip_json: typing.Optional[str] = None,
     mask_file: typing.Optional[str] = None,
+    iono_filter: typing.Optional[bool] = False,
+    is_nisar_file: typing.Optional[bool] = False,
     verbose: typing.Optional[bool] = False,
     overwrite: typing.Optional[bool] = True,
 ) -> None:
@@ -280,6 +288,8 @@ def export_ionosphere(
         yres=arrres[1],
         proj=epsg,
         direction_N_S=True,
+        iono_filter=iono_filter,
+        is_nisar_file=is_nisar_file,
     )
 
     ARIAtools.util.stitch.write_GUNW_array(
@@ -318,13 +328,15 @@ def export_ionosphere(
     ds = None
 
     # Fill NoData using nearest neighbor interpolation
-    ds = osgeo.gdal.Open(str(output_iono), osgeo.gdal.GA_Update)
-    band = ds.GetRasterBand(1)
-    osgeo.gdal.FillNodata(
-        targetBand=band, maskBand=None, maxSearchDist=100, smoothingIterations=0
-    )
-    band = None
-    ds = None
+    if not is_nisar_file:
+        ds = osgeo.gdal.Open(str(output_iono), osgeo.gdal.GA_Update)
+        band = ds.GetRasterBand(1)
+        osgeo.gdal.FillNodata(
+            targetBand=band, maskBand=None, maxSearchDist=100,
+            smoothingIterations=0
+        )
+        band = None
+        ds = None
 
     # Update VRT
     if verbose:

--- a/tools/ARIAtools/util/ionosphere.py
+++ b/tools/ARIAtools/util/ionosphere.py
@@ -125,63 +125,58 @@ def stitch_ionosphere_frames(
     # Loop through files
     for iono_file in input_iono_files:
         filename = iono_file.split(":")[1]
-        iono_attr_list.append(ARIAtools.util.stitch.get_GUNW_attr(iono_file, xres=xres, yres=yres, proj=proj))
+        iono_attr_list.append(
+            ARIAtools.util.stitch.get_GUNW_attr(
+                iono_file, xres=xres, yres=yres, proj=proj
+            )
+        )
 
-        # Load raster and generate mask using unwrapPhase connectedComponents
+        # 1. Fetch NISAR mask if applicable
+        nisar_mask = None
         if is_nisar_file:
-            iono_xr = ARIAtools.util.stitch.get_GUNW_array(
-                filename=iono_file,
-                proj=proj,
-                xres=xres, yres=yres,
-                nodata=iono_attr_list[-1]['NODATA'],
-                as_xarray = True,
-                varname = "connectedComponents"
-            ).squeeze()
-            # get concomp nodata value
-            conn_file = NISAR_GUNW_LAYERS["connectedComponents"] % (filename, file_pol)
-            conn_np = osgeo.gdal.Open(conn_file)
-            conn_nodata = conn_np.GetRasterBand(1)
-            conn_nodata = conn_nodata.GetNoDataValue()
-            mask_xr = ARIAtools.util.stitch.get_GUNW_array(
-                filename=conn_file,
-                proj=proj,
-                xres=xres, yres=yres,
-                nodata=conn_nodata,
-                as_xarray = True,
-                varname = "connectedComponents"
-            ).squeeze()
+            nisar_mask = ARIAtools.util.stitch.get_binary_nisar_mask_from_path(
+                iono_file
+            )
+            conn_file = NISAR_GUNW_LAYERS["connectedComponents"] % (
+                filename, file_pol
+            )
         else:
-            # Dynamically warp legacy ionosphere to target projection
-            iono_xr = ARIAtools.util.stitch.get_GUNW_array(
-                filename=iono_file,
-                proj=proj,
-                xres=xres,
-                yres=yres,
-                nodata=iono_attr_list[-1]['NODATA'],
-                as_xarray=True,
-                varname="ionosphere"
-            ).squeeze()
-
-            # Retrieve nodata value for legacy connectedComponents
             conn_file = GUNW_LAYERS["connectedComponents"] % filename
-            conn_np = osgeo.gdal.Open(conn_file)
-            conn_nodata = conn_np.GetRasterBand(1).GetNoDataValue()
-            conn_np = None
 
-            # Dynamically warp legacy mask to target projection
-            mask_xr = ARIAtools.util.stitch.get_GUNW_array(
-                filename=conn_file,
-                proj=proj,
-                xres=xres,
-                yres=yres,
-                nodata=conn_nodata,
-                as_xarray=True,
-                varname="connectedComponents"
-            ).squeeze()
+        # 2. Load Ionosphere (Mask applied natively during load)
+        iono_xr = ARIAtools.util.stitch.get_GUNW_array(
+            filename=iono_file,
+            proj=proj,
+            xres=xres,
+            yres=yres,
+            nodata=iono_attr_list[-1]["NODATA"],
+            as_xarray=True,
+            varname="ionosphere",
+            mask=nisar_mask,
+        ).squeeze()
 
+        # 3. Retrieve nodata value for connectedComponents
+        conn_np = osgeo.gdal.Open(conn_file)
+        conn_nodata = conn_np.GetRasterBand(1).GetNoDataValue()
+        conn_np = None
+
+        # 4. Load connectedComponents (Mask applied natively during load)
+        mask_xr = ARIAtools.util.stitch.get_GUNW_array(
+            filename=conn_file,
+            proj=proj,
+            xres=xres,
+            yres=yres,
+            nodata=conn_nodata,
+            as_xarray=True,
+            varname="connectedComponents",
+            mask=nisar_mask,
+        ).squeeze()
+
+        # 5. Create final mask isolating reliable areas (!= 0)
         mask = np.bool_(mask_xr.connectedComponents.data != 0)
         mask_xr["connectedComponents"].values = mask
         mask_xr = mask_xr.rename_vars({"connectedComponents": "mask"})
+        
         # Interpolate to iono grid
         mask_xr = mask_xr.interp_like(iono_xr)
 
@@ -214,21 +209,26 @@ def stitch_ionosphere_frames(
     data_list = [d[list(d.data_vars.keys())[0]].data for d in iono_xr_list]
     mask_list = [d.mask.data for d in mask_xr_list]
 
-    combined_iono = ARIAtools.util.stitch.combine_data_to_single(
-        data_list,
-        SNWE.tolist(),
-        LATLON.tolist(),
-        method="mean",
-        latlon_step=LATLON[0, :].tolist(),
-    )
+    if len(data_list) == 1:
+        # Bypass combine_data_to_single for single frames
+        combined_iono = (data_list[0], SNWE[0].tolist(), LATLON[0].tolist())
+        combined_mask = (mask_list[0], SNWE[0].tolist(), LATLON[0].tolist())
+    else:
+        combined_iono = ARIAtools.util.stitch.combine_data_to_single(
+            data_list,
+            SNWE.tolist(),
+            LATLON.tolist(),
+            method="mean",
+            latlon_step=LATLON[0, :].tolist(),
+        )
 
-    combined_mask = ARIAtools.util.stitch.combine_data_to_single(
-        mask_list,
-        SNWE.tolist(),
-        LATLON.tolist(),
-        method="min",
-        latlon_step=LATLON[0, :].tolist(),
-    )
+        combined_mask = ARIAtools.util.stitch.combine_data_to_single(
+            mask_list,
+            SNWE.tolist(),
+            LATLON.tolist(),
+            method="min",
+            latlon_step=LATLON[0, :].tolist(),
+        )
 
     # Step 3: Fit quadratic surface
     # Mask combined_iono before surface fitting
@@ -272,31 +272,27 @@ def export_ionosphere(
     # create temp files
     temp_iono_out = output_iono.parent / ("temp_" + output_iono.name)
 
-    # Create VRT and exit early if only one frame passed,
-    # and therefore no stitching needed
-    if len(input_iono_files) == 1:
-        osgeo.gdal.Translate(
-            str(temp_iono_out), input_iono_files[0], format=output_format
-        )
-        osgeo.gdal.BuildVRT(str(temp_iono_out.with_suffix(".vrt")), str(temp_iono_out))
+    # Process single frames and stitched frames identically
+    # to ensure consistent quadratic surface fitting and masking.
+    (combined_iono, snwe, latlon_spacing) = stitch_ionosphere_frames(
+        input_iono_files,
+        xres=arrres[0],
+        yres=arrres[1],
+        proj=epsg,
+        direction_N_S=True,
+    )
 
-    else:
-        (combined_iono, snwe, latlon_spacing) = stitch_ionosphere_frames(
-            input_iono_files, xres=arrres[0], yres=arrres[1],
-            proj=epsg, direction_N_S=True
-        )
-
-        ARIAtools.util.stitch.write_GUNW_array(
-            temp_iono_out,
-            combined_iono,
-            snwe,
-            format=output_format,
-            epsg=epsg,
-            verbose=verbose,
-            update_mode=overwrite,
-            add_vrt=True,
-            nodata=0.0,
-        )
+    ARIAtools.util.stitch.write_GUNW_array(
+        temp_iono_out,
+        combined_iono,
+        snwe,
+        format=output_format,
+        epsg=epsg,
+        verbose=verbose,
+        update_mode=overwrite,
+        add_vrt=True,
+        nodata=0.0,
+    )
 
     # Crop
     if verbose:

--- a/tools/ARIAtools/util/seq_stitch.py
+++ b/tools/ARIAtools/util/seq_stitch.py
@@ -43,6 +43,7 @@ LOGGER = logging.getLogger(__name__)
 
 def stitch_unwrapped_frames(input_unw_files: List[str],
                             input_conncomp_files: List[str],
+                            is_nisar_file: Optional[bool] = False,
                             proj: Optional[str] = 'EPSG:4326',
                             xres: Optional[float] = None,
                             yres: Optional[float] = None,
@@ -95,13 +96,10 @@ def stitch_unwrapped_frames(input_unw_files: List[str],
                 'PATH'].split('"')[1].split('/')[-1]
             LOGGER.info('Frame-2: ', frame2_prods)
 
-        # determine if NISAR GUNW
-        is_nisar_file = False
+        # apply embedded artifact mask if NISAR GUNW
         frame1_nisar_msk = None
         frame2_nisar_msk = None
-        track_fileext = unw_attr_dicts[ix1]['PATH'].split('"')[1]
-        if track_fileext.endswith('.h5'):
-            is_nisar_file = True
+        if is_nisar_file:
             # Get paths to masks from each respective frame
             # NOTE: Only load Frame 1 mask if it's the very first iteration.
             # In subsequent iterations, Frame 1 is the
@@ -665,6 +663,7 @@ def product_stitch_sequential(input_unw_files: List[str],
                               output_unw: Optional[str] = './unwMerged',
                               output_conn: Optional[str] = './connCompMerged',
                               output_format: Optional[str] = 'ENVI',
+                              is_nisar_file: Optional[bool] = False,
                               bounds: Optional[tuple] = None,
                               clip_json: Optional[str] = None,
                               mask_file: Optional[str] = None,
@@ -700,6 +699,8 @@ def product_stitch_sequential(input_unw_files: List[str],
         Connected Components
     output_format : str
         output format used for gdal writer [e.g., Gtiff ENVI], default is ENVI
+    is_nisar_file : bool
+        is NISAR GUNW or now [True/False], default is False (assumes S1 GUNW)
     bounds : tuple
         (West, South, East, North) bounds obtained in ariaExtract.py
     clip_json : str
@@ -737,12 +738,6 @@ def product_stitch_sequential(input_unw_files: List[str],
     temp_unw_out = output_unw.parent / ('temp_' + output_unw.name)
     temp_conn_out = output_conn.parent / ('temp_' + output_conn.name)
 
-    # determine if NISAR GUNW
-    is_nisar_file = False
-    track_fileext = input_unw_files[0].split('"')[1]
-    if track_fileext.endswith('.h5'):
-        is_nisar_file = True
-
     # Create VRT and exit early if only one frame passed,
     # and therefore no stitching needed
     if len(input_unw_files) == 1:
@@ -770,6 +765,7 @@ def product_stitch_sequential(input_unw_files: List[str],
         (combined_unwrap, combined_conn, combined_snwe) = \
             stitch_unwrapped_frames(
                 input_unw_files, input_conncomp_files,
+                is_nisar_file=is_nisar_file,
                 proj=epsg,
                 xres=arrres[0], yres=arrres[1],
                 correction_method=correction_method,

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -114,6 +114,13 @@ def createParser():
              'bounding box. Default 0.0081 = 0.0081km\u00b2 = area of single '
              'pixel at standard 90m resolution')
     parser.add_argument(
+        '-if', '--iono_filter', action='store_true', dest='iono_filter',
+        help='Enable spatial filtering and quadratic surface approximation '
+             'of the NISAR ionosphere layer. Caution: This may smooth out '
+             'valid short-wavelength signals. (Note: This filter is always '
+             'enforced for S1 GUNWs to mitigate large, unreliable artifacts).'
+    )
+    parser.add_argument(
         '--version', dest='version', default=None,
         help='Specify version as str, e.g. 2_0_4 or all prods; default: all')
     parser.add_argument(
@@ -296,6 +303,7 @@ def main():
         'prods_TOTbbox': prods_TOTbbox,
         'proj': proj,
         'layers': args.layers,
+        'iono_filter':  args.iono_filter,
         'is_nisar_file': is_nisar_file,
         'arrres': arrres,
         'rankedResampling': args.rankedResampling,

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -30,7 +30,7 @@ def createParser():
     Extract specified product layers. The default will export all layers.
     """
     parser = argparse.ArgumentParser(
-        description='Program to extract data and meta-data layers from ARIA '
+        description='Program to extract data and meta-data layers from '
                     'standard GUNW products. Program will handle cropping/'
                     'stitching when needed. By default, the program will crop '
                     'all IFGs to bounds determined by the common intersection '

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -51,7 +51,8 @@ LOGGER = logging.getLogger('ariaTSsetup.py')
 def create_parser():
     """Parser to read command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Prepare ARIA products for time series processing.')
+        description='Prepare standard GUNW products products for '
+                    'time series processing.')
     parser.add_argument(
         '-f', '--file', dest='imgfile', type=str, required=True,
         help='ARIA file')

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -132,6 +132,13 @@ def create_parser():
              'bounding box. Default 0.0081 = 0.0081km\u00b2 = area of single'
              'pixel at standard 90m resolution')
     parser.add_argument(
+        '-if', '--iono_filter', action='store_true', dest='iono_filter',
+        help='Enable spatial filtering and quadratic surface approximation '
+             'of the NISAR ionosphere layer. Caution: This may smooth out '
+             'valid short-wavelength signals. (Note: This filter is always '
+             'enforced for S1 GUNWs to mitigate large, unreliable artifacts).'
+    )
+    parser.add_argument(
         '--version', dest='version', default=None,
         help='Specify version as str, e.g. 2_0_4 or all prods; default: all')
     parser.add_argument(
@@ -582,6 +589,7 @@ def main():
         'prods_TOTbbox': prods_TOTbbox,
         'demfile': demfile,
         'demfile_expanded': demfile_expanded,
+        'iono_filter':  args.iono_filter,
         'is_nisar_file': is_nisar_file,
         'arrres': arrres,
         'lat': lat,


### PR DESCRIPTION
#Summary
This PR fixes a bug in ionosphere.py where S1 GUNW frames would fail to stitch properly when requested in a target projection  or specific resolution.

#Details
Previously, S1 GUNW files were loaded directly as native EPSG:4326 arrays using xr.open_dataset(). This caused a severe spatial misalignment, as the arrays were being mapped to bounding boxes (SNWE) that had already been calculated for the warped target projection.

To fix this, the legacy fallback block in stitch_ionosphere_frames has been updated to use get_GUNW_array(..., as_xarray=True). This ensures that standard ARIA files are dynamically warped and reprojected in memory before stitching, perfectly aligning their behavior with the new NISAR pipeline.

Iono stitching before bug-fix:
<img width="655" height="540" alt="Screenshot 2026-02-26 at 6 24 13 PM" src="https://github.com/user-attachments/assets/f7355cbe-46be-47a5-b322-98636f630637" />

Iono stitching after bug-fix:
<img width="655" height="540" alt="Screenshot 2026-02-26 at 6 23 52 PM" src="https://github.com/user-attachments/assets/1673c83b-9c77-4d7f-a155-f48217272ed4" />
