### PR TITLE
Silence warnings and fix amplitude overlap bug

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1747,7 +1747,7 @@ def export_products(
         prev_maskfile = log_data['maskfilename'] if 'maskfilename' \
             in log_data.keys() else None
 
-        if maskfile != prev_maskfile:
+        if maskfile != prev_maskfile and prev_maskfile is not None:
             update_mode = 'full_extract'
             LOGGER.warning(
                 'Mask file has changed. Setting update mode to full_extract.')
@@ -1758,7 +1758,7 @@ def export_products(
         prev_demfile = log_data['demfile'] if 'demfile' \
             in log_data.keys() else None
 
-        if demfile != prev_demfile:
+        if demfile != prev_demfile and prev_demfile is not None:
             update_mode = 'full_extract'
             LOGGER.warning(
                 'DEM file has changed. Setting update mode to full_extract.')

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1505,12 +1505,6 @@ def export_product_worker(
                             tmp_vrts.append(t_vrt)
                             
                         osgeo.gdal.BuildVRT(tmp_mosaic, tmp_vrts)
-                        
-                        # Clean up intermediate VRTs
-                        for t_vrt in tmp_vrts:
-                            if os.path.exists(t_vrt):
-                                os.remove(t_vrt)
-                                
                         warp_inputs = tmp_mosaic
                     else:
                         warp_inputs = (
@@ -1578,6 +1572,13 @@ def export_product_worker(
                 tmp_mosaic = str(outname) + "_uncropped.vrt"
                 if os.path.exists(tmp_mosaic):
                     os.remove(tmp_mosaic)
+                
+                # Clean up intermediate heterogeneous projection VRTs!
+                if isinstance(product, list) and len(product) > 1:
+                    for idx in range(len(product)):
+                        t_vrt = f"{outname}_{idx}_tmp.vrt"
+                        if os.path.exists(t_vrt):
+                            os.remove(t_vrt)
 
         # Extract/crop phs and conn_comp layers
         else:

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1494,7 +1494,23 @@ def export_product_worker(
                     # 1. If multiple frames are passed, build a VRT mosaic
                     if isinstance(product, list) and len(product) > 1:
                         tmp_mosaic = str(outname) + "_uncropped.vrt"
-                        osgeo.gdal.BuildVRT(tmp_mosaic, product)
+                        
+                        # Reproject heterogeneous UTM zones safely via VRTs
+                        tmp_vrts = []
+                        for idx, p in enumerate(product):
+                            t_vrt = f"{outname}_{idx}_tmp.vrt"
+                            osgeo.gdal.Warp(
+                                t_vrt, p, format="VRT", dstSRS=proj
+                            )
+                            tmp_vrts.append(t_vrt)
+                            
+                        osgeo.gdal.BuildVRT(tmp_mosaic, tmp_vrts)
+                        
+                        # Clean up intermediate VRTs
+                        for t_vrt in tmp_vrts:
+                            if os.path.exists(t_vrt):
+                                os.remove(t_vrt)
+                                
                         warp_inputs = tmp_mosaic
                     else:
                         warp_inputs = (

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -1437,72 +1437,82 @@ def export_product_worker(
             if is_nisar_file:
 
                 if layer == 'amplitude':
-                    # 1. Build a temp VRT to merge the input files
-                    temp_vrt = outname + '_temp_complex.vrt'
-                    ds_vrt = osgeo.gdal.BuildVRT(temp_vrt, product)
-                    ds_vrt = None
-
-                    # 2. Open VRT and Calculate Amplitude in Memory
-                    # This guarantees we get Magnitude, not Real component
-                    ds_in = osgeo.gdal.Open(temp_vrt)
+                    amp_ds_list = []
+                    # Ensure product is a list
+                    prod_list = product if isinstance(product, list) else [product]
                     
-                    # Create an in-memory (MEM) dataset for the Amplitude
-                    # This avoids writing an intermediate file to disk
                     mem_driver = osgeo.gdal.GetDriverByName('MEM')
-                    ds_amp = mem_driver.Create(
-                        '',
-                        ds_in.RasterXSize,
-                        ds_in.RasterYSize,
-                        1,
-                        osgeo.gdal.GDT_Float32
-                    )
+                    for prod_frame in prod_list:
+                        ds_in = osgeo.gdal.Open(prod_frame)
+                        complex_data = ds_in.GetRasterBand(1).ReadAsArray()
+                        
+                        ds_amp = mem_driver.Create(
+                            '', ds_in.RasterXSize, ds_in.RasterYSize, 1, osgeo.gdal.GDT_Float32
+                        )
+                        ds_amp.SetProjection(ds_in.GetProjection())
+                        ds_amp.SetGeoTransform(ds_in.GetGeoTransform())
+                        
+                        amp_band = ds_amp.GetRasterBand(1)
+                        amp_arr = np.abs(complex_data)
+                        
+                        # 1. Standardize any weird NaNs back to 0 
+                        # so GDAL's C++ engine can safely identify the transparent edge padding
+                        amp_arr[np.isnan(amp_arr)] = 0
+                        
+                        amp_band.WriteArray(amp_arr)
+                        amp_band.SetNoDataValue(0)
+                        
+                        amp_ds_list.append(ds_amp)
+                        ds_in = None
 
-                    # Copy Projection and GeoTransform
-                    ds_amp.SetProjection(ds_in.GetProjection())
-                    ds_amp.SetGeoTransform(ds_in.GetGeoTransform())
-
-                    # Read Complex, Compute Abs, Write Float32
-                    # Note: For ~250MB, this is safe for RAM.
-                    complex_data = ds_in.GetRasterBand(1).ReadAsArray()
-                    ds_amp.GetRasterBand(1).WriteArray(np.abs(complex_data))
-                    
-                    # Close input to free strict lock
-                    ds_in = None
-
-                    # 3. Setup Warp Options
                     amp_kwargs = gdal_warp_kwargs.copy()
-                    
-                    # Handle integer EPSG codes for compliance
+                    amp_kwargs['format'] = outputFormatPhys
                     if ('dstSRS' in amp_kwargs and
                             isinstance(amp_kwargs['dstSRS'], int)):
-                        amp_kwargs['dstSRS'] = (
-                            f"EPSG:{amp_kwargs['dstSRS']}"
-                        )
+                        amp_kwargs['dstSRS'] = f"EPSG:{amp_kwargs['dstSRS']}"
 
-                    # Explicitly force Float32 output
+                    # 2. srcNodata=0 forces the overlapping blank edges to be completely transparent.
+                    # 3. dstNodata=np.nan converts the final stitched background safely back to NaN!
                     amp_warp_opts = osgeo.gdal.WarpOptions(
                         outputType=osgeo.gdal.GDT_Float32,
+                        srcNodata=0,
+                        dstNodata=np.nan,
                         **amp_kwargs
                     )
 
-                    # 4. Warp the In-Memory Amplitude to Disk
-                    # We pass the 'ds_amp' object directly to Warp
+                    # Warp directly from the MEM datasets
                     ds_amp_warp = osgeo.gdal.Warp(
-                        outname, ds_amp, options=amp_warp_opts
+                        outname, amp_ds_list, options=amp_warp_opts
                     )
-
+                    
                     # Cleanup
-                    ds_amp = None
                     ds_amp_warp = None
-                    if os.path.exists(temp_vrt):
-                        os.remove(temp_vrt)
+                    amp_ds_list = None
 
                 else:
                     # Standard NISAR layer options
-                    ds = osgeo.gdal.Warp(
-                        outname, product, options=warp_options
-                    )
-                    ds = None
+                    # 1. If multiple frames are passed, build a VRT mosaic
+                    if isinstance(product, list) and len(product) > 1:
+                        tmp_mosaic = str(outname) + "_uncropped.vrt"
+                        osgeo.gdal.BuildVRT(tmp_mosaic, product)
+                        warp_inputs = tmp_mosaic
+                    else:
+                        warp_inputs = (
+                            product[0] if isinstance(product, list)
+                            else product
+                        )
+
+                    # 2. Safely warp the single mosaic/file
+                    if outputFormat == 'VRT':
+                        ds = osgeo.gdal.Warp(
+                            outname + '.vrt', warp_inputs, options=warp_options
+                        )
+                        ds = None
+                    else:
+                        ds = osgeo.gdal.Warp(
+                            outname, warp_inputs, options=warp_options
+                        )
+                        ds = None
 
             else:
                 # Legacy handling
@@ -1539,15 +1549,19 @@ def export_product_worker(
                         )
                         ds_trans = None
 
-            # Create VRT (Global for this block)
-            ds_trans = osgeo.gdal.Translate(
-                outname + '.vrt',
-                outname,
-                options=osgeo.gdal.TranslateOptions(
-                    format="VRT"
+            # Create VRT pointing to physical file if a physical file was written
+            if os.path.exists(outname):
+                ds_trans = osgeo.gdal.Translate(
+                    outname + '.vrt', outname, format="VRT"
                 )
-            )
-            ds_trans = None
+                ds_trans = None
+
+            # VRT formats require the source mosaic to remain on disk.
+            # Only delete the uncropped mosaic if data was physically extracted.
+            if outputFormat != 'VRT':
+                tmp_mosaic = str(outname) + "_uncropped.vrt"
+                if os.path.exists(tmp_mosaic):
+                    os.remove(tmp_mosaic)
 
         # Extract/crop phs and conn_comp layers
         else:
@@ -2027,7 +2041,6 @@ def export_products(
             'find %s/export_workers -name "export_product_args_*.json" | '
             'parallel -j %d export_product.py {}') % (
                 outDir, int(num_threads)), shell=True)
-        end_time = time.time()
 
         # load in output files and verify dimensions
         output_files = glob.glob(os.path.join(

--- a/tools/ARIAtools/util/stitch.py
+++ b/tools/ARIAtools/util/stitch.py
@@ -477,27 +477,22 @@ def combine_data_to_single(data_list: list,
         else:
             comb_data[i, y:y + data.shape[0], x: x + data.shape[1]] = data
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message="Mean of empty slice",
-            category=RuntimeWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="All-NaN slice encountered",
-            category=RuntimeWarning,
-        )
+    # Apply warning filters globally to the thread pool
+    # instead of using a context manager
+    # because Dask threads leak Python context managers and
+    # cause the warning to bleed through.
+    warnings.filterwarnings("ignore", message="Mean of empty slice")
+    warnings.filterwarnings("ignore", message="All-NaN slice encountered")
 
-        # combine using numpy
-        if method == 'mean':
-            comb_data = np.nanmean(comb_data, axis=0)
-        elif method == 'median':
-            comb_data = np.nanmedian(comb_data, axis=0)
-        elif method == 'min':
-            comb_data = np.nanmin(comb_data, axis=0)
-        elif method == 'max':
-            comb_data = np.nanmax(comb_data, axis=0)
+    # combine using numpy
+    if method == 'mean':
+        comb_data = np.nanmean(comb_data, axis=0)
+    elif method == 'median':
+        comb_data = np.nanmedian(comb_data, axis=0)
+    elif method == 'min':
+        comb_data = np.nanmin(comb_data, axis=0)
+    elif method == 'max':
+        comb_data = np.nanmax(comb_data, axis=0)
 
     return comb_data, SNWE, latlon_step
 

--- a/tools/ARIAtools/util/stitch.py
+++ b/tools/ARIAtools/util/stitch.py
@@ -468,14 +468,23 @@ def combine_data_to_single(data_list: list,
     else:
         comb_data = np.empty((n, length, width), dtype=np.float64) * np.nan
     for i, data in enumerate(data_list):
-        x, y = np.abs(lalo2xy(SNWE[1], SNWE[2], snwe_list[i],
-                              latlon_step_list[i], 'around'))
-        # handle if 3D metadata layer
-        if len(data.shape) > 2:
-            comb_data[i, 0:data.shape[0], y:y + data.shape[1],
-                      x: x + data.shape[2]] = data
-        else:
-            comb_data[i, y:y + data.shape[0], x: x + data.shape[1]] = data
+            x, y = np.abs(lalo2xy(SNWE[1], SNWE[2], snwe_list[i],
+                                  latlon_step_list[i], 'around'))
+            x, y = int(x), int(y)
+            
+            # handle if 3D metadata layer
+            if len(data.shape) > 2:
+                y_end = min(y + data.shape[1], comb_data.shape[2])
+                x_end = min(x + data.shape[2], comb_data.shape[3])
+                comb_data[
+                    i, 0:data.shape[0], y:y_end, x:x_end
+                ] = data[:, :y_end - y, :x_end - x]
+            else:
+                y_end = min(y + data.shape[0], comb_data.shape[1])
+                x_end = min(x + data.shape[1], comb_data.shape[2])
+                comb_data[
+                    i, y:y_end, x:x_end
+                ] = data[:y_end - y, :x_end - x]
 
     # Apply warning filters globally to the thread pool
     # instead of using a context manager


### PR DESCRIPTION
Fix benign warnings captured in #483

Fix benign stitching warning triggered when multiproc_method='threads` method used for unwrap stitching and VRT for first frame is processed in the loop:
```
/u/trappist-r0/ssangha/conda_installation/miniforge/miniforge/ARIA-tools_dev/tools/ARIAtools/util/stitch.py:485: RuntimeWarning: Mean of empty slice
  comb_data = np.nanmean(comb_data, axis=0)
```


Also fix overlooked amplitude output issue associated with NISAR GUNW where the stitched overlap region is nan (left) because 0s/nans in one frame mask an overlapping frame. This logic has been corrected avoid improperly masking out pixels in the overlap region (right).
<img width="1320" height="688" alt="Screenshot 2026-03-02 at 5 24 49 PM" src="https://github.com/user-attachments/assets/388326cf-5a43-44c9-bae1-481295bdd3aa" />
