### PR TITLE
Standardize NISAR GUNW date order and phase sign to `date2_date1` convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ ARIA-tools is an open-source package in Python which contains tools to manipulat
 > [!IMPORTANT]
 > ARIA-tools now supports **NISAR GUNW** products created routinely by the NASA-ISRO SAR mission. We welcome the community for reporting bugs using the issue ticket functionality
 
+> [!NOTE]
+> **Standardized Date and Phase Convention**
+> To prevent confusion during time-series analysis, **all** ARIA-tools outputs enforce a consistent date and phase convention, regardless of the native format of the input product:
+> * **Date Order:** ARIA-tools strictly uses a `ReferenceDate_SecondaryDate` naming convention, where the reference scene is the more recent pass and the secondary scene is the earlier pass. 
+> * **Phase Sign:** Because the more recent acquisition is used as the reference, the unwrapped phase convention is standardized across all outputs. Negative phase differences indicate movement away from the sensor, and positive phase differences indicate movement towards the sensor.
+> * **NISAR vs. S1:** While ARIA-S1-GUNW products natively follow this convention out of the box, NISAR GUNW products natively use the opposite date order. ARIA-tools automatically flips the dates and mathematical signs for NISAR inputs during extraction to ensure all your downstream time-series outputs are 100% consistent!
 
 ------
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ ARIA-tools is an open-source package in Python which contains tools to manipulat
 
 > [!NOTE]
 > **Standardized Date and Phase Convention**
+>
 > To prevent confusion during time-series analysis, **all** ARIA-tools outputs enforce a consistent date and phase convention, regardless of the native format of the input product:
 > * **Date Order:** ARIA-tools strictly uses a `ReferenceDate_SecondaryDate` naming convention, where the reference scene is the more recent pass and the secondary scene is the earlier pass. 
 > * **Phase Sign:** Because the more recent acquisition is used as the reference, the unwrapped phase convention is standardized across all outputs. Negative phase differences indicate movement away from the sensor, and positive phase differences indicate movement towards the sensor.

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -675,7 +675,8 @@ def merged_productbbox(
             is_nisar_file)
 
 
-def create_raster_from_gunw(fname, data_lis, proj, driver, hgt_field=None):
+def create_raster_from_gunw(fname, data_lis, proj, driver, hgt_field=None,
+    sign_multiplier=1):
     """Wrapper to create raster and apply projection using Rioxarray (Safe)"""
 
     # 1) Build a lightweight reference warp (VRT)
@@ -719,6 +720,10 @@ def create_raster_from_gunw(fname, data_lis, proj, driver, hgt_field=None):
             del da.attrs["_FillValue"]
         # -----------------------------------------
         
+        # Flip the sign for NISAR convention
+        if sign_multiplier == -1:
+            da = da * -1
+            
         # Enforce threading during the write
         with rasterio.Env(GDAL_NUM_THREADS='ALL_CPUS'): 
             da.rio.to_raster(fname, driver=driver, crs=proj)
