### PR TITLE
Fix TROPO warning message + update logging messages

### DIFF
--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -521,9 +521,9 @@ def merged_productbbox(
 
     # Remove scenes with insufficient overlap w.r.t. bbox
     if rejected_scenes != []:
-        LOGGER.info(("%d out of %d interferograms rejected for not meeting "
-                     "specified spatial thresholds"),
-                    len(rejected_scenes), len(product_dict))
+        LOGGER.warning(("%d out of %d interferograms rejected for not "
+                        "meeting specified spatial thresholds"),
+                        len(rejected_scenes), len(product_dict))
     metadata_dict = [
         i for j, i in enumerate(metadata_dict) if j not in rejected_scenes]
     product_dict = [

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -909,8 +909,9 @@ class Product:
                     addkeys.append(f'{tropo_lyrs[0]}_' + i)
                     addkeys.append(f'{tropo_lyrs[1]}_' + i)
 
-            keys_reject.extend([
-                i for i in tropo_lyrs if i not in ''.join(addkeys)])
+            if self.tropo_extract:
+                keys_reject.extend([
+                    i for i in tropo_lyrs if i not in ''.join(addkeys)])
             for i in keys_reject:
                 LOGGER.warning(
                     'Expected data layer key %s not found in %s' % (i, fname))

--- a/tools/ARIAtools/util/dem.py
+++ b/tools/ARIAtools/util/dem.py
@@ -53,11 +53,13 @@ def prep_dem(demfilename, bbox_file, prods_TOTbbox, prods_TOTbbox_metadatalyr,
                 '%s must be in %s' % (
                     dem_name, ', '.join(dem_stitcher.datasets.DATASETS)))
 
-        LOGGER.info("Downloading DEM...")
+        LOGGER.info('Downloading DEM: %s', dem_name)
         demfilename = download_dem(
             aria_dem, prods_TOTbbox_metadatalyr, num_threads, dem_name, runlog)
 
-    else:  # checks for user specified DEM, ensure it's georeferenced
+    # checks for user specified DEM, ensure it's georeferenced
+    else:
+        LOGGER.info("Using user specified DEM %s" % demfilename)
         demfilename = os.path.abspath(demfilename)
         assert os.path.exists(demfilename), (
             f'Cannot open DEM at: {demfilename}')

--- a/tools/ARIAtools/util/mask.py
+++ b/tools/ARIAtools/util/mask.py
@@ -73,7 +73,7 @@ def prep_mask(
         if maskfilename.lower() == 'download':
             maskfilename = 'esa_world_cover_2021'
         lyr_name = copy.deepcopy(maskfilename)
-        LOGGER.debug('Downloading water mask: %s', lyr_name)
+        LOGGER.info('Downloading water mask: %s', lyr_name)
 
         # set file names
         uncropped_maskfilename = os.path.join(workdir,
@@ -147,7 +147,7 @@ def prep_mask(
 
     # User specified mask
     else:
-        LOGGER.debug("Using user specified mask %s" % maskfilename)
+        LOGGER.info("Using user specified mask %s" % maskfilename)
         # Path to local version of user specified mask
         user_mask = os.path.abspath(maskfilename)  # for clarity
         user_mask_n = os.path.basename(os.path.splitext(user_mask)[0])

--- a/tools/ARIAtools/util/meta_cache.py
+++ b/tools/ARIAtools/util/meta_cache.py
@@ -155,7 +155,7 @@ def get_or_extract(fname, cache_data):
         LOGGER.debug('Cache hit: %s', os.path.basename(key))
         return cache_data[key]
 
-    LOGGER.info('Cache miss – extracting metadata: %s',
+    LOGGER.debug('Cache miss – extracting metadata: %s',
                 os.path.basename(key))
     meta = extract_metadata_gdal(fname)
     if meta is not None:

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -129,7 +129,11 @@ def createParser():
         '-v', '--verbose', action='store_true',
         help='Print products to be downloaded to stdout')
     parser.add_argument(
-        '--log-level', default='info', help='Logger log level')
+        '--log-level', 
+        choices=['debug', 'info', 'warning', 'error'], 
+        default='info', 
+        help='Logger log level. Default: info.'
+    )
     return parser
 
 
@@ -448,6 +452,10 @@ def main():
         'debug': logging.DEBUG, 'info': logging.INFO,
         'warning': logging.WARNING, 'error': logging.ERROR}[args.log_level]
     logging.basicConfig(level=log_level, format=ARIAtools.util.log.FORMAT)
+
+    print('*****************************************************************')
+    LOGGER.info('*** Download Function ***')
+    print('*****************************************************************')
 
     # format dates
     args.start = datetime.datetime.strptime(args.start, '%Y%m%d')

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -137,7 +137,11 @@ def createParser():
         '-verbose', '--verbose', action='store_true', dest='verbose',
         help="Toggle verbose mode on.")
     parser.add_argument(
-        '--log-level', default='info', help='Logger log level')
+        '--log-level', 
+        choices=['debug', 'info', 'warning', 'error'], 
+        default='info', 
+        help='Logger log level. Default: info.'
+    )
     return parser
 
 
@@ -151,7 +155,10 @@ def main():
         'debug': logging.DEBUG, 'info': logging.INFO,
         'warning': logging.WARNING, 'error': logging.ERROR}[args.log_level]
     logging.basicConfig(level=log_level, format=ARIAtools.util.log.FORMAT)
