### PR TITLE
Fix NISAR extraction: VRT race conditions, cross-UTM stitching, and edge mask tapers

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -20,7 +20,7 @@ import logging
 import datetime
 import tarfile
 import subprocess
-import tqdm
+import threading
 
 import dask
 import rioxarray
@@ -1153,6 +1153,9 @@ def handle_epoch_layers(
 
     # Iterate through all IFGs
     all_outputs = []
+    prog_bar = ARIAtools.util.misc.ProgressBar(
+        maxValue=len(product_dict[0]), prefix=f'Exporting {key}: '
+    )
     for i in enumerate(product_dict[0]):
         ifg = product_dict[1][i[0]][0]
         outname = os.path.abspath(os.path.join(workdir, ifg))
@@ -1255,6 +1258,9 @@ def handle_epoch_layers(
             sec_outname = os.path.dirname(ref_outname)
             sec_outname = os.path.abspath(
                 os.path.join(sec_outname, ifg.split('_')[0]))
+
+        prog_bar.update(i[0] + 1)
+    prog_bar.close()
 
     # delete temporary files if layers not requested
     prod_ver_list = i[1]
@@ -1688,6 +1694,8 @@ def export_products(
     and clipped to the track extent denoted by the input prods_TOTbbox.
     Optionally, a user may pass a mask-file.
     """
+
+    start_time = time.time()
     LOGGER.debug('export_products, layers: {}'.format(layers))
 
     if not layers and not tropo_total:
@@ -1697,6 +1705,7 @@ def export_products(
     ref_wid = None
     ref_hgt = None
     ref_geotrans = None
+    ref_arr = None
 
     mask = None if maskfile is None else osgeo.gdal.Open(maskfile)
     dem = None if demfile is None else osgeo.gdal.Open(demfile)
@@ -1935,6 +1944,9 @@ def export_products(
                               verbose=verbose,
                               overwrite=True)
 
+        prog_bar = ARIAtools.util.misc.ProgressBar(
+            maxValue=len(product_dict[0]), prefix='Exporting ionosphere: '
+        )
         for i, layer in enumerate(product_dict[0]):
             outname = os.path.abspath(
                 os.path.join(
@@ -1958,6 +1970,9 @@ def export_products(
             # track valid files
             if os.path.exists(outname + '.vrt'):
                 prev_outname_check = copy.deepcopy(outname)
+                
+            prog_bar.update(i + 1)
+        prog_bar.close()
 
         # track consistency of dimensions
         if 'prev_outname_check' in locals():
@@ -1976,8 +1991,6 @@ def export_products(
     with open(full_product_dict_file, 'w') as ofp:
         json.dump(full_product_dict, ofp)
 
-    mp_args = []
-    extracted_files = []
     for ilayer, layer in enumerate(layers):
 
         product_dict = [[j[layer] for j in full_product_dict],
@@ -1988,9 +2001,8 @@ def export_products(
         if not os.path.exists(workdir):
             os.mkdir(workdir)
 
+        mp_args = []
         # Iterate through all IFGs
-        # TODO can we wrap this into funtion and run it
-        # with multiprocessing, to gain speed up
         for ii, product in enumerate(product_dict[0]):
             ifg_tag = product_dict[1][ii][0]
             outname = os.path.abspath(os.path.join(workdir, ifg_tag))
@@ -2007,73 +2019,112 @@ def export_products(
                 multilooking, verbose, is_nisar_file, range_correction,
                 rankedResampling, update_mode))
 
-    start_time = time.time()
-    if int(num_threads) == 1 or multiproc_method in ['single', 'threads']:
-        if multiproc_method == 'single':
-            outputs = []
-            for arg in tqdm.tqdm(mp_args, total=len(mp_args),
-                                 desc='Exporting'):
-                outputs.append(export_product_worker_helper(arg))
-                sys.stdout.flush()
-        else:
-            LOGGER.debug('Running %d total jobs with threads', len(mp_args))
+        if int(num_threads) == 1 or multiproc_method in ['single', 'threads']:
+            
+            # Initialize the custom ARIA progress bar
+            prog_bar = ARIAtools.util.misc.ProgressBar(
+                maxValue=len(mp_args), prefix=f'Exporting {layer}: '
+            )
 
-            # Create a progress bar
-            with tqdm.tqdm(total=len(mp_args), desc='Exporting') as pbar:
-                # Create jobs with a wrapper that includes progress update
+            if multiproc_method == 'single':
+                outputs = []
+                for i, arg in enumerate(mp_args):
+                    outputs.append(export_product_worker_helper(arg))
+                    prog_bar.update(i + 1)
+                    sys.stdout.flush()
+                prog_bar.close()
+                
+            else:
+                LOGGER.debug('Running %d total jobs with threads', len(mp_args))
+
+                # Set up a thread-safe counter for Dask
+                lock = threading.Lock()
+                completed = 0
+
+                def update_progress(result):
+                    nonlocal completed
+                    with lock:
+                        completed += 1
+                        prog_bar.update(completed)
+                    return result
+
+                # Create jobs wrapped with our thread-safe progress updater
                 jobs = []
                 for arg in mp_args:
-                    # Create a delayed job including work and progress update
-                    job = dask.delayed(lambda x: (export_product_worker(*x),
-                                                  pbar.update(1))[0])(arg)
+                    job = dask.delayed(
+                        lambda x: update_progress(export_product_worker(*x))
+                    )(arg)
                     jobs.append(job)
 
                 # Compute all jobs
-                outputs = dask.compute(jobs, num_workers=int(num_threads),
-                                       scheduler='threads')[0]
+                outputs = dask.compute(
+                    jobs, num_workers=int(num_threads), scheduler='threads'
+                )[0]
+                prog_bar.close()
 
-        for ii, ilayer, outname, prod_arr in outputs:
-            if ii == 0 and ilayer == 0:
-                ref_arr = copy.deepcopy(prod_arr)
-            else:
-                ARIAtools.util.vrt.dim_check(ref_arr, prod_arr)
-            prev_outname = outname
+            for ii_out, ilayer_out, outname, prod_arr in outputs:
+                if ref_arr is None:
+                    ref_arr = copy.deepcopy(prod_arr)
+                else:
+                    ARIAtools.util.vrt.dim_check(ref_arr, prod_arr)
+                prev_outname = outname
 
-    elif multiproc_method == 'gnu_parallel':
-        export_workers_temp_dir = os.path.join(outDir, 'export_workers')
-        if os.path.isdir(export_workers_temp_dir):
-            shutil.rmtree(export_workers_temp_dir)
-        os.mkdir(export_workers_temp_dir)
+        elif multiproc_method == 'gnu_parallel':
+            export_workers_temp_dir = os.path.join(outDir, 'export_workers')
+            if os.path.isdir(export_workers_temp_dir):
+                shutil.rmtree(export_workers_temp_dir)
+            os.mkdir(export_workers_temp_dir)
 
-        for ii, args in enumerate(mp_args):
-            this_json_file = os.path.join(
-                outDir, 'export_workers',
-                'export_product_args_%2.2d.json' % ii)
-            with open(this_json_file, 'w') as ofp:
-                json.dump(args, ofp)
+            for ii_arg, args in enumerate(mp_args):
+                this_json_file = os.path.join(
+                    outDir, 'export_workers',
+                    'export_product_args_%2.2d.json' % ii_arg)
+                with open(this_json_file, 'w') as ofp:
+                    json.dump(args, ofp)
 
-        LOGGER.debug('Running %d total jobs in parallel' % len(mp_args))
-        # Run the export worker jobs with GNU parallel
-        subprocess.call((
-            'find %s/export_workers -name "export_product_args_*.json" | '
-            'parallel -j %d export_product.py {}') % (
-                outDir, int(num_threads)), shell=True)
+            LOGGER.debug('Running %d total jobs in parallel' % len(mp_args))
+            
+            prog_bar = ARIAtools.util.misc.ProgressBar(
+                maxValue=len(mp_args), prefix=f'Exporting {layer}: '
+            )
 
-        # load in output files and verify dimensions
-        output_files = glob.glob(os.path.join(
-            export_workers_temp_dir, 'outputs_*.json'))
+            # Run the export worker jobs with GNU parallel in the background
+            proc = subprocess.Popen((
+                'find %s/export_workers -name "export_product_args_*.json" | '
+                'parallel -j %d export_product.py {}') % (
+                    outDir, int(num_threads)), shell=True)
 
-        if len(output_files) > 0:
-            with open(os.path.join(
-                    export_workers_temp_dir, 'outputs_0_0.json')) as ifp:
-                output_dict = json.load(ifp)
-                ref_arr = copy.deepcopy(output_dict['prod_arr'])
+            # Poll the directory for completed JSON files to update progress
+            while proc.poll() is None:
+                num_done = len(glob.glob(
+                    os.path.join(export_workers_temp_dir, 'outputs_*.json')
+                ))
+                prog_bar.update(num_done)
+                time.sleep(1.0)
 
-            for output_file in output_files:
-                with open(output_file) as ifp:
-                    output_dict = json.load(ifp)
-                ARIAtools.util.vrt.dim_check(ref_arr, output_dict['prod_arr'])
-                prev_outname = output_dict['outname']
+            # Catch the final update immediately after the process finishes
+            num_done = len(glob.glob(
+                os.path.join(export_workers_temp_dir, 'outputs_*.json')
+            ))
+            prog_bar.update(num_done)
+            prog_bar.close()
+
+            # load in output files and verify dimensions
+            output_files = glob.glob(os.path.join(
+                export_workers_temp_dir, 'outputs_*.json'))
+
+            if len(output_files) > 0:
+                # Remove hardcoded 0_0 so it grabs the correct layer file
+                if ref_arr is None:
+                    with open(output_files[0]) as ifp:
+                        output_dict = json.load(ifp)
+                        ref_arr = copy.deepcopy(output_dict['prod_arr'])
+
+                for output_file in output_files:
+                    with open(output_file) as ifp:
+                        output_dict = json.load(ifp)
+                    ARIAtools.util.vrt.dim_check(ref_arr, output_dict['prod_arr'])
+                    prev_outname = output_dict['outname']
 
     end_time = time.time()
     LOGGER.debug(
@@ -2089,10 +2140,8 @@ def export_products(
     if os.path.exists(plots_subdir) and len(os.listdir(plots_subdir)) == 0:
         shutil.rmtree(plots_subdir)
 
-    try:
-        retval = ref_arr
-    except UnboundLocalError:
-        retval = [None, None, None, None]
+    retval = [None]*4 if ref_arr is None else ref_arr
+
     return retval
 
 

--- a/tools/ARIAtools/util/stitch.py
+++ b/tools/ARIAtools/util/stitch.py
@@ -1,12 +1,14 @@
-import numpy as np
+# 1. Standard library imports
 import warnings
-from numpy.typing import NDArray
-
-import rioxarray
-
-from typing import Optional, Tuple, Union
-from osgeo import gdal, osr, gdal_array
 from pathlib import Path
+from typing import Optional, Tuple, Union
+
+# 2. Third-party imports
+import numpy as np
+import rioxarray
+import scipy.ndimage
+from numpy.typing import NDArray
+from osgeo import gdal, osr, gdal_array
 
 #  READ/WRITE GDAL UTILITIES
 
@@ -508,19 +510,44 @@ def combine_data_to_single(data_list: list,
 
 def get_binary_nisar_mask_from_path(gdal_path):
     """
-    Given a GDAL-style path to an unwrapped phase layer, 
-    reconstructs the path to the internal mask and generates a binary mask.
+    Given a GDAL-style path, reconstructs the internal mask path.
+    Uses spatial morphology to screen wide edge artifacts.
     """
-    # Isolate the file path from the internal HDF5 subpath
-    # This splits at the boundary of the filename and the internal layers
     prefix, subpath = gdal_path.split('":')
-    
-    # Inherit the parent tree (e.g., frequencyA/) and swap the leaf to /mask
-    base, sep, _ = subpath.partition("unwrappedInterferogram")
+    base, sep, rest = subpath.partition("unwrappedInterferogram")
     nisar_mask_path = f'{prefix}":{base}{sep}/mask'
-    
-    # Generate and return the binary mask using ARIAtools
-    return create_binary_nisar_mask(nisar_mask_path)
+
+    binary_mask = create_binary_nisar_mask(nisar_mask_path)
+
+    pol = rest.strip("/").split("/")[0] if rest else "HH"
+    unw_path = f'{prefix}":{base}{sep}/{pol}/unwrappedPhase'
+
+    ds_unw = gdal.Open(unw_path, gdal.GA_ReadOnly)
+    if ds_unw is not None:
+        unw_arr = ds_unw.ReadAsArray()
+        ds_unw = None
+
+        # 1. Find the "core" of the artifact taper
+        near_zeros = (np.abs(unw_arr) < 5e-5) & (unw_arr != 0)
+
+        if np.any(near_zeros):
+            # 2. Define a safe boundary containment zone (~75px)
+            edge_zone = scipy.ndimage.binary_dilation(
+                binary_mask == 0, iterations=75
+            )
+            core_artifacts = near_zeros & edge_zone
+
+            # 3. Dilate the core to swallow the fading rest of the taper
+            # which naturally exceeds the 5e-5 threshold
+            full_artifacts = scipy.ndimage.binary_dilation(
+                core_artifacts, iterations=40
+            )
+
+            # 4. Contain it within the edge zone and mask it
+            full_artifacts = full_artifacts & edge_zone
+            binary_mask = np.where(full_artifacts, 0, binary_mask)
+
+    return binary_mask
 
 
 def create_binary_nisar_mask(mask_path: str) -> np.ndarray:

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -309,7 +309,7 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
 
     # Progress bar
     prog_bar = ARIAtools.util.misc.ProgressBar(
-        maxValue=len(int_list), print_msg='Creating stack: ')
+        maxValue=len(int_list), prefix=f'Exporting {output_file_name}: ')
 
     # only perform following checks if a differential layer
     # all NISAR layers are differential


### PR DESCRIPTION
This PR addresses several critical edge cases in the NISAR GUNW extraction and stitching pipeline to ensure robust multi-frame processing:
- Concurrency & VRT Management: Resolves silent data loss and Dask threading race conditions by enforcing unique temporary filenames and delaying VRT cleanup until physical files are safely written.
- Cross-UTM Stitching: Handles heterogeneous UTM projections during mosaicking by dynamically reprojecting inputs via VRTs and utilizing safe NumPy slicing to prevent array broadcasting crashes.
- Artifact Masking: Implements a robust morphological mask using `scipy.ndimage` to identify and strip wide, near-zero filter tapers from the edges of the `unwrappedPhase` and `ionosphere`layers. These artifacts weren't captured by the embedded mask.

Regarding the artifact masking, I first observed this with what appears to be a partial frame (at the northern tip of the track I documented in #488 ).

Again, this artifact isn't captured after applying the embedded mask (left is the embedded mask, right is the original unw phase field, both directly extracted from the product with no manipulation):
<img width="2166" height="451" alt="Screenshot 2026-03-03 at 1 56 07 PM" src="https://github.com/user-attachments/assets/946ee374-e6ae-4b03-96a6-f17e710bab3e" />

Applying the mask directly leaves some of these very close to 0 (~1e-6 level) artifacts that are ~50 pixels in width:
<img width="1082" height="451" alt="Screenshot 2026-03-03 at 1 56 15 PM" src="https://github.com/user-attachments/assets/e68c4864-8a17-4066-b80f-e232156f6dbc" />

These artifacts also persist in the `ionosphere` layer.


After implementing my approach, I capture these edge effects nicely (see before vs after for unw and iono fields):

<img width="2174" height="327" alt="Screenshot 2026-03-03 at 4 42 43 PM" src="https://github.com/user-attachments/assets/ac34c99d-e6ab-4a3d-93bb-166ce76f2d46" />
<img width="2175" height="325" alt="Screenshot 2026-03-03 at 4 59 56 PM" src="https://github.com/user-attachments/assets/bb114c37-1b5f-4844-9d47-82e9e4473586" />


For reference also, here is the connected component field before and after implementing this patch just to confirm that the area of valid pixels has a relatively small footprint:
<img width="1951" height="328" alt="Screenshot 2026-03-04 at 10 11 38 AM" src="https://github.com/user-attachments/assets/6a4fa40b-edb5-430f-a453-c8fe07db8e77" />