@@ -751,7 +756,7 @@ def create_raster_from_gunw(fname, data_lis, proj, driver, hgt_field=None):
 
 def prep_metadatalayers(
         outname, metadata_arr, dem, layer, layers, is_nisar_file=False,
-        proj='4326', driver='ENVI', model_name=None):
+        proj='4326', driver='ENVI', model_name=None, sign_multiplier=1):
     """Wrapper to prep metadata layer for extraction"""
     if dem is None:
         raise Exception('No DEM input specified. '
@@ -831,7 +836,8 @@ def prep_metadatalayers(
             for j in glob.glob(i[0] + '*'):
                 if os.path.isfile(j):
                     os.remove(j)
-            create_raster_from_gunw(i[0], i[1], proj, driver, hgt_field)
+            create_raster_from_gunw(i[0], i[1], proj, driver, hgt_field,
+                sign_multiplier)
 
         if not is_nisar_file:
             # compute differential
@@ -942,7 +948,7 @@ def prep_metadatalayers(
                                 pass
                 else:
                     create_raster_from_gunw(outname, metadata_arr,
-                        proj, driver, hgt_field)
+                        proj, driver, hgt_field, sign_multiplier)
             else:
                 ds_vrt = osgeo.gdal.BuildVRT(outname + '.vrt', metadata_arr)
                 
@@ -959,7 +965,7 @@ def prep_metadatalayers(
 
 
 def generate_diff(ref_outname, sec_outname, outname, key, OG_key, tropo_total,
-                  hgt_field, proj, driver):
+                  hgt_field, proj, driver, sign_multiplier=1):
     """ Compute differential from reference and secondary scenes (Multi-dim safe) """
 
     # if specified workdir doesn't exist, create it
@@ -984,6 +990,9 @@ def generate_diff(ref_outname, sec_outname, outname, key, OG_key, tropo_total,
                 arr_total = arr_sec + arr_ref
             else:
                 arr_total = arr_sec - arr_ref
+
+            if sign_multiplier == -1:
+                arr_total = arr_total * -1
 
             # 3. Create Output DataArray
             # We copy da_sec to preserve coordinates/dims/attrs
@@ -1150,6 +1159,11 @@ def handle_epoch_layers(
     for i in all_workdirs:
         if not os.path.exists(i):
             os.mkdir(i)
+
+    # Flip sign for external corrections if NISAR
+    sign_multiplier = -1 if (is_nisar_file and key in [
+        'solidEarthTide', 'troposphereWet', 
+        'troposphereHydrostatic', 'troposphereTotal']) else 1
 
     # Iterate through all IFGs
     all_outputs = []
@@ -1363,6 +1377,10 @@ def export_product_worker(
         **gdal_warp_kwargs
     )
 
+    # Flip sign for baselines if NISAR
+    sign_multiplier = -1 if (is_nisar_file and layer in [
+        'bPerpendicular', 'bParallel']) else 1
+
     mask = None if maskfile is None else osgeo.gdal.Open(maskfile)
     dem = None if demfile is None else osgeo.gdal.Open(demfile)
     dem_expanded = (
@@ -1428,7 +1446,7 @@ def export_product_worker(
             # make VRT pointing to metadata layers in standard product
             hgt_field, outname = prep_metadatalayers(
                 outname, product, dem_expanded, layer, layers,
-                is_nisar_file, proj)
+                is_nisar_file, proj, sign_multiplier=sign_multiplier)
 
             # Interpolate/intersect with DEM before cropping
             finalize_metadata(

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -884,10 +884,10 @@ class Product:
         # initiate variables
         rdrmetadata_dict = {}
         sdskeys = ['/science/LSAR/identification/boundingPolygon']
-        # Pass pair name
+        # Pass pair name (Forced to date2_date1 convention)
         basename = os.path.basename(fname)
-        self.pairname = basename.split('_')[11][:8] + '_'
-        self.pairname += basename.split('_')[13][:8]
+        self.pairname = basename.split('_')[13][:8] + '_'
+        self.pairname += basename.split('_')[11][:8]
 
         # Get polarization
         pol_dict = {}

--- a/tools/ARIAtools/util/ionosphere.py
+++ b/tools/ARIAtools/util/ionosphere.py
@@ -291,6 +291,10 @@ def export_ionosphere(
         is_nisar_file=is_nisar_file,
     )
 
+    # Invert phase to match date2_date1 convention
+    if is_nisar_file:
+        combined_iono = combined_iono * -1
+
     ARIAtools.util.stitch.write_GUNW_array(
         temp_iono_out,
         combined_iono,

--- a/tools/ARIAtools/util/seq_stitch.py
+++ b/tools/ARIAtools/util/seq_stitch.py
@@ -758,7 +758,8 @@ def product_stitch_sequential(input_unw_files: List[str],
                 vrt_conn_path=str(temp_conn_out.with_suffix('.vrt')),
                 binary_mask=nisar_binary_mask,
                 out_unw_path=temp_unw_out,
-                out_conn_path=temp_conn_out
+                out_conn_path=temp_conn_out,
+                multiply_unw_by=-1
             )
 
     else:
@@ -771,6 +772,10 @@ def product_stitch_sequential(input_unw_files: List[str],
                 correction_method=correction_method,
                 range_correction=range_correction, direction_N_S=True,
                 verbose=verbose)
+
+        # Invert phase to match date2_date1 convention
+        if is_nisar_file:
+            combined_unwrap = combined_unwrap * -1
 
         # Write
         # write stitched unwrappedPhase

--- a/tools/ARIAtools/util/stitch.py
+++ b/tools/ARIAtools/util/stitch.py
@@ -590,7 +590,8 @@ def apply_mask_and_write(
     vrt_conn_path: str,
     binary_mask: np.ndarray,
     out_unw_path: str,
-    out_conn_path: str
+    out_conn_path: str,
+    multiply_unw_by: int = 1
     ) -> Tuple[str, str]:
     """
     Applies a NISAR binary mask to VRT datasets, writes the results to temp
@@ -627,6 +628,8 @@ def apply_mask_and_write(
 
     # Apply the mask directly to the arrays read from the VRTs
     masked_unw = ds_unw.ReadAsArray() * binary_mask
+    if multiply_unw_by == -1:
+        masked_unw = masked_unw * -1
     masked_conn = ds_conn.ReadAsArray() * binary_mask
 
     # Driver for writing standard GeoTIFFs

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -150,7 +150,7 @@ def create_parser():
         '-verbose', '--verbose', action='store_true', dest='verbose',
         help="Toggle verbose mode on.")
     parser.add_argument(
-        '--log-level', default='warning', help='Logger log level')
+        '--log-level', default='info', help='Logger log level')
     return parser
 
 
@@ -375,8 +375,10 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
     range_spacing = aria_prod.products[0][0]['slantRangeSpacing'][0]
     if is_nisar_file:
         orbit_direction = str.split(os.path.basename(aria_prod.files[0]), '_')[6]
+        platform = 'NISAR'
     else:
         orbit_direction = str.split(os.path.basename(aria_prod.files[0]), '-')[2]
+        platform = 'Sen'
 
     with open(os.path.join(stack_dir, output_file_name + '.vrt'), 'w') as fid:
         fid.write('''<VRTDataset rasterXSize="{xsize}" rasterYSize="{ysize}">
@@ -429,7 +431,8 @@ def generate_stack(aria_prod, stack_layer, output_file_name,
             <MDI key="startRange">{start_range}</MDI>
             <MDI key="endRange">{end_range}</MDI>
             <MDI key="slantRangeSpacing">{range_spacing}</MDI>
-            <MDI key="orbitDirection">{orbDir}</MDI>'''
+            <MDI key="orbitDirection">{orbDir}</MDI>
+            <MDI key="PLATFORM">{platform}</MDI>'''
             fid.write(outstr)
             if b_perp != []:
                 bPerp = b_perp[dates]


### PR DESCRIPTION
This PR enforces a universal `date2_date1` (newer_older) naming and phase convention across all ARIA-tools outputs to prevent downstream time-series errors (addressing #487 ):
- **Date Order**: Flips the parsed date order of NISAR GUNW inputs in `product.py` to match the standard S1 convention.
- **Phase Inversion**: Dynamically passes a sign multiplier (-1) through `extractProduct.py`, `seq_stitch.py`, and `ionosphere.py` to invert the mathematical sign of all distance/phase-based layers (`unwrappedPhase`, `bPerpendicular`, `bParallel`, `ionosphere`, `troposphere*`, and `solidEarthTide`) when processing NISAR products.
- **Documentation**: Updates the `README.md` to explicitly define this standardized convention and explain the physical meaning of the phase sign (positive = towards sensor).

Default log for `ariaTSsetup.py` set to `INFO` following #493 

Platform now set/passed for MintPy compatibility, addressing #482 . However in `prep_aria.py` within the MintPy package, the `PLATFORM` variable is [hardcoded to Sentinel](https://github.com/insarlab/MintPy/blob/main/src/mintpy/prep_aria.py#L146). So I'll have to issue a patch upstream in MintPy, but depending on how we implement this, this may break compatibility with older stacks (because the program will attempt to search for a `PLATFORM` variable from the older ARIA-tools outputs that doesn't exist).