-    LOGGER.info('Extract Product Function')
+    LOGGER.info('ARIAtools version: %s' % ARIAtools.__version__)
+    print('*****************************************************************')
+    LOGGER.info('*** Extract Product Function ***')
+    print('*****************************************************************')
     # Switch tropo models to None if troposphere isn't specified
     if args.layers == None or 'tropo' not in args.layers:
         args.tropo_models = None
@@ -267,7 +274,7 @@ def main():
             'rankedResampling': args.rankedResampling,
             'runlog': runlog
         }
-        LOGGER.info('Download/cropping mask')
+        LOGGER.debug('Download/cropping mask')
         maskfilename = ARIAtools.util.mask.prep_mask(**mask_dict)
     else:
         maskfilename = None
@@ -290,7 +297,7 @@ def main():
             'runlog': runlog
         }
         # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-        LOGGER.info('Download/cropping DEM')
+        LOGGER.debug('Download/cropping DEM')
         demfile, demfile_expanded, lat, lon = \
             ARIAtools.util.dem.prep_dem(**dem_dict)
     else:

--- a/tools/bin/ariaKml2box.py
+++ b/tools/bin/ariaKml2box.py
@@ -37,7 +37,11 @@ def createParser():
         '-o', '--outfile', dest='outFile', type=str, required=True,
         help='Output file name')
     parser.add_argument(
-        '--log-level', default='warning', help='Logger log level')
+        '--log-level', 
+        choices=['debug', 'info', 'warning', 'error'], 
+        default='info', 
+        help='Logger log level. Default: info.'
+    )
     return parser
 
 

--- a/tools/bin/ariaMisclosure.py
+++ b/tools/bin/ariaMisclosure.py
@@ -146,7 +146,11 @@ def create_parser():
         '--plot-time-intervals', dest='plotTimeIntervals', action='store_true',
         help='Plot triplet intervals in misclosure analysis figure.')
     parser.add_argument(
-        '--log-level', default='info', help='Logger log level')
+        '--log-level', 
+        choices=['debug', 'info', 'warning', 'error'], 
+        default='info', 
+        help='Logger log level. Default: info.'
+    )
     return parser
 
 

--- a/tools/bin/ariaPlot.py
+++ b/tools/bin/ariaPlot.py
@@ -131,7 +131,11 @@ def createParser():
         '-v', '--verbose', action='store_true', dest='verbose',
         help="Toggle verbose mode on.")
     parser.add_argument(
-        '--log-level', default='info', help='Logger log level')
+        '--log-level', 
+        choices=['debug', 'info', 'warning', 'error'], 
+        default='info', 
+        help='Logger log level. Default: info.'
+    )
     return parser
 
 
@@ -143,6 +147,7 @@ def main(inps=None):
         'debug': logging.DEBUG, 'info': logging.INFO,
         'warning': logging.WARNING, 'error': logging.ERROR}[args.log_level]
     logging.basicConfig(level=log_level, format=ARIAtools.util.log.FORMAT)
+    LOGGER.info('ARIAtools version: %s' % ARIAtools.__version__)
     print('*****************************************************************')
     print('*** Plotting Function ***')
     print('*****************************************************************')

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -156,7 +156,11 @@ def create_parser():
         '-verbose', '--verbose', action='store_true', dest='verbose',
         help="Toggle verbose mode on.")
     parser.add_argument(
-        '--log-level', default='info', help='Logger log level')
+        '--log-level', 
+        choices=['debug', 'info', 'warning', 'error'], 
+        default='info', 
+        help='Logger log level. Default: info.'
+    )
     return parser
 
 
@@ -473,7 +477,9 @@ def main():
         args.num_threads = 'ALL_CPUS'
 
     LOGGER.info('ARIAtools version: %s' % ARIAtools.__version__)
-    LOGGER.info('Time-series Preparation Function')
+    print('*****************************************************************')
+    LOGGER.info('*** Time-series Preparation Function ***')
+    print('*****************************************************************')
     LOGGER.info(
         'Thread count specified for gdal multiprocessing = %s' % (
             args.num_threads))
@@ -551,7 +557,7 @@ def main():
     }
 
     # Pass DEM-filename, loaded DEM array, and lat/lon arrays
-    LOGGER.info('Download/cropping DEM')
+    LOGGER.debug('Download/cropping DEM')
     demfile, demfile_expanded, lat, lon = \
         ARIAtools.util.dem.prep_dem(**dem_dict)
 
@@ -587,7 +593,7 @@ def main():
             'rankedResampling': args.rankedResampling,
             'runlog': runlog
         }
-        LOGGER.info('Download/cropping mask')
+        LOGGER.debug('Download/cropping mask')
         maskfilename = ARIAtools.util.mask.prep_mask(**mask_dict)
     else:
         maskfilename = None


### PR DESCRIPTION
Following up on conversation on PR #504 , updated TROPO logging check to not inundate print screen with TROPO warnings if the user doesn't even wish to extract TROPO layers.

Overall made some sweeping changes to the LOGGING print screen reporting across multiple scripts to clean up the default print screen further. Removed items like duplicate DEM/mask download notices.

Also updated the parsers for the underlying `bin` scripts to clarify available logging options.