### PR TITLE
add support for virtual nisar GUNW processing using VSI curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Actual time-series processing is not supported in ARIA-tools. However, outputs a
     -   [Installing a stable release from conda](#installing-a-stable-release-from-conda)
     -   [Installing the latest development branch](#installing-the-latest-development-branch)
     -   [Other installation options](#other-installation-options)
-    -   [ARIA-tools with support for S3 virtual data access](#aria-tools-with-support-for-s3-virtual-data-access)
+    -   [ARIA-tools with support for virtual data access](#aria-tools-with-support-for-virtual-data-access)
 3.  [Running ARIA-tools](#running-aria-tools)
     -   [Commandline download of GUNW Products](#commandline-download-of-gunw-products)
     -   [Manipulating GUNW Products](#manipulating-gunw-products)
@@ -174,8 +174,8 @@ The following pages might be of use to those trying to build third party package
 -   [Installing dependencies from source on mac](https://github.com/aria-tools/ARIA-tools/blob/master/MacOSSourceBuild.md)
 
 
-### ARIA-tools with support for S3 virtual data access
-GDAL Virtual File Systems capabilities (vsicurl) can be leveraged in ARIA-tools to avoid downloading Sentinel-1 GUNW products during processing. This is currently only supported for Sentinel-1 GUNW products (not NISAR GUNW).
+### ARIA-tools with support for virtual data access
+GDAL Virtual File Systems capabilities (vsicurl) can be leveraged in ARIA-tools to avoid downloading GUNW products during processing. This is supported for both **Sentinel-1 GUNW** and **NISAR GUNW** products.
 
 To use virtual access, generate a URL list using `ariaDownload.py -o url`, which produces a `.txt` file of product URLs. Pass this `.txt` file directly to `ariaExtract.py`, `ariaTSsetup.py`, or `ariaPlot.py` via the `-f` option — no download step is needed. ARIA-tools will stream data on-the-fly from the ASF archive using GDAL's `/vsicurl/` driver.
 
@@ -209,7 +209,7 @@ The ARIA-tools scripts are highly modulized in Python and therefore allows for b
 
 
 ### Commandline download of GUNW Products
-ARIA GUNW-S1/NISAR_L2_GUNW products can be downloaded through the commandline using the *ariaDownload.py* program, which wraps around the ASF DAAC api. For Sentinel-1 GUNW, there is also the option for virtual data access by using `ariaDownload.py -o url`, which creates a `.txt` file with HTTPS paths to archived products instead of downloading them. This URL file can be passed directly to subsequent programs (*ariaExtract.py*, *ariaTSsetup.py*, *ariaPlot.py*) for streaming access without local downloads (see [ARIA-tools with support for S3 virtual data access](#aria-tools-with-support-for-s3-virtual-data-access)).
+ARIA GUNW-S1/NISAR_L2_GUNW products can be downloaded through the commandline using the *ariaDownload.py* program, which wraps around the ASF DAAC api. There is the option for virtual data access by using `ariaDownload.py -o url`, which creates a `.txt` file with HTTPS paths to archived products instead of downloading them. This URL file can be passed directly to subsequent programs (*ariaExtract.py*, *ariaTSsetup.py*, *ariaPlot.py*) for streaming access without local downloads (see [ARIA-tools with support for virtual data access](#aria-tools-with-support-for-virtual-data-access)).
 
 ### Manipulating GUNW Products
 ARIA GUNW-S1/NISAR_L2_GUNW products can be manipulated (cropped, stitched, extracted) using the *ariaExtract.py* program. 

--- a/README.md
+++ b/README.md
@@ -194,14 +194,6 @@ echo "machine urs.earthdata.nasa.gov login myUsername password myPassword" > ~/.
 chmod 600 ~/.netrc
 ```
 
-In addition, users should set the following environment variables:
-```.bash
-export GDAL_HTTP_COOKIEFILE=/tmp/cookies.txt
-export GDAL_HTTP_COOKIEJAR=/tmp/cookies.txt
-export VSI_CACHE=YES
-```
-If these environment variables are not set, ARIA-tools will configure them automatically and issue a warning.
-
 ------
 ## Running ARIA-tools
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ channels:
 dependencies:
   - affine
   - arm_pyart
+  - boto3               # optional: S3 direct download when running on AWS
   - dask
   - dem_stitcher>=2.5.8
   - gdal>=3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 affine
 arm_pyart
 asf_search[asf-enumeration]>=12.0.3   # ariaOrderASF --getpairs requires the asf-enumeration extra
+boto3               # optional: S3 direct download when running on AWS
 dask
 dem_stitcher>=2.5.8
 gdal>=3.7.0

--- a/tests/benchmark_s3_vs_https.py
+++ b/tests/benchmark_s3_vs_https.py
@@ -1,0 +1,728 @@
+#!/usr/bin/env python3
+"""
+Benchmark: S3 direct access vs HTTPS (vsicurl) virtual processing.
+
+Compares wall-clock times for the key ARIA-tools virtual processing steps
+using ``/vsis3/`` (S3 direct, AWS only) vs ``/vsicurl/`` (HTTPS, anywhere).
+
+Benchmark categories
+--------------------
+1. **GDAL Open**         – open a remote NetCDF/HDF5 with ``gdal.Open()``
+2. **Metadata Extract**  – ``gdal.Info()`` metadata extraction (cache miss)
+3. **Layer Read**        – read a coherence raster subset via GDAL
+4. **Product Init**      – ``Product()`` full initialisation with bbox crop
+5. **h5py Scalar Read**  – read an HDF5 scalar field via HTTP byte-range
+
+Each operation is performed ``--reps`` times (default 3) and the median
+is reported.  On AWS, both S3 and HTTPS paths are tested side-by-side;
+off-AWS only HTTPS is available.
+
+Prerequisites
+-------------
+- NASA Earthdata credentials in ``~/.netrc``
+- ARIA-tools installed (``pip install -e .``)
+- GDAL >= 3.8 with NetCDF support
+- ``asf_search`` for product discovery
+- ``boto3`` (for S3 path, optional)
+
+Usage
+-----
+    # On AWS – full comparison:
+    python tests/benchmark_s3_vs_https.py
+
+    # Off-AWS – HTTPS-only baselines:
+    python tests/benchmark_s3_vs_https.py
+
+    # Quick run (1 rep, 2 products):
+    python tests/benchmark_s3_vs_https.py --reps 1 --max-products 2
+
+    # Specify products / custom dataset:
+    python tests/benchmark_s3_vs_https.py --track 64 \\
+        --start 20260101 --end 20260131
+
+    # Use a pre-existing URL file instead of querying ASF:
+    python tests/benchmark_s3_vs_https.py --url-file /path/to/urls.txt
+
+    # Include download benchmark:
+    python tests/benchmark_s3_vs_https.py --download
+
+    # Save results to JSON:
+    python tests/benchmark_s3_vs_https.py -o benchmark_results.json
+"""
+import argparse
+import csv
+import datetime
+import json
+import logging
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+
+# ---------------------------------------------------------------------------
+# Ensure the tools/ tree is importable
+# ---------------------------------------------------------------------------
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_REPO_ROOT, 'tools'))
+
+# ---------------------------------------------------------------------------
+# Heavy imports are deferred to main() so --help works without deps
+# ---------------------------------------------------------------------------
+
+
+LOGGER = logging.getLogger('benchmark')
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+DEFAULT_TRACK = 161
+DEFAULT_BBOX_WKT = (
+    'POLYGON((2.7291 50.7556,5.3028 50.7556,'
+    '5.3028 51.4959,2.7291 51.4959,2.7291 50.7556))'
+)
+DEFAULT_BBOX_SNWE = '50.7556 51.4959 2.7291 5.3028'
+DEFAULT_START = '20260201'
+DEFAULT_END = '20260228'
+
+
+# ══════════════════════════════════════════════════════════════════════════
+#  Timing helpers
+# ══════════════════════════════════════════════════════════════════════════
+class Timer:
+    """Reusable context-manager timer."""
+    def __init__(self):
+        self.elapsed = 0.0
+
+    def __enter__(self):
+        self._t0 = time.perf_counter()
+        return self
+
+    def __exit__(self, *_):
+        self.elapsed = time.perf_counter() - self._t0
+
+
+class BenchmarkResult:
+    """Holds timings for a single benchmark across multiple repetitions."""
+    def __init__(self, name, access_method):
+        self.name = name
+        self.access_method = access_method  # 'S3' or 'HTTPS'
+        self.timings = []                   # list of floats (seconds)
+        self.detail = ''                    # extra context
+
+    @property
+    def median(self):
+        return statistics.median(self.timings) if self.timings else 0.0
+
+    @property
+    def mean(self):
+        return statistics.mean(self.timings) if self.timings else 0.0
+
+    @property
+    def stdev(self):
+        return statistics.stdev(self.timings) if len(self.timings) > 1 else 0.0
+
+    @property
+    def best(self):
+        return min(self.timings) if self.timings else 0.0
+
+    @property
+    def worst(self):
+        return max(self.timings) if self.timings else 0.0
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'access_method': self.access_method,
+            'median_s': round(self.median, 4),
+            'mean_s': round(self.mean, 4),
+            'stdev_s': round(self.stdev, 4),
+            'best_s': round(self.best, 4),
+            'worst_s': round(self.worst, 4),
+            'reps': len(self.timings),
+            'detail': self.detail,
+        }
+
+
+# ══════════════════════════════════════════════════════════════════════════
+#  Product discovery
+# ══════════════════════════════════════════════════════════════════════════
+def discover_products(track, bbox_wkt, start_date, end_date, max_products):
+    """Query ASF for GUNW products and return (https_urls, s3_urls)."""
+    import asf_search
+
+    start = datetime.datetime.strptime(start_date, '%Y%m%d')
+    end = datetime.datetime.strptime(end_date, '%Y%m%d')
+
+    LOGGER.info('Querying ASF – Track %d, %s to %s', track,
+                start_date, end_date)
+    scenes = asf_search.geo_search(
+        collections=['C2859376221-ASF', 'C1261881077-ASF'],
+        dataset=asf_search.constants.ARIA_S1_GUNW,
+        processingLevel=asf_search.constants.GUNW_STD,
+        relativeOrbit=[track],
+        intersectsWith=bbox_wkt,
+        start=start - datetime.timedelta(days=1),
+        end=end + datetime.timedelta(days=1),
+    )
+
+    if not scenes:
+        LOGGER.error('No products found. Check query parameters or '
+                     'Earthdata credentials in ~/.netrc.')
+        return [], []
+
+    if max_products and len(scenes) > max_products:
+        scenes = scenes[:max_products]
+
+    https_urls = [s.properties['url'] for s in scenes]
+    s3_urls = []
+    for s in scenes:
+        addl = s.properties.get('additionalUrls', [])
+        s3 = next((u for u in addl if u.startswith('s3://')), None)
+        s3_urls.append(s3)
+
+    n_s3 = sum(1 for u in s3_urls if u)
+    LOGGER.info('Found %d products (%d with S3 URLs)', len(https_urls), n_s3)
+    return https_urls, s3_urls
+
+
+def load_url_file(path):
+    """Parse an existing URL file (1 or 2 columns) into lists."""
+    https_urls, s3_urls = [], []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            h, s = s3_util.parse_url_line(line)
+            https_urls.append(h)
+            s3_urls.append(s)
+    LOGGER.info('Loaded %d URLs from %s', len(https_urls), path)
+    return https_urls, s3_urls
+
+
+# ══════════════════════════════════════════════════════════════════════════
+#  GDAL configuration helpers
+# ══════════════════════════════════════════════════════════════════════════
+def _configure_https():
+    """Configure GDAL for HTTPS /vsicurl/ access."""
+    from ARIAtools.product import _configure_gdal_virtual_access
+    _configure_gdal_virtual_access()
+
+
+def _configure_s3(s3_urls):
+    """Configure GDAL for S3 direct access. Returns endpoint_key."""
+    _configure_https()
+    first_s3 = next((u for u in s3_urls if u), None)
+    if first_s3 is None:
+        return None
+    endpoint_key = s3_util._endpoint_key_for_s3uri(first_s3)
+    s3_util.configure_gdal_s3(endpoint_key)
+    return endpoint_key
+
+
+# ══════════════════════════════════════════════════════════════════════════
+#  Individual benchmarks
+# ══════════════════════════════════════════════════════════════════════════
+def bench_gdal_open(url, access_method, reps):
+    """Benchmark: gdal.Open() on a single product."""
+    r = BenchmarkResult('gdal.Open', access_method)
+    for i in range(reps):
+        t = Timer()
+        with t:
+            ds = osgeo.gdal.Open(f'NETCDF:"{url}')
+        r.timings.append(t.elapsed)
+        if ds:
+            n_sub = len([k for k in ds.GetMetadata('SUBDATASETS')
+                         if 'NAME' in k])
+            r.detail = f'subdatasets={n_sub}'
+            ds = None
+        else:
+            r.detail = 'gdal.Open returned None'
+            break
+    return r
+
+
+def bench_metadata_extract(url, workdir, access_method, reps):
+    """Benchmark: full metadata extraction (cache miss each time)."""
+    r = BenchmarkResult('metadata extract (gdal.Info)', access_method)
+    for i in range(reps):
+        cache_data = {}  # fresh cache each rep → forces cache miss
+        t = Timer()
+        with t:
+            meta = meta_cache.get_or_extract(url, cache_data)
+        r.timings.append(t.elapsed)
+        if meta:
+            r.detail = (
+                f"version={meta.get('version')}, "
+                f"subdatasets={len(meta.get('subdatasets', []))}")
+        else:
+            r.detail = 'metadata extraction returned None'
+            break
+    return r
+
+
+def bench_layer_read(url, access_method, reps):
+    """Benchmark: open coherence subdataset and read a 256x256 window."""
+    r = BenchmarkResult('layer read (coherence 256x256)', access_method)
+
+    # Discover coherence subdataset path
+    ds = osgeo.gdal.Open(f'NETCDF:"{url}')
+    if ds is None:
+        r.detail = 'failed to open product'
+        return r
+    sds = ds.GetMetadata('SUBDATASETS')
+    ds = None
+    coh_path = None
+    for k, v in sorted(sds.items()):
+        if 'NAME' in k and 'coherence' in v:
+            coh_path = v
+            break
+    if coh_path is None:
+        r.detail = 'no coherence subdataset'
+        return r
+
+    for i in range(reps):
+        t = Timer()
+        with t:
+            coh_ds = osgeo.gdal.Open(coh_path)
+            if coh_ds:
+                xsz = coh_ds.RasterXSize
+                ysz = coh_ds.RasterYSize
+                x_off = max(0, xsz // 2 - 128)
+                y_off = max(0, ysz // 2 - 128)
+                wx = min(256, xsz - x_off)
+                wy = min(256, ysz - y_off)
+                arr = coh_ds.GetRasterBand(1).ReadAsArray(
+                    x_off, y_off, wx, wy)
+                coh_ds = None
+        r.timings.append(t.elapsed)
+        if arr is not None:
+            r.detail = (f'{wx}x{wy} window, '
+                        f'range=[{np.nanmin(arr):.3f}, {np.nanmax(arr):.3f}]')
+
+    return r
+
+
+def bench_product_init(url_file, bbox, workdir, access_method, reps):
+    """Benchmark: Product() initialisation (metadata, pairing, bbox)."""
+    r = BenchmarkResult('Product() init', access_method)
+
+    from ARIAtools.product import Product
+
+    for i in range(reps):
+        # Delete cache so each rep starts cold (measures full I/O)
+        cache_file = meta_cache._cache_path(url_file)
+        if cache_file and os.path.isfile(cache_file):
+            os.remove(cache_file)
+        t = Timer()
+        with t:
+            p = Product(
+                filearg=url_file,
+                bbox=bbox,
+                workdir=workdir,
+                num_threads=1,
+                url_version=None,
+                nc_version='1c',
+            )
+        r.timings.append(t.elapsed)
+        n = len(p.products[0]) if len(p.products) == 2 else 0
+        r.detail = f'{len(p.files)} files, {n} ifg groups'
+
+    return r
+
+
+def bench_product_init_cached(url_file, bbox, workdir, access_method, reps):
+    """Benchmark: Product() init with warm cache."""
+    r = BenchmarkResult('Product() init (cached)', access_method)
+
+    from ARIAtools.product import Product
+
+    # Warm the cache with a single init
+    Product(
+        filearg=url_file, bbox=bbox, workdir=workdir,
+        num_threads=1, url_version=None, nc_version='1c')
+
+    for i in range(reps):
+        t = Timer()
+        with t:
+            p = Product(
+                filearg=url_file, bbox=bbox, workdir=workdir,
+                num_threads=1, url_version=None, nc_version='1c')
+        r.timings.append(t.elapsed)
+        n = len(p.products[0]) if len(p.products) == 2 else 0
+        r.detail = f'{len(p.files)} files, {n} ifg groups (cached)'
+
+    return r
+
+
+def bench_h5py_open(https_url, access_method, reps):
+    """Benchmark: open a remote HDF5/NetCDF via h5py HTTP byte-range.
+
+    Uses the meta_cache ``open_gunw_h5`` helper which wraps h5py with
+    an HTTP byte-range file-like object.  This measures the raw
+    connection + HDF5 superblock read overhead.
+    """
+    r = BenchmarkResult('h5py remote open', access_method)
+    vsi_url = f'/vsicurl/{https_url}'
+
+    for i in range(reps):
+        t = Timer()
+        try:
+            with t:
+                h5f = meta_cache.open_gunw_h5(vsi_url)
+                # Read the root group keys to force superblock parse
+                keys = list(h5f.keys())
+                h5f.close()
+            r.timings.append(t.elapsed)
+            r.detail = f'root keys: {keys}'
+        except Exception as exc:
+            r.detail = f'error: {exc}'
+            LOGGER.warning('h5py open failed: %s', exc)
+            break
+
+    return r
+
+
+def bench_download_single(https_url, s3_url, workdir, access_method,
+                          endpoint_key, reps):
+    """Benchmark: download a single product via S3 or HTTPS."""
+    r = BenchmarkResult('single file download', access_method)
+    fname = https_url.split('/')[-1]
+
+    for i in range(reps):
+        filepath = os.path.join(workdir, f'dl_bench_{i}_{fname}')
+        t = Timer()
+        try:
+            with t:
+                if access_method == 'S3' and s3_url:
+                    client = s3_util.get_s3_client(
+                        endpoint_key, max_pool_connections=10)
+                    bucket, key = s3_util.parse_s3_uri(s3_url)
+                    client.download_file(bucket, key, filepath)
+                else:
+                    import asf_search
+                    session = asf_search.ASFSession()
+                    resp = session.get(https_url, stream=True)
+                    resp.raise_for_status()
+                    with open(filepath, 'wb') as f:
+                        for chunk in resp.iter_content(chunk_size=65536):
+                            f.write(chunk)
+            r.timings.append(t.elapsed)
+            size_mb = os.path.getsize(filepath) / 1e6
+            r.detail = f'{size_mb:.1f} MB'
+        except Exception as exc:
+            LOGGER.warning('Download bench failed (%s): %s',
+                           access_method, exc)
+            r.detail = f'error: {exc}'
+        finally:
+            if os.path.exists(filepath):
+                os.remove(filepath)
+
+    return r
+
+
+# ══════════════════════════════════════════════════════════════════════════
+#  Report formatting
+# ══════════════════════════════════════════════════════════════════════════
+def print_report(results, on_aws):
+    """Pretty-print benchmark results as a table, with speedup column."""
+    # Group by benchmark name
+    by_name = {}
+    for r in results:
+        by_name.setdefault(r.name, {})[r.access_method] = r
+
+    print()
+    print('=' * 90)
+    print(f'  ARIA-tools Virtual Access Benchmark')
+    print(f'  On AWS: {on_aws}')
+    print('=' * 90)
+
+    hdr = (f'  {"Benchmark":<35s} {"Method":<7s} '
+           f'{"Median":>8s} {"Best":>8s} {"Worst":>8s} '
+           f'{"Speedup":>8s}  Detail')
+    print(hdr)
+    print('-' * 90)
+
+    for name in dict.fromkeys(r.name for r in results):
+        group = by_name[name]
+        s3_r = group.get('S3')
+        https_r = group.get('HTTPS')
+
+        for method, r in sorted(group.items()):
+            speedup = ''
+            if s3_r and https_r and method == 'S3' and https_r.median > 0:
+                sp = https_r.median / s3_r.median
+                speedup = f'{sp:.1f}x'
+            elif s3_r and https_r and method == 'HTTPS' and s3_r:
+                speedup = '(baseline)'
+
+            print(f'  {r.name:<35s} {r.access_method:<7s} '
+                  f'{r.median:>7.3f}s {r.best:>7.3f}s {r.worst:>7.3f}s '
+                  f'{speedup:>8s}  {r.detail}')
+        print()
+
+    print('=' * 90)
+
+
+def save_results(results, filepath, on_aws, meta):
+    """Save results to JSON for later analysis."""
+    data = {
+        'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+        'on_aws': on_aws,
+        'metadata': meta,
+        'benchmarks': [r.to_dict() for r in results],
+    }
+    with open(filepath, 'w') as f:
+        json.dump(data, f, indent=2)
+    LOGGER.info('Results saved to %s', filepath)
+
+
+def save_csv(results, filepath, on_aws):
+    """Save results to CSV for easy import into spreadsheets."""
+    with open(filepath, 'w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            'benchmark', 'method', 'median_s', 'mean_s', 'stdev_s',
+            'best_s', 'worst_s', 'reps', 'on_aws', 'detail',
+        ])
+        for r in results:
+            writer.writerow([
+                r.name, r.access_method,
+                f'{r.median:.4f}', f'{r.mean:.4f}', f'{r.stdev:.4f}',
+                f'{r.best:.4f}', f'{r.worst:.4f}', len(r.timings),
+                on_aws, r.detail,
+            ])
+    LOGGER.info('CSV saved to %s', filepath)
+
+
+# ══════════════════════════════════════════════════════════════════════════
+#  Main
+# ══════════════════════════════════════════════════════════════════════════
+def main():
+    parser = argparse.ArgumentParser(
+        description='Benchmark S3 vs HTTPS virtual access for ARIA-tools',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split('Usage\n-----')[0],
+    )
+    # Product discovery
+    parser.add_argument('--url-file', default=None,
+                        help='Pre-existing URL file (skip ASF query)')
+    parser.add_argument('--track', type=int, default=DEFAULT_TRACK,
+                        help=f'S1 track number (default: {DEFAULT_TRACK})')
+    parser.add_argument('--bbox', default=DEFAULT_BBOX_WKT,
+                        help='WKT polygon for ASF search')
+    parser.add_argument('--bbox-snwe', default=DEFAULT_BBOX_SNWE,
+                        help='SNWE bbox for Product class')
+    parser.add_argument('--start', default=DEFAULT_START,
+                        help=f'Start date YYYYMMDD (default: {DEFAULT_START})')
+    parser.add_argument('--end', default=DEFAULT_END,
+                        help=f'End date YYYYMMDD (default: {DEFAULT_END})')
+    parser.add_argument('--max-products', type=int, default=4,
+                        help='Max products to benchmark (default: 4)')
+
+    # Benchmark control
+    parser.add_argument('--reps', type=int, default=3,
+                        help='Repetitions per benchmark (default: 3)')
+    parser.add_argument('--download', action='store_true',
+                        help='Include single-file download benchmark')
+    parser.add_argument('--skip-product-init', action='store_true',
+                        help='Skip Product() init benchmarks (slowest)')
+    parser.add_argument('--force-s3', action='store_true',
+                        help='Run S3 benchmarks even if is_on_aws() is False '
+                             '(for testing with explicit AWS creds)')
+
+    # Output
+    parser.add_argument('-o', '--output', default=None,
+                        help='Save results to JSON file')
+    parser.add_argument('--csv', default=None,
+                        help='Save results to CSV file')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='Debug logging')
+    parser.add_argument('--workdir', default=None,
+                        help='Working directory (default: auto temp dir)')
+
+    args = parser.parse_args()
+
+    # Deferred heavy imports — after argparse so --help works without deps
+    global np, osgeo, s3_util, meta_cache
+    import numpy as np
+    import osgeo.gdal
+    import ARIAtools.util.s3 as s3_util
+    import ARIAtools.util.meta_cache as meta_cache
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s [%(name)s] %(levelname)s: %(message)s',
+        datefmt='%H:%M:%S')
+
+    # ── Product discovery ─────────────────────────────────────────────
+    if args.url_file:
+        https_urls, s3_urls = load_url_file(args.url_file)
+    else:
+        https_urls, s3_urls = discover_products(
+            args.track, args.bbox, args.start, args.end, args.max_products)
+
+    if not https_urls:
+        LOGGER.error('No products to benchmark. Exiting.')
+        return 1
+
+    # ── Environment detection ─────────────────────────────────────────
+    on_aws = s3_util.is_on_aws()
+    has_s3 = any(u is not None for u in s3_urls)
+    run_s3 = (on_aws or args.force_s3) and has_s3
+
+    LOGGER.info('Environment: on_aws=%s, has_s3_urls=%s, run_s3=%s',
+                on_aws, has_s3, run_s3)
+
+    # ── Working directory ─────────────────────────────────────────────
+    cleanup = args.workdir is None
+    workdir = args.workdir or tempfile.mkdtemp(prefix='aria_bench_')
+    os.makedirs(workdir, exist_ok=True)
+    LOGGER.info('Working directory: %s', workdir)
+
+    # Prepare directories
+    https_workdir = os.path.join(workdir, 'https')
+    s3_workdir = os.path.join(workdir, 's3')
+    os.makedirs(https_workdir, exist_ok=True)
+    if run_s3:
+        os.makedirs(s3_workdir, exist_ok=True)
+
+    results = []
+    endpoint_key = None
+
+    try:
+        # ── Configure GDAL ───────────────────────────────────────────
+        _configure_https()
+
+        # Build HTTPS paths
+        test_https_url = https_urls[0]
+        https_vsi = f'/vsicurl/{test_https_url}'
+
+        # Build S3 paths if available
+        s3_vsi = None
+        if run_s3:
+            endpoint_key = _configure_s3(s3_urls)
+            test_s3_url = next((u for u in s3_urls if u), None)
+            if test_s3_url:
+                s3_vsi = s3_util.s3uri_to_vsis3(test_s3_url)
+
+        # Write URL files for Product() init
+        https_url_file = os.path.join(https_workdir, 'urls.txt')
+        with open(https_url_file, 'w') as f:
+            for h in https_urls:
+                f.write(h + '\n')
+
+        s3_url_file = None
+        if run_s3:
+            s3_url_file = os.path.join(s3_workdir, 'urls.txt')
+            with open(s3_url_file, 'w') as f:
+                for h, s in zip(https_urls, s3_urls):
+                    line = f'{h},{s}' if s else h
+                    f.write(line + '\n')
+
+        # ══════════════════════════════════════════════════════════════
+        #  Run benchmarks
+        # ══════════════════════════════════════════════════════════════
+        LOGGER.info('Starting benchmarks (%d reps each) ...', args.reps)
+
+        # --- 1. gdal.Open ---
+        LOGGER.info('[1/%d] gdal.Open ...', 5 + int(args.download))
+        results.append(bench_gdal_open(
+            https_vsi, 'HTTPS', args.reps))
+        if run_s3 and s3_vsi:
+            results.append(bench_gdal_open(
+                s3_vsi, 'S3', args.reps))
+
+        # --- 2. Metadata extract ---
+        LOGGER.info('[2/%d] Metadata extract ...', 5 + int(args.download))
+        results.append(bench_metadata_extract(
+            https_vsi, https_workdir, 'HTTPS', args.reps))
+        if run_s3 and s3_vsi:
+            results.append(bench_metadata_extract(
+                s3_vsi, s3_workdir, 'S3', args.reps))
+
+        # --- 3. Layer read ---
+        LOGGER.info('[3/%d] Layer read ...', 5 + int(args.download))
+        results.append(bench_layer_read(
+            https_vsi, 'HTTPS', args.reps))
+        if run_s3 and s3_vsi:
+            results.append(bench_layer_read(
+                s3_vsi, 'S3', args.reps))
+
+        # --- 4. Product() init ---
+        if not args.skip_product_init:
+            LOGGER.info('[4/%d] Product() init (cold) ...',
+                        5 + int(args.download))
+            results.append(bench_product_init(
+                https_url_file, args.bbox_snwe, https_workdir,
+                'HTTPS', args.reps))
+            if run_s3 and s3_url_file:
+                results.append(bench_product_init(
+                    s3_url_file, args.bbox_snwe, s3_workdir,
+                    'S3', args.reps))
+
+            LOGGER.info('[5/%d] Product() init (cached) ...',
+                        5 + int(args.download))
+            results.append(bench_product_init_cached(
+                https_url_file, args.bbox_snwe, https_workdir,
+                'HTTPS', args.reps))
+            if run_s3 and s3_url_file:
+                results.append(bench_product_init_cached(
+                    s3_url_file, args.bbox_snwe, s3_workdir,
+                    'S3', args.reps))
+
+        # --- 5. h5py remote open ---
+        LOGGER.info('[%d/%d] h5py remote open ...',
+                    (4 if args.skip_product_init else 6),
+                    5 + int(args.download))
+        results.append(bench_h5py_open(
+            test_https_url, 'HTTPS', args.reps))
+        # h5py always uses HTTPS internally (even on S3), so no S3 bench
+
+        # --- 6. Download (optional) ---
+        if args.download:
+            LOGGER.info('[%d/%d] Single-file download ...',
+                        (5 if args.skip_product_init else 7),
+                        5 + int(args.download))
+            dl_dir = os.path.join(workdir, 'dl_bench')
+            os.makedirs(dl_dir, exist_ok=True)
+            results.append(bench_download_single(
+                test_https_url, s3_urls[0], dl_dir, 'HTTPS',
+                endpoint_key, 1))  # download only 1 rep — it's big
+            if run_s3 and s3_urls[0]:
+                results.append(bench_download_single(
+                    test_https_url, s3_urls[0], dl_dir, 'S3',
+                    endpoint_key, 1))
+
+        # ══════════════════════════════════════════════════════════════
+        #  Results
+        # ══════════════════════════════════════════════════════════════
+        print_report(results, on_aws)
+
+        # Metadata for output file
+        run_meta = {
+            'track': args.track,
+            'bbox_wkt': args.bbox,
+            'bbox_snwe': args.bbox_snwe,
+            'start_date': args.start,
+            'end_date': args.end,
+            'n_products': len(https_urls),
+            'reps': args.reps,
+        }
+
+        if args.output:
+            save_results(results, args.output, on_aws, run_meta)
+        if args.csv:
+            save_csv(results, args.csv, on_aws)
+
+    finally:
+        if cleanup:
+            LOGGER.info('Cleaning up %s', workdir)
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_aws_detection_diagnostic.py
+++ b/tests/test_aws_detection_diagnostic.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Diagnostic script to test AWS detection methods.
+
+Run this on your JupyterHub (or any environment) to see which
+detection methods succeed. Copy-paste into a notebook cell or
+run from a terminal:
+
+    python test_aws_detection_diagnostic.py
+"""
+
+import os
+import sys
+
+
+def test_imdsv2():
+    """Test 1: EC2 Instance Metadata Service v2 (current method)."""
+    print("=" * 60)
+    print("TEST 1: EC2 IMDSv2 metadata service")
+    print("=" * 60)
+    try:
+        import requests
+        # IMDSv2 token request
+        token_resp = requests.put(
+            'http://169.254.169.254/latest/api/token',
+            headers={'X-aws-ec2-metadata-token-ttl-seconds': '60'},
+            timeout=2)
+        token_resp.raise_for_status()
+        token = token_resp.text
+        print(f"  Token obtained: {token[:20]}...")
+
+        meta_resp = requests.get(
+            'http://169.254.169.254/latest/meta-data/instance-id',
+            headers={'X-aws-ec2-metadata-token': token},
+            timeout=2)
+        meta_resp.raise_for_status()
+        print(f"  Instance ID: {meta_resp.text}")
+        print("  RESULT: DETECTED as AWS EC2")
+        return True
+    except Exception as exc:
+        print(f"  FAILED: {type(exc).__name__}: {exc}")
+        print("  RESULT: NOT detected via IMDSv2")
+        return False
+
+
+def test_imdsv1():
+    """Test 2: EC2 Instance Metadata Service v1 (legacy, no token)."""
+    print()
+    print("=" * 60)
+    print("TEST 2: EC2 IMDSv1 metadata service (legacy)")
+    print("=" * 60)
+    try:
+        import requests
+        meta_resp = requests.get(
+            'http://169.254.169.254/latest/meta-data/instance-id',
+            timeout=2)
+        meta_resp.raise_for_status()
+        print(f"  Instance ID: {meta_resp.text}")
+        print("  RESULT: DETECTED as AWS EC2 via IMDSv1")
+        return True
+    except Exception as exc:
+        print(f"  FAILED: {type(exc).__name__}: {exc}")
+        print("  RESULT: NOT detected via IMDSv1")
+        return False
+
+
+def test_boto3_sts():
+    """Test 3: boto3 STS GetCallerIdentity (works with IAM roles)."""
+    print()
+    print("=" * 60)
+    print("TEST 3: boto3 STS GetCallerIdentity")
+    print("=" * 60)
+    try:
+        import boto3
+        import botocore.exceptions
+        sts = boto3.client('sts', region_name='us-west-2')
+        identity = sts.get_caller_identity()
+        print(f"  Account: {identity['Account']}")
+        print(f"  ARN:     {identity['Arn']}")
+        print(f"  UserId:  {identity['UserId']}")
+        print("  RESULT: DETECTED as AWS (valid AWS credentials)")
+        return True
+    except ImportError:
+        print("  FAILED: boto3 not installed")
+        print("  RESULT: Cannot test (install boto3)")
+        return False
+    except Exception as exc:
+        print(f"  FAILED: {type(exc).__name__}: {exc}")
+        print("  RESULT: NOT detected via STS")
+        return False
+
+
+def test_boto3_region():
+    """Test 4: boto3 session region / credential detection."""
+    print()
+    print("=" * 60)
+    print("TEST 4: boto3 session metadata")
+    print("=" * 60)
+    try:
+        import boto3
+        import botocore.exceptions
+        session = boto3.session.Session()
+        region = session.region_name
+        creds = session.get_credentials()
+        print(f"  Region: {region}")
+        if creds:
+            resolved = creds.get_frozen_credentials()
+            has_key = bool(resolved.access_key)
+            has_token = bool(resolved.token)
+            print(f"  Has access key: {has_key}")
+            print(f"  Has session token: {has_token}")
+            print(f"  Credential method: {creds.method}")
+            if has_key:
+                print("  RESULT: AWS credentials FOUND via boto3 session")
+                return True
+        print("  RESULT: No AWS credentials found")
+        return False
+    except ImportError:
+        print("  FAILED: boto3 not installed")
+        return False
+    except Exception as exc:
+        print(f"  FAILED: {type(exc).__name__}: {exc}")
+        return False
+
+
+def test_env_vars():
+    """Test 5: Check AWS-related environment variables."""
+    print()
+    print("=" * 60)
+    print("TEST 5: AWS environment variables")
+    print("=" * 60)
+    aws_vars = [
+        'AWS_DEFAULT_REGION',
+        'AWS_REGION',
+        'AWS_ACCESS_KEY_ID',
+        'AWS_SECRET_ACCESS_KEY',
+        'AWS_SESSION_TOKEN',
+        'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+        'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+        'AWS_EXECUTION_ENV',
+        'AWS_LAMBDA_FUNCTION_NAME',
+        'ECS_CONTAINER_METADATA_URI',
+        'ECS_CONTAINER_METADATA_URI_V4',
+    ]
+
+    found_any = False
+    for var in aws_vars:
+        val = os.environ.get(var)
+        if val:
+            # Mask credentials
+            if 'KEY' in var or 'SECRET' in var or 'TOKEN' in var:
+                display = val[:8] + '...' if len(val) > 8 else '***'
+            else:
+                display = val
+            print(f"  {var} = {display}")
+            found_any = True
+        else:
+            print(f"  {var} = (not set)")
+
+    if found_any:
+        print("  RESULT: Some AWS env vars are set")
+    else:
+        print("  RESULT: No AWS env vars found")
+    return found_any
+
+
+def test_ecs_metadata():
+    """Test 6: ECS/Fargate container metadata endpoint."""
+    print()
+    print("=" * 60)
+    print("TEST 6: ECS/Fargate metadata endpoint")
+    print("=" * 60)
+    ecs_uri = os.environ.get('ECS_CONTAINER_METADATA_URI_V4') or \
+              os.environ.get('ECS_CONTAINER_METADATA_URI')
+    if not ecs_uri:
+        print("  ECS metadata URI not in environment")
+        print("  RESULT: NOT in ECS/Fargate container")
+        return False
+    try:
+        import requests
+        resp = requests.get(ecs_uri, timeout=2)
+        resp.raise_for_status()
+        data = resp.json()
+        print(f"  Container: {data.get('DockerId', 'unknown')[:12]}")
+        print("  RESULT: DETECTED as ECS/Fargate")
+        return True
+    except Exception as exc:
+        print(f"  FAILED: {type(exc).__name__}: {exc}")
+        return False
+
+
+def test_container_creds():
+    """Test 7: AWS container credentials URI (ECS/EKS task role)."""
+    print()
+    print("=" * 60)
+    print("TEST 7: Container credentials endpoint")
+    print("=" * 60)
+    rel_uri = os.environ.get('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI')
+    full_uri = os.environ.get('AWS_CONTAINER_CREDENTIALS_FULL_URI')
+    if rel_uri:
+        print(f"  Relative URI: {rel_uri}")
+        print("  RESULT: Container role credentials available")
+        return True
+    elif full_uri:
+        print(f"  Full URI: {full_uri[:40]}...")
+        print("  RESULT: Container role credentials available")
+        return True
+    else:
+        print("  No container credential env vars set")
+        print("  RESULT: No container credentials endpoint")
+        return False
+
+
+def main():
+    print("AWS Detection Diagnostic")
+    print("Running from:", sys.executable)
+    print("Platform:", sys.platform)
+    print()
+
+    results = {}
+    results['IMDSv2'] = test_imdsv2()
+    results['IMDSv1'] = test_imdsv1()
+    results['boto3_STS'] = test_boto3_sts()
+    results['boto3_session'] = test_boto3_region()
+    results['env_vars'] = test_env_vars()
+    results['ECS_metadata'] = test_ecs_metadata()
+    results['container_creds'] = test_container_creds()
+
+    print()
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    for name, ok in results.items():
+        status = "PASS" if ok else "FAIL"
+        print(f"  {name:20s}: {status}")
+
+    detected = any(results.values())
+    print()
+    if detected:
+        # Which methods worked
+        working = [k for k, v in results.items() if v]
+        print(f"  --> AWS DETECTED via: {', '.join(working)}")
+    else:
+        print("  --> NOT detected as AWS by any method")
+
+    return detected
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -695,7 +695,7 @@ def create_raster_from_gunw(fname, data_lis, proj, driver, hgt_field=None,
         format='VRT',
         dstSRS=proj,
         dstNodata=np.nan,
-        multithread=False
+        multithread=True
     )
     ds = None # Close immediately
 
@@ -714,7 +714,7 @@ def create_raster_from_gunw(fname, data_lis, proj, driver, hgt_field=None,
         xRes=xres, yRes=yres,
         dstSRS=proj,
         dstNodata=np.nan,
-        multithread=False,
+        multithread=True,
         creationOptions=["TILED=YES", "COMPRESS=LZW", "BIGTIFF=IF_SAFER"]
     )
     ds = None # Close immediately
@@ -1061,29 +1061,30 @@ def generate_diff(ref_outname, sec_outname, outname, key, OG_key, tropo_total,
 def extract_bperp_dict(products, num_threads):
     """Extracts bPerpendicular mean over frames for each product in products"""
 
-    bperp_lock = threading.Lock()
-    
     def read_and_average_bperp(frame):
         """Helper function for dask multiprocessing"""
-        with bperp_lock:
-            # 1. Open explicitly
-            ds = osgeo.gdal.Open(frame, osgeo.gdal.GA_ReadOnly)
+
+        # Re-authenticate GDAL for the isolated worker process
+        ARIAtools.product._configure_gdal_virtual_access()
+
+        # 1. Open explicitly
+        ds = osgeo.gdal.Open(frame, osgeo.gdal.GA_ReadOnly)
         
-            # 2. Read data and get nodata value
-            arr = ds.ReadAsArray().astype(float)
-            nodata = ds.GetRasterBand(1).GetNoDataValue()
+        # 2. Read data and get nodata value
+        arr = ds.ReadAsArray().astype(float)
+        nodata = ds.GetRasterBand(1).GetNoDataValue()
         
-            # 3. CRITICAL: Close the file explicitly
-            ds = None 
+        # 3. CRITICAL: Close the file explicitly
+        ds = None 
         
-            # 4. Replace nodata with NaN (if nodata is not already NaN)
-            if nodata is not None and not np.isnan(nodata):
-                arr = np.where(arr == nodata, np.nan, arr)
+        # 4. Replace nodata with NaN (if nodata is not already NaN)
+        if nodata is not None and not np.isnan(nodata):
+            arr = np.where(arr == nodata, np.nan, arr)
         
-            # 5. Take mean ignoring NaN values
-            res = np.nanmean(arr)
+        # 5. Take mean ignoring NaN values
+        res = np.nanmean(arr)
         
-            return res
+        return res
 
     bperp_dict = {}
     for product in products:
@@ -1092,7 +1093,7 @@ def extract_bperp_dict(products, num_threads):
             jobs.append(dask.delayed(read_and_average_bperp)(frame))
 
         mean_bperp_by_frames = dask.compute(
-            jobs, num_workers=int(num_threads), scheduler='threads')[0]
+            jobs, num_workers=int(num_threads), scheduler='processes')[0]
 
         LOGGER.debug('Pair name: %s, bPerpendicular %s' % (
             product['pair_name'][0], mean_bperp_by_frames))
@@ -1395,7 +1396,7 @@ def export_product_worker(
     gdal_warp_kwargs = {
         'format': outputFormat, 'cutlineDSName': prods_TOTbbox,
         'outputBounds': bounds, 'xRes': arrres[0], 'yRes': arrres[1],
-        'targetAlignedPixels': True, 'multithread': False, 'dstSRS': proj}
+        'targetAlignedPixels': True, 'multithread': True, 'dstSRS': proj}
     warp_options = osgeo.gdal.WarpOptions(
         **gdal_warp_kwargs
     )

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -32,6 +32,7 @@ import numpy as np
 import scipy.interpolate
 import shapely.geometry
 
+import ARIAtools.product
 import ARIAtools.util.ionosphere
 import ARIAtools.util.vrt
 import ARIAtools.util.shp
@@ -1057,27 +1058,30 @@ def generate_diff(ref_outname, sec_outname, outname, key, OG_key, tropo_total,
 
 def extract_bperp_dict(products, num_threads):
     """Extracts bPerpendicular mean over frames for each product in products"""
+
+    bperp_lock = threading.Lock()
     
     def read_and_average_bperp(frame):
         """Helper function for dask multiprocessing"""
-        # 1. Open explicitly
-        ds = osgeo.gdal.Open(frame, osgeo.gdal.GA_ReadOnly)
+        with bperp_lock:
+            # 1. Open explicitly
+            ds = osgeo.gdal.Open(frame, osgeo.gdal.GA_ReadOnly)
         
-        # 2. Read data and get nodata value
-        arr = ds.ReadAsArray().astype(float)
-        nodata = ds.GetRasterBand(1).GetNoDataValue()
+            # 2. Read data and get nodata value
+            arr = ds.ReadAsArray().astype(float)
+            nodata = ds.GetRasterBand(1).GetNoDataValue()
         
-        # 3. CRITICAL: Close the file explicitly
-        ds = None 
+            # 3. CRITICAL: Close the file explicitly
+            ds = None 
         
-        # 4. Replace nodata with NaN (if nodata is not already NaN)
-        if nodata is not None and not np.isnan(nodata):
-            arr = np.where(arr == nodata, np.nan, arr)
+            # 4. Replace nodata with NaN (if nodata is not already NaN)
+            if nodata is not None and not np.isnan(nodata):
+                arr = np.where(arr == nodata, np.nan, arr)
         
-        # 5. Take mean ignoring NaN values
-        res = np.nanmean(arr)
+            # 5. Take mean ignoring NaN values
+            res = np.nanmean(arr)
         
-        return res
+            return res
 
     bperp_dict = {}
     for product in products:
@@ -1382,6 +1386,9 @@ def export_product_worker(
     Worker function for export_products for parallel execution with
     multiprocessing package.
     """
+    # Re-authenticate GDAL for the isolated worker process
+    ARIAtools.product._configure_gdal_virtual_access()
+
     # Initialize warp dict
     gdal_warp_kwargs = {
         'format': outputFormat, 'cutlineDSName': prods_TOTbbox,

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -695,7 +695,7 @@ def create_raster_from_gunw(fname, data_lis, proj, driver, hgt_field=None,
         format='VRT',
         dstSRS=proj,
         dstNodata=np.nan,
-        multithread=True
+        multithread=False
     )
     ds = None # Close immediately
 
@@ -714,7 +714,7 @@ def create_raster_from_gunw(fname, data_lis, proj, driver, hgt_field=None,
         xRes=xres, yRes=yres,
         dstSRS=proj,
         dstNodata=np.nan,
-        multithread=True,
+        multithread=False,
         creationOptions=["TILED=YES", "COMPRESS=LZW", "BIGTIFF=IF_SAFER"]
     )
     ds = None # Close immediately
@@ -1393,7 +1393,7 @@ def export_product_worker(
     gdal_warp_kwargs = {
         'format': outputFormat, 'cutlineDSName': prods_TOTbbox,
         'outputBounds': bounds, 'xRes': arrres[0], 'yRes': arrres[1],
-        'targetAlignedPixels': True, 'multithread': True, 'dstSRS': proj}
+        'targetAlignedPixels': True, 'multithread': False, 'dstSRS': proj}
     warp_options = osgeo.gdal.WarpOptions(
         **gdal_warp_kwargs
     )

--- a/tools/ARIAtools/extractProduct.py
+++ b/tools/ARIAtools/extractProduct.py
@@ -938,12 +938,14 @@ def prep_metadatalayers(
 
                     # Add height info
                     if hgt_field is not None:
-                        # Write height layers
-                        ds_meta = osgeo.gdal.Open(metadata_arr[0])
+                        # Fetch height from the LOCAL file
+                        ds_meta = osgeo.gdal.Open(losx_name + '.vrt')
                         hgt_meta = ds_meta.GetMetadataItem(hgt_field)
                         ds_meta = None  # Close file
 
-                        ds_vrt = osgeo.gdal.Open(outname + '.vrt')
+                        # Also added GA_Update so GDAL does not fail
+                        # silently when saving metadata)
+                        ds_vrt = osgeo.gdal.Open(outname + '.vrt', osgeo.gdal.GA_Update)
                         ds_vrt.SetMetadataItem(hgt_field, hgt_meta)
                         ds_vrt = None  # Close file
 

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -235,20 +235,24 @@ def _configure_gdal_virtual_access():
     """Configure GDAL for optimized virtual (vsicurl) remote access."""
     _get = osgeo.gdal.GetConfigOption
     _set = osgeo.gdal.SetConfigOption
+    import os
+
+    # Create a unique cookie file for this OS process to prevent 
+    # parallel workers from corrupting each other's auth sessions!
+    cookie_path = f'/tmp/cookies_{os.getpid()}.txt'
 
     # Authentication: cookie-based auth for Earthdata Login
     # Only set if user has not already configured via environment variables
-    # (see README: export GDAL_HTTP_COOKIEFILE=/tmp/cookies.txt)
     if _get('GDAL_HTTP_COOKIEFILE') is None:
-        _set('GDAL_HTTP_COOKIEFILE', '/tmp/cookies.txt')
+        _set('GDAL_HTTP_COOKIEFILE', cookie_path)
         LOGGER.warning(
-            'GDAL_HTTP_COOKIEFILE not set – defaulting to /tmp/cookies.txt. '
+            f'GDAL_HTTP_COOKIEFILE not set – defaulting to {cookie_path}. '
             'Consider setting this environment variable permanently '
             '(see ARIA-tools README).')
     if _get('GDAL_HTTP_COOKIEJAR') is None:
-        _set('GDAL_HTTP_COOKIEJAR', '/tmp/cookies.txt')
+        _set('GDAL_HTTP_COOKIEJAR', cookie_path)
         LOGGER.warning(
-            'GDAL_HTTP_COOKIEJAR not set – defaulting to /tmp/cookies.txt. '
+            f'GDAL_HTTP_COOKIEJAR not set – defaulting to {cookie_path}. '
             'Consider setting this environment variable permanently '
             '(see ARIA-tools README).')
 

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -257,6 +257,10 @@ def _configure_gdal_virtual_access():
     _set('GDAL_HTTP_MULTIPLEX', 'YES')
     _set('GDAL_HTTP_VERSION', '2')
 
+    # If AWS S3 credentials are in the environment (set by the parent
+    # process), restore GDAL config so /vsis3/ paths work in workers.
+    ARIAtools.util.s3.restore_gdal_s3_from_env()
+
     LOGGER.debug(f'GDAL virtual access configured using {cookie_path}')
 
 

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -25,6 +25,7 @@ import ARIAtools.constants
 import ARIAtools.util.url
 import ARIAtools.util.shp
 import ARIAtools.util.meta_cache
+import ARIAtools.util.s3
 
 osgeo.gdal.UseExceptions()
 osgeo.gdal.PushErrorHandler('CPLQuietErrorHandler')
@@ -367,7 +368,19 @@ class Product:
         # If list of URLs provided
         elif os.path.basename(filearg).endswith('.txt'):
             with open(filearg, 'r') as fh:
-                self.files = [f.rstrip('\n') for f in fh.readlines()]
+                lines = [f.rstrip('\n') for f in fh.readlines()]
+            # Parse 2-column format (https_url,s3_url) or legacy
+            # single-column (https_url only)
+            self.files = []
+            self._s3_url_map = {}
+            for line in lines:
+                if not line.strip():
+                    continue
+                https_url, s3_url = \
+                    ARIAtools.util.s3.parse_url_line(line)
+                self.files.append(https_url)
+                if s3_url:
+                    self._s3_url_map[https_url] = s3_url
 
         # If single file or wildcard
         else:
@@ -395,9 +408,24 @@ class Product:
                 self.files.remove(f)
                 LOGGER.warning('%s is not a supported NetCDF... skipping', f)
 
-        # If URLs, append with '/vsicurl/'
-        self.files = [
-            f'/vsicurl/{i}' if 'https://' in i else i for i in self.files]
+        # Build S3 URL list aligned to filtered self.files
+        s3_url_map = getattr(self, '_s3_url_map', {})
+        s3_urls = [s3_url_map.get(f) for f in self.files]
+
+        # For remote URLs, try S3 direct access (AWS) first,
+        # otherwise fall back to /vsicurl/ (HTTPS).
+        has_urls = any('https://' in i for i in self.files)
+        self._using_s3 = False
+        if has_urls:
+            converted, self._using_s3 = \
+                ARIAtools.util.s3.maybe_use_s3(self.files, s3_urls)
+            if self._using_s3:
+                self.files = converted
+            else:
+                # Default: wrap URLs with /vsicurl/
+                self.files = [
+                    f'/vsicurl/{i}' if 'https://' in i else i
+                    for i in self.files]
 
         # Initialize metadata cache for GUNW products (S1 .nc and NISAR .h5)
         if any(ext in i for i in self.files
@@ -408,10 +436,13 @@ class Product:
                 self._cache_file)
 
         # check if virtual file reader is being captured as netcdf
-        if any("https://" in i for i in self.files):
+        is_remote = any('/vsicurl/' in i or '/vsis3/' in i
+                        for i in self.files)
+        if is_remote:
             _configure_gdal_virtual_access()
 
-            this_file = [s for s in self.files if 'https://' in s][0]
+            this_file = [s for s in self.files
+                         if '/vsicurl/' in s or '/vsis3/' in s][0]
             # Use NETCDF: prefix to force the netCDF driver — works
             # for both .nc (S1 GUNW) and .h5 (NISAR GUNW) files since
             # NISAR products are CF-compliant NetCDF-4.
@@ -430,7 +461,8 @@ class Product:
                     f'Got driver={fmt!r} for {os.path.basename(this_file)}')
 
         # check if local file reader is being captured as netcdf
-        local_files = [s for s in self.files if 'https://' not in s]
+        local_files = [s for s in self.files
+                       if '/vsicurl/' not in s and '/vsis3/' not in s]
         if local_files:
             try:
                 ds = osgeo.gdal.Open(
@@ -1475,7 +1507,8 @@ class Product:
             # Ensure product still exists where originally found
             # For virtual (vsicurl) paths, os.path.exists() always returns
             # False, so we only check membership in current file list.
-            is_remote = '/vsicurl/' in prod_name
+            is_remote = ('/vsicurl/' in prod_name
+                         or '/vsis3/' in prod_name)
             if prod_name in self.files and (is_remote or os.path.exists(prod_name)):
                 self.products += [product]
             else:

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -233,30 +233,18 @@ def remove_scenes(products):
 
 def _configure_gdal_virtual_access():
     """Configure GDAL for optimized virtual (vsicurl) remote access."""
-    _get = osgeo.gdal.GetConfigOption
     _set = osgeo.gdal.SetConfigOption
 
     # Create a unique cookie file for this OS process to prevent 
-    # parallel workers from corrupting each other's auth sessions!
+    # parallel workers from locking/corrupting each other's auth sessions!
     cookie_path = f'/tmp/cookies_{os.getpid()}.txt'
 
-    # Authentication: cookie-based auth for Earthdata Login
-    # Only set if user has not already configured via environment variables
-    if _get('GDAL_HTTP_COOKIEFILE') is None:
-        _set('GDAL_HTTP_COOKIEFILE', cookie_path)
-        LOGGER.warning(
-            f'GDAL_HTTP_COOKIEFILE not set – defaulting to {cookie_path}. '
-            'Consider setting this environment variable permanently '
-            '(see ARIA-tools README).')
-    if _get('GDAL_HTTP_COOKIEJAR') is None:
-        _set('GDAL_HTTP_COOKIEJAR', cookie_path)
-        LOGGER.warning(
-            f'GDAL_HTTP_COOKIEJAR not set – defaulting to {cookie_path}. '
-            'Consider setting this environment variable permanently '
-            '(see ARIA-tools README).')
+    # Force GDAL to use the unique cookie path (and skip the noisy warnings)
+    _set('GDAL_HTTP_COOKIEFILE', cookie_path)
+    _set('GDAL_HTTP_COOKIEJAR', cookie_path)
 
     # Caching: enable and tune VSI cache for range-request efficiency
-    if _get('VSI_CACHE') is None:
+    if osgeo.gdal.GetConfigOption('VSI_CACHE') is None:
         _set('VSI_CACHE', 'YES')
     _set('VSI_CACHE_SIZE', '67108864')           # 64 MB cache
 
@@ -268,7 +256,7 @@ def _configure_gdal_virtual_access():
     _set('GDAL_HTTP_MULTIPLEX', 'YES')
     _set('GDAL_HTTP_VERSION', '2')
 
-    LOGGER.debug('GDAL virtual access configured for remote files')
+    LOGGER.debug(f'GDAL virtual access configured using {cookie_path}')
 
 
 def _read_hdf5_dataset(fname, dataset_path):

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -233,23 +233,23 @@ def remove_scenes(products):
 
 def _configure_gdal_virtual_access():
     """Configure GDAL for optimized virtual (vsicurl) remote access."""
+    _get = osgeo.gdal.GetConfigOption
     _set = osgeo.gdal.SetConfigOption
 
-    # Create a unique cookie file for this OS process to prevent 
-    # parallel workers from locking/corrupting each other's auth sessions!
-    cookie_path = f'/tmp/cookies_{os.getpid()}.txt'
+    # Use the shared master cookie so background workers inherit the Earthdata login!
+    cookie_path = os.environ.get('GDAL_HTTP_COOKIEFILE', '/tmp/cookies.txt')
 
-    # Force GDAL to use the unique cookie path (and skip the noisy warnings)
-    _set('GDAL_HTTP_COOKIEFILE', cookie_path)
-    _set('GDAL_HTTP_COOKIEJAR', cookie_path)
+    if _get('GDAL_HTTP_COOKIEFILE') is None:
+        _set('GDAL_HTTP_COOKIEFILE', cookie_path)
+    if _get('GDAL_HTTP_COOKIEJAR') is None:
+        _set('GDAL_HTTP_COOKIEJAR', cookie_path)
 
-    # Caching: enable and tune VSI cache for range-request efficiency
-    if osgeo.gdal.GetConfigOption('VSI_CACHE') is None:
+    # Cloud optimizations + Disable HDF5 Locking
+    _set('HDF5_USE_FILE_LOCKING', 'FALSE')
+    if _get('VSI_CACHE') is None:
         _set('VSI_CACHE', 'YES')
-    _set('VSI_CACHE_SIZE', '67108864')           # 64 MB cache
-
-    # HTTP tuning: chunk size, retries, and range merging
-    _set('CPL_VSIL_CURL_CHUNK_SIZE', '524288')   # 512 KB per request
+    _set('VSI_CACHE_SIZE', '67108864')           
+    _set('CPL_VSIL_CURL_CHUNK_SIZE', '524288')   
     _set('GDAL_HTTP_MAX_RETRY', '3')
     _set('GDAL_HTTP_RETRY_DELAY', '2')
     _set('GDAL_HTTP_MERGE_CONSECUTIVE_RANGES', 'YES')

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -235,7 +235,6 @@ def _configure_gdal_virtual_access():
     """Configure GDAL for optimized virtual (vsicurl) remote access."""
     _get = osgeo.gdal.GetConfigOption
     _set = osgeo.gdal.SetConfigOption
-    import os
 
     # Create a unique cookie file for this OS process to prevent 
     # parallel workers from corrupting each other's auth sessions!

--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -14,7 +14,6 @@ import datetime
 import itertools
 import osgeo
 
-import h5py
 import netCDF4
 import numpy as np
 import shapely.geometry
@@ -269,6 +268,44 @@ def _configure_gdal_virtual_access():
     LOGGER.debug('GDAL virtual access configured for remote files')
 
 
+def _read_hdf5_dataset(fname, dataset_path):
+    """Read a raster-like dataset from an HDF5/NetCDF-4 file via GDAL.
+
+    Uses the netCDF driver (``NETCDF:"path":dataset_path``) so that both
+    local and remote (``/vsicurl/``) files are supported transparently.
+
+    Only works for datasets that GDAL can represent as raster bands
+    (2-D or 3-D arrays).  For scalar or string datasets, use
+    ``meta_cache.get_nisar_h5_field()`` which reads via h5py with
+    caching.
+
+    Parameters
+    ----------
+    fname : str
+        GDAL-style file reference, already wrapped as
+        ``NETCDF:"<path>`` (without the trailing ``"``).
+    dataset_path : str
+        HDF5 internal path, e.g.
+        ``/science/LSAR/GUNW/metadata/radarGrid/referenceSlantRange``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array data from the dataset.
+    """
+    sds = fname + '":' + dataset_path
+    ds = osgeo.gdal.Open(sds, osgeo.gdal.GA_ReadOnly)
+
+    if ds is not None:
+        arr = ds.ReadAsArray()
+        ds = None
+        if arr is not None:
+            return arr.item() if arr.ndim == 0 else arr
+
+    raise RuntimeError(
+        f'Could not read {dataset_path} from {fname} via GDAL')
+
+
 # Input file(s) and bbox as either list or physical shape file.
 class Product:
     """
@@ -371,8 +408,9 @@ class Product:
         self.files = [
             f'/vsicurl/{i}' if 'https://' in i else i for i in self.files]
 
-        # Initialize metadata cache for ARIA-S1-GUNW products
-        if any('.nc' in i for i in self.files):
+        # Initialize metadata cache for GUNW products (S1 .nc and NISAR .h5)
+        if any(ext in i for i in self.files
+               for ext in ('.nc', '.h5')):
             self._cache_file = ARIAtools.util.meta_cache._cache_path(
                 self._filearg)
             self._cache_data = ARIAtools.util.meta_cache.load_cache(
@@ -383,24 +421,39 @@ class Product:
             _configure_gdal_virtual_access()
 
             this_file = [s for s in self.files if 'https://' in s][0]
-            fmt = osgeo.gdal.Open(this_file).GetDriver().GetDescription()
+            # Use NETCDF: prefix to force the netCDF driver — works
+            # for both .nc (S1 GUNW) and .h5 (NISAR GUNW) files since
+            # NISAR products are CF-compliant NetCDF-4.
+            try:
+                ds = osgeo.gdal.Open('NETCDF:"' + this_file + '"')
+                fmt = ds.GetDriver().GetDescription() if ds else None
+                ds = None
+            except Exception:
+                fmt = None
 
             if fmt != 'netCDF':
                 raise Exception(
                     'System update required to read requested virtual '
-                    'products: Linux kernel >=4.3 and libnetcdf >=4.5')
+                    'products via the netCDF driver. '
+                    'Requires: Linux kernel >=4.3 and libnetcdf >=4.5. '
+                    f'Got driver={fmt!r} for {os.path.basename(this_file)}')
 
         # check if local file reader is being captured as netcdf
-        check_for_urls = any("https://" not in i for i in self.files)
-        check_for_h5 = any(".h5" in i for i in self.files)
-        if check_for_urls and not check_for_h5:
-            fmt = osgeo.gdal.Open(
-                [s for s in self.files if 'https://' not in s][0]
-            ).GetDriver().GetDescription()
+        local_files = [s for s in self.files if 'https://' not in s]
+        if local_files:
+            try:
+                ds = osgeo.gdal.Open(
+                    'NETCDF:"' + local_files[0] + '"')
+                fmt = ds.GetDriver().GetDescription() if ds else None
+                ds = None
+            except Exception:
+                fmt = None
             if fmt != 'netCDF':
-                raise Exception('System update required to '
-                                'read requested local products: '
-                                'Linux kernel >=4.3 and libnetcdf >=4.5')
+                raise Exception(
+                    'System update required to read requested local '
+                    'products via the netCDF driver. '
+                    'Requires: Linux kernel >=4.3 and libnetcdf >=4.5. '
+                    f'Got driver={fmt!r} for {os.path.basename(local_files[0])}')
 
         if len(self.files) == 0:
             raise Exception('No file match found')
@@ -456,14 +509,18 @@ class Product:
                 pol_dict['SH'] = 'HH'
                 pol_dict['HHNA'] = 'HH'
                 for i in self.files:
-                    fname = 'NETCDF:"' + i
                     basename = os.path.basename(i)
                     file_pol = pol_dict[basename.split('_')[10]]
                     lyr_pref = '/science/LSAR/GUNW/grids/frequencyA'
                     lyr_pref += f'/unwrappedInterferogram/{file_pol}/'
-                    proj_location = lyr_pref + 'projection'
-                    with h5py.File(fname[8:], 'r') as hdf_gunw:
-                        file_proj = int(hdf_gunw[proj_location][()])
+                    # Read projection from the spatial reference of a
+                    # data layer; the 'projection' scalar dataset in
+                    # HDF5 is not readable via GDAL's netCDF driver.
+                    sds = f'NETCDF:"{i}":{lyr_pref}unwrappedPhase'
+                    ds = osgeo.gdal.Open(sds, osgeo.gdal.GA_ReadOnly)
+                    srs = ds.GetSpatialRef()
+                    file_proj = int(srs.GetAuthorityCode(None))
+                    ds = None
                     record_proj.append(file_proj)
                 self.projection = int(np.median(record_proj))
             else:
@@ -978,24 +1035,45 @@ class Product:
         lyr_pref = '/science/LSAR/GUNW/grids/frequencyA'
         wrapped_lyr_pref = f'{lyr_pref}/wrappedInterferogram/{file_pol}/'
         lyr_pref += f'/unwrappedInterferogram/{file_pol}/'
-        center_freq = '/science/LSAR/GUNW/grids/frequencyA/centerFrequency'
-        with h5py.File(fname[8:], 'r') as hdf_gunw:
-            # get bbox
-            latlon_file_bbox = hdf_gunw[sdskeys[0]]
-            latlon_file_bbox = latlon_file_bbox[()]
-            latlon_file_bbox = shapely.wkt.loads(latlon_file_bbox)
-            # get center frequency
-            center_freq_var = float(hdf_gunw[center_freq][()])
-            # get slant range info
-            rdr_slant_range = hdf_gunw[
-                '/science/LSAR/GUNW/metadata/' +
-                'radarGrid/referenceSlantRange'][()].flatten()
-            min_range = min(rdr_slant_range)
-            max_range = max(rdr_slant_range)
-            rdr_slant_range_spac = hdf_gunw['/science/LSAR/GUNW/grids/' +
-                                            'frequencyA/' +
-                                            'unwrappedInterferogram/' +
-                                            'xCoordinateSpacing'][()]
+
+        # Raw file path (without NETCDF:" prefix) for cache lookups
+        raw_fname = fname.replace('NETCDF:"', '')
+
+        # HDF5 paths for NISAR scalar/string metadata that GDAL's
+        # netCDF driver cannot read (scalars/strings).  Read once
+        # via h5py then cached in the metadata sidecar.
+        nisar_h5_fields = {
+            'boundingPolygon':
+                '/science/LSAR/identification/boundingPolygon',
+            'centerFrequency':
+                '/science/LSAR/GUNW/grids/frequencyA/centerFrequency',
+            'xCoordinateSpacing':
+                f'{lyr_pref}xCoordinateSpacing',
+        }
+
+        latlon_file_bbox = ARIAtools.util.meta_cache.get_h5_field(
+            raw_fname, 'boundingPolygon',
+            nisar_h5_fields, self._cache_data)
+        latlon_file_bbox = shapely.wkt.loads(latlon_file_bbox)
+
+        center_freq_var = float(
+            ARIAtools.util.meta_cache.get_h5_field(
+                raw_fname, 'centerFrequency',
+                nisar_h5_fields, self._cache_data))
+
+        rdr_slant_range_spac = float(
+            ARIAtools.util.meta_cache.get_h5_field(
+                raw_fname, 'xCoordinateSpacing',
+                nisar_h5_fields, self._cache_data))
+
+        # referenceSlantRange is a 3D array — readable via GDAL netCDF
+        rdr_slant_range = np.asarray(
+            _read_hdf5_dataset(
+                fname,
+                '/science/LSAR/GUNW/metadata/'
+                'radarGrid/referenceSlantRange')).flatten()
+        min_range = float(min(rdr_slant_range))
+        max_range = float(max(rdr_slant_range))
         rdrmetadata_dict['centerFrequency'] = center_freq_var
         rdrmetadata_dict[
             'wavelength'] = 299792458 / rdrmetadata_dict['centerFrequency']

--- a/tools/ARIAtools/util/meta_cache.py
+++ b/tools/ARIAtools/util/meta_cache.py
@@ -11,15 +11,23 @@ Metadata cache for ARIA GUNW products.
 Caches per-product metadata extracted from remote (vsicurl) or local
 NetCDF files so that repeated invocations avoid re-reading product
 headers over HTTP. The cache is stored as a JSON sidecar file.
+
+Also provides h5py-based access for scalar/string HDF5 metadata
+that GDAL cannot read (e.g. boundingPolygon, centerFrequency).
 """
 
 import hashlib
+import http.cookiejar
+import io
 import json
 import logging
 import os
 import time
 
+import h5py
+import numpy as np
 import osgeo.gdal
+import requests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -161,3 +169,223 @@ def get_or_extract(fname, cache_data):
     if meta is not None:
         cache_data[key] = meta
     return meta
+
+
+# ---------- h5py helpers for scalar/string HDF5 metadata ------------------
+
+
+class _HTTPRangeFile(io.RawIOBase):
+    """Seekable read-only file backed by HTTP byte-range requests.
+
+    Handles the Earthdata OAuth redirect chain by resolving the final
+    signed URL up front, then issues byte-range GET requests for each
+    read.  h5py uses this to fetch only the HDF5 chunks it needs.
+    """
+
+    def __init__(self, url, session=None):
+        super().__init__()
+        self._session = session or requests.Session()
+        self._pos = 0
+
+        # Resolve the redirect chain to get the final signed URL +
+        # determine file size.
+        resp = self._session.get(
+            url, headers={'Range': 'bytes=0-0'},
+            allow_redirects=True, stream=True, timeout=60)
+        resp.close()
+
+        # Store the final (signed) URL so subsequent requests skip
+        # the redirect chain entirely.
+        self._url = resp.url
+
+        # Parse total file size from Content-Range: bytes 0-0/<total>
+        cr = resp.headers.get('Content-Range', '')
+        if '/' in cr:
+            self._size = int(cr.split('/')[-1])
+        else:
+            head = self._session.head(self._url, timeout=60)
+            self._size = int(head.headers.get('Content-Length', 0))
+
+        LOGGER.debug('Resolved URL (size=%d bytes)', self._size)
+
+    def readable(self):
+        return True
+
+    def writable(self):
+        return False
+
+    def seekable(self):
+        return True
+
+    def tell(self):
+        return self._pos
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        if whence == io.SEEK_SET:
+            self._pos = offset
+        elif whence == io.SEEK_CUR:
+            self._pos += offset
+        elif whence == io.SEEK_END:
+            self._pos = self._size + offset
+        return self._pos
+
+    def read(self, size=-1):
+        if self._pos >= self._size:
+            return b''
+        if size < 0:
+            size = self._size - self._pos
+        end = min(self._pos + size - 1, self._size - 1)
+        headers = {'Range': f'bytes={self._pos}-{end}'}
+        resp = self._session.get(
+            self._url, headers=headers, timeout=120)
+        resp.raise_for_status()
+        data = resp.content
+        self._pos += len(data)
+        return data
+
+    def readinto(self, b):
+        data = self.read(len(b))
+        n = len(data)
+        b[:n] = data
+        return n
+
+    @property
+    def size(self):
+        return self._size
+
+
+def _get_earthdata_session():
+    """Create a ``requests.Session`` with Earthdata cookie auth."""
+    cookie_file = osgeo.gdal.GetConfigOption(
+        'GDAL_HTTP_COOKIEFILE', '/tmp/cookies.txt')
+
+    session = requests.Session()
+
+    if os.path.isfile(cookie_file):
+        jar = http.cookiejar.MozillaCookieJar(cookie_file)
+        try:
+            jar.load(ignore_discard=True, ignore_expires=True)
+            session.cookies.update(jar)
+            LOGGER.debug('Loaded cookies from %s (%d cookies)',
+                         cookie_file, len(jar))
+        except Exception as exc:
+            LOGGER.debug('Could not load cookies from %s: %s',
+                         cookie_file, exc)
+
+    return session
+
+
+def open_gunw_h5(url_or_path):
+    """Open a GUNW HDF5 file (local or remote) as an h5py.File.
+
+    For remote URLs (https://...), resolves the Earthdata OAuth
+    redirect chain, then uses HTTP byte-range requests so that h5py
+    fetches only the HDF5 chunks it needs.
+
+    Parameters
+    ----------
+    url_or_path : str
+        HTTPS URL or local file path.  VSICURL prefixes
+        (``/vsicurl/``) are stripped automatically.
+
+    Returns
+    -------
+    h5py.File
+    """
+    path = url_or_path.replace('/vsicurl/', '')
+
+    if path.startswith('https://') or path.startswith('http://'):
+        LOGGER.debug('Opening remote HDF5: %s', path)
+        session = _get_earthdata_session()
+        fh = _HTTPRangeFile(path, session=session)
+        return h5py.File(fh, 'r')
+    else:
+        LOGGER.debug('Opening local HDF5: %s', path)
+        return h5py.File(path, 'r')
+
+
+# ---------- h5py scalar/string metadata caching --------------------------
+
+
+def _extract_h5_fields(fname, h5_fields):
+    """Read scalar/string metadata from an HDF5 file via h5py.
+
+    Parameters
+    ----------
+    fname : str
+        Product path or ``/vsicurl/...`` URL.
+    h5_fields : dict
+        Mapping of ``{field_name: hdf5_path}``.  Each path is read
+        from the HDF5 file and returned as a Python scalar or string.
+
+    Returns
+    -------
+    dict
+        Keys matching *h5_fields* with their scalar values.
+    """
+    result = {}
+    with open_gunw_h5(fname) as h5f:
+        for field_name, h5_path in h5_fields.items():
+            if h5_path in h5f:
+                val = h5f[h5_path][()]
+                # Decode bytes → str for string datasets
+                if isinstance(val, bytes):
+                    val = val.decode('utf-8')
+                elif isinstance(val, np.generic):
+                    val = val.item()
+                result[field_name] = val
+            else:
+                LOGGER.warning('h5py field %s not found at %s',
+                               field_name, h5_path)
+    return result
+
+
+def get_h5_field(fname, field_name, h5_fields, cache_data):
+    """Return a single h5py metadata field, using cache.
+
+    On the first call for a given product, all fields in *h5_fields*
+    are read in one ``h5py.File`` open and cached together.
+    Subsequent calls return from cache without any I/O.
+
+    Parameters
+    ----------
+    fname : str
+        Product path (may include ``/vsicurl/`` prefix).
+    field_name : str
+        One of the keys in *h5_fields*.
+    h5_fields : dict
+        Mapping of ``{field_name: hdf5_path}`` — the caller defines
+        which datasets to read.
+    cache_data : dict
+        Mutable cache dict; updated in-place on cache miss.
+
+    Returns
+    -------
+    value
+        The scalar/string value for the requested field.
+    """
+    key = _file_key(fname)
+    entry = cache_data.get(key, {})
+
+    # Check if this specific h5py field is already cached
+    h5_cache_key = f'h5_{field_name}'
+    if h5_cache_key in entry:
+        LOGGER.debug('h5py cache hit: %s [%s]',
+                     os.path.basename(key), field_name)
+        return entry[h5_cache_key]
+
+    # Cache miss — extract all requested h5py fields at once
+    LOGGER.debug('h5py cache miss – reading: %s',
+                 os.path.basename(key))
+    h5_meta = _extract_h5_fields(fname, h5_fields)
+
+    # Merge into the existing cache entry
+    if key not in cache_data:
+        cache_data[key] = {}
+    for k, v in h5_meta.items():
+        cache_data[key][f'h5_{k}'] = v
+
+    if field_name not in h5_meta:
+        raise RuntimeError(
+            f'h5py field {field_name!r} not found in {fname}')
+    return h5_meta[field_name]

--- a/tools/ARIAtools/util/meta_cache.py
+++ b/tools/ARIAtools/util/meta_cache.py
@@ -51,10 +51,14 @@ def _cache_path(url_file):
 def _file_key(fname):
     """Produce a stable key for a product file (URL or local path).
 
-    For remote URLs we strip the /vsicurl/ prefix so the key is the
-    canonical URL.  For local files we use the absolute path.
+    For remote URLs we strip the /vsicurl/ or /vsis3/ prefix so the
+    key is the canonical URL.  For local files we use the absolute path.
     """
-    key = fname.replace('/vsicurl/', '')
+    import re
+    key = re.sub(r'^/vsi(curl|s3)/', '', fname)
+    # Strip the bucket prefix for S3 paths to recover the original URL
+    # e.g. asf-cumulus-prod-nisar-gunw/path → path
+    # The key should be the URL path or local path, not bucket-specific
     return key
 
 
@@ -285,14 +289,26 @@ def open_gunw_h5(url_or_path):
     Parameters
     ----------
     url_or_path : str
-        HTTPS URL or local file path.  VSICURL prefixes
-        (``/vsicurl/``) are stripped automatically.
+        HTTPS URL or local file path.  VSICURL/VSIS3 prefixes
+        are stripped automatically.  For ``/vsis3/`` paths, the
+        underlying HTTPS URL is resolved via the reverse mapping
+        built by ``ARIAtools.util.s3.maybe_use_s3()``.
 
     Returns
     -------
     h5py.File
     """
     path = url_or_path.replace('/vsicurl/', '')
+
+    # For /vsis3/ paths, resolve back to HTTPS for h5py access
+    if path.startswith('/vsis3/'):
+        from ARIAtools.util.s3 import vsis3_to_https
+        https_url = vsis3_to_https(path)
+        if https_url:
+            path = https_url
+        else:
+            LOGGER.warning(
+                'Cannot resolve /vsis3/ path to HTTPS: %s', path)
 
     if path.startswith('https://') or path.startswith('http://'):
         LOGGER.debug('Opening remote HDF5: %s', path)

--- a/tools/ARIAtools/util/s3.py
+++ b/tools/ARIAtools/util/s3.py
@@ -51,18 +51,26 @@ _vsis3_to_https = {}
 
 
 def is_on_aws():
-    """Detect whether the current environment is an AWS EC2 instance.
+    """Detect whether the current environment is running on AWS.
 
-    Uses IMDSv2 (Instance Metadata Service v2) with a 1.5-second
-    timeout.  Returns ``False`` on any failure, so this is safe to
-    call from any environment.
+    Detection strategy (in order):
+
+    1. **IMDSv2** — EC2 Instance Metadata Service v2.  Works on
+       standard EC2 instances.
+    2. **boto3 STS** — ``GetCallerIdentity``.  Works in containers,
+       JupyterHub on EKS/ECS, SageMaker, Lambda, and any environment
+       where IAM credentials are available (instance role, task role,
+       env vars, or config files).
+
+    Returns ``False`` on any failure, so this is safe to call from
+    any environment.
 
     Returns
     -------
     bool
     """
+    # --- Attempt 1: IMDSv2 (fast, no extra dependency) ---
     try:
-        # IMDSv2 requires a PUT to get a session token first
         token_resp = requests.put(
             'http://169.254.169.254/latest/api/token',
             headers={'X-aws-ec2-metadata-token-ttl-seconds': '60'},
@@ -70,7 +78,6 @@ def is_on_aws():
         token_resp.raise_for_status()
         token = token_resp.text
 
-        # Verify we can read instance metadata
         meta_resp = requests.get(
             'http://169.254.169.254/latest/meta-data/instance-id',
             headers={'X-aws-ec2-metadata-token': token},
@@ -80,9 +87,25 @@ def is_on_aws():
                     meta_resp.text)
         return True
     except Exception:
-        LOGGER.debug('Not running on AWS EC2 (metadata service '
-                     'unreachable)')
-        return False
+        LOGGER.debug('IMDSv2 unavailable — trying boto3 fallback')
+
+    # --- Attempt 2: boto3 STS GetCallerIdentity ---
+    try:
+        import boto3
+        import botocore.exceptions
+        sts = boto3.client('sts', region_name='us-west-2')
+        identity = sts.get_caller_identity()
+        LOGGER.info(
+            'Running on AWS (STS identity: %s)', identity.get('Arn'))
+        return True
+    except ImportError:
+        LOGGER.debug('boto3 not installed — cannot use STS fallback')
+    except Exception:
+        LOGGER.debug('boto3 STS call failed — not on AWS or no '
+                     'credentials available')
+
+    LOGGER.debug('Not running on AWS (all detection methods failed)')
+    return False
 
 
 def _fetch_s3_credentials():

--- a/tools/ARIAtools/util/s3.py
+++ b/tools/ARIAtools/util/s3.py
@@ -361,6 +361,55 @@ def vsis3_to_https(vsis3_path):
     return _vsis3_to_https.get(vsis3_path)
 
 
+def fixup_vrt_s3_paths(directory):
+    """Replace ``/vsis3/`` paths with ``/vsicurl/`` paths in all VRT files.
+
+    VRT files are persistent output artifacts consumed by downstream
+    tools (e.g. MintPy) that don't have ARIA-tools' S3 credential
+    setup.  This function rewrites ``/vsis3/bucket/key`` references
+    to ``/vsicurl/https_url`` using the reverse mapping built by
+    ``maybe_use_s3()``, making the VRTs portable.
+
+    Should be called after all extraction/export is complete and
+    before downstream tools read the VRTs.
+
+    Parameters
+    ----------
+    directory : str
+        Root directory to scan for ``.vrt`` files (recursive).
+    """
+    if not _vsis3_to_https:
+        return  # No S3 paths were used — nothing to fix
+
+    import glob as _glob
+    vrt_files = _glob.glob(os.path.join(directory, '**', '*.vrt'),
+                           recursive=True)
+    n_fixed = 0
+    for vrt_path in vrt_files:
+        try:
+            with open(vrt_path, 'r') as f:
+                content = f.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        if '/vsis3/' not in content:
+            continue
+
+        new_content = content
+        for vsis3_path, https_url in _vsis3_to_https.items():
+            new_content = new_content.replace(
+                vsis3_path, f'/vsicurl/{https_url}')
+
+        if new_content != content:
+            with open(vrt_path, 'w') as f:
+                f.write(new_content)
+            n_fixed += 1
+
+    if n_fixed:
+        LOGGER.info('Fixed %d VRT file(s): replaced /vsis3/ with '
+                     '/vsicurl/ for downstream compatibility', n_fixed)
+
+
 def get_s3_client(endpoint_key='default', max_pool_connections=10):
     """Create a boto3 S3 client using temporary DAAC credentials.
 

--- a/tools/ARIAtools/util/s3.py
+++ b/tools/ARIAtools/util/s3.py
@@ -1,0 +1,261 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Author: David Bekaert
+# Copyright (c) 2026
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+AWS S3 direct-access helpers for ARIA GUNW virtual processing.
+
+When running on an AWS EC2 instance (any region), GDAL can access
+NASA Earthdata products via ``/vsis3/`` instead of ``/vsicurl/``.
+This bypasses the Earthdata OAuth redirect chain and uses the AWS
+internal network, which is significantly faster.
+
+The URL list file written by ``ariaDownload.py`` contains two
+comma-separated columns per line::
+
+    https://host/path/file.h5,s3://bucket/path/file.h5
+
+On startup, ARIA-tools checks if it is running on AWS via the EC2
+metadata service.  If yes, the S3 column is used (with ``/vsis3/``);
+otherwise the HTTPS column is used (with ``/vsicurl/``).
+
+The module provides:
+- AWS instance detection via the EC2 metadata service (IMDSv2)
+- Temporary S3 credential retrieval from the ASF DAAC endpoint
+- GDAL configuration for S3 access
+- Parsing of the 2-column URL file format
+"""
+
+import logging
+import os
+import time
+
+import osgeo.gdal
+import requests
+
+LOGGER = logging.getLogger(__name__)
+
+# ASF DAAC S3 credential endpoint — returns temporary AWS credentials
+# for in-cloud access to NASA Earthdata products hosted on S3.
+_ASF_S3_CREDS_URL = 'https://cumulus.asf.alaska.edu/s3credentials'
+
+# Cached credentials (module-level) — refreshed when expired
+_s3_creds = None
+_s3_creds_expiry = 0
+
+# Reverse mapping: /vsis3/ path → HTTPS URL, populated by maybe_use_s3.
+# Used by open_gunw_h5 to resolve /vsis3/ paths back to HTTPS for h5py.
+_vsis3_to_https = {}
+
+
+def is_on_aws():
+    """Detect whether the current environment is an AWS EC2 instance.
+
+    Uses IMDSv2 (Instance Metadata Service v2) with a 1.5-second
+    timeout.  Returns ``False`` on any failure, so this is safe to
+    call from any environment.
+
+    Returns
+    -------
+    bool
+    """
+    try:
+        # IMDSv2 requires a PUT to get a session token first
+        token_resp = requests.put(
+            'http://169.254.169.254/latest/api/token',
+            headers={'X-aws-ec2-metadata-token-ttl-seconds': '60'},
+            timeout=1.5)
+        token_resp.raise_for_status()
+        token = token_resp.text
+
+        # Verify we can read instance metadata
+        meta_resp = requests.get(
+            'http://169.254.169.254/latest/meta-data/instance-id',
+            headers={'X-aws-ec2-metadata-token': token},
+            timeout=1.5)
+        meta_resp.raise_for_status()
+        LOGGER.info('Running on AWS EC2 (instance %s)',
+                    meta_resp.text)
+        return True
+    except Exception:
+        LOGGER.debug('Not running on AWS EC2 (metadata service '
+                     'unreachable)')
+        return False
+
+
+def _fetch_s3_credentials():
+    """Fetch temporary S3 credentials from the ASF DAAC endpoint.
+
+    Requires Earthdata Login credentials in ``~/.netrc``.  The
+    returned credentials are valid for ~1 hour.
+
+    Returns
+    -------
+    dict
+        Keys: ``accessKeyId``, ``secretAccessKey``, ``sessionToken``,
+        ``expiration``.
+
+    Raises
+    ------
+    RuntimeError
+        If credential retrieval fails.
+    """
+    LOGGER.info('Fetching temporary S3 credentials from ASF')
+    try:
+        resp = requests.get(_ASF_S3_CREDS_URL, timeout=30)
+        resp.raise_for_status()
+        creds = resp.json()
+    except Exception as exc:
+        raise RuntimeError(
+            f'Failed to fetch S3 credentials from {_ASF_S3_CREDS_URL}: '
+            f'{exc}') from exc
+
+    required = ('accessKeyId', 'secretAccessKey', 'sessionToken')
+    for key in required:
+        if key not in creds:
+            raise RuntimeError(
+                f'S3 credential response missing key {key!r}')
+
+    LOGGER.debug('S3 credentials obtained (expires: %s)',
+                 creds.get('expiration', 'unknown'))
+    return creds
+
+
+def get_s3_credentials():
+    """Return cached S3 credentials, refreshing if expired.
+
+    Returns
+    -------
+    dict
+        Keys: ``accessKeyId``, ``secretAccessKey``, ``sessionToken``.
+    """
+    global _s3_creds, _s3_creds_expiry
+
+    # Refresh 5 minutes before expiry to avoid mid-operation failures
+    if _s3_creds is None or time.time() > (_s3_creds_expiry - 300):
+        _s3_creds = _fetch_s3_credentials()
+        # Default to 1 hour if no expiration provided
+        _s3_creds_expiry = time.time() + 3600
+    return _s3_creds
+
+
+def configure_gdal_s3():
+    """Set GDAL config options for S3 access using ASF credentials.
+
+    Should be called once before opening ``/vsis3/`` paths with GDAL.
+    Automatically fetches/refreshes temporary credentials.
+    """
+    creds = get_s3_credentials()
+
+    _set = osgeo.gdal.SetConfigOption
+    _set('AWS_ACCESS_KEY_ID', creds['accessKeyId'])
+    _set('AWS_SECRET_ACCESS_KEY', creds['secretAccessKey'])
+    _set('AWS_SESSION_TOKEN', creds['sessionToken'])
+    _set('AWS_REGION', 'us-west-2')
+    _set('AWS_NO_SIGN_REQUEST', 'NO')
+
+    LOGGER.info('GDAL configured for S3 direct access (region: us-west-2)')
+
+
+def s3uri_to_vsis3(s3_uri):
+    """Convert an ``s3://bucket/path`` URI to a GDAL ``/vsis3/`` path.
+
+    Parameters
+    ----------
+    s3_uri : str
+        S3 URI, e.g. ``s3://bucket-name/path/to/file.h5``
+
+    Returns
+    -------
+    str
+        ``/vsis3/bucket-name/path/to/file.h5``
+    """
+    return '/vsis3/' + s3_uri[len('s3://'):]
+
+
+def parse_url_line(line):
+    """Parse a line from the URL list file.
+
+    Supports both the 2-column format (``https_url,s3_url``) and the
+    legacy single-column format (``https_url`` only).
+
+    Parameters
+    ----------
+    line : str
+        A single line from the URL file (stripped of newline).
+
+    Returns
+    -------
+    tuple of (str, str or None)
+        ``(https_url, s3_url)`` where ``s3_url`` is ``None`` if not
+        present or empty.
+    """
+    parts = line.split(',', 1)
+    https_url = parts[0].strip()
+    s3_url = parts[1].strip() if len(parts) > 1 and parts[1].strip() else None
+    return https_url, s3_url
+
+
+def maybe_use_s3(https_urls, s3_urls):
+    """If on AWS and S3 URLs are available, use ``/vsis3/`` access.
+
+    This is the main entry point.  Call it once with the URL lists
+    parsed from the URL file before processing begins.
+
+    Parameters
+    ----------
+    https_urls : list of str
+        Product HTTPS URLs.
+    s3_urls : list of (str or None)
+        Corresponding S3 URIs (``s3://...``) from the URL file.
+        ``None`` entries indicate no S3 URL was available.
+
+    Returns
+    -------
+    list of str
+        GDAL-ready paths: ``/vsis3/...`` if on AWS with S3 URLs
+        available, otherwise the original HTTPS URLs (caller wraps
+        with ``/vsicurl/``).
+    bool
+        ``True`` if S3 access is being used.
+    """
+    # Check if any S3 URLs are available
+    has_s3 = any(u is not None for u in s3_urls)
+    if not has_s3:
+        LOGGER.info('No S3 URLs in URL file — using HTTPS access')
+        return https_urls, False
+
+    if not is_on_aws():
+        LOGGER.info('Not on AWS — using HTTPS (vsicurl) access')
+        return https_urls, False
+
+    # We're on AWS with S3 URLs — set up credentials and convert
+    configure_gdal_s3()
+
+    converted = []
+    for https_url, s3_url in zip(https_urls, s3_urls):
+        if s3_url is not None:
+            vsis3_path = s3uri_to_vsis3(s3_url)
+            converted.append(vsis3_path)
+            _vsis3_to_https[vsis3_path] = https_url
+        else:
+            # Fallback for products without S3 URLs
+            converted.append(https_url)
+    LOGGER.info('Using S3 direct access for %d/%d products',
+                sum(1 for u in s3_urls if u is not None),
+                len(https_urls))
+    return converted, True
+
+
+def vsis3_to_https(vsis3_path):
+    """Look up the HTTPS URL for a ``/vsis3/`` path.
+
+    Uses the reverse mapping built by ``maybe_use_s3()``.
+
+    Returns
+    -------
+    str or None
+    """
+    return _vsis3_to_https.get(vsis3_path)

--- a/tools/ARIAtools/util/s3.py
+++ b/tools/ARIAtools/util/s3.py
@@ -259,3 +259,40 @@ def vsis3_to_https(vsis3_path):
     str or None
     """
     return _vsis3_to_https.get(vsis3_path)
+
+
+def get_s3_client():
+    """Create a boto3 S3 client using ASF temporary credentials.
+
+    Credentials are automatically fetched/refreshed.
+
+    Returns
+    -------
+    boto3.client
+    """
+    import boto3
+    creds = get_s3_credentials()
+    return boto3.client(
+        's3',
+        aws_access_key_id=creds['accessKeyId'],
+        aws_secret_access_key=creds['secretAccessKey'],
+        aws_session_token=creds['sessionToken'],
+        region_name='us-west-2')
+
+
+def parse_s3_uri(s3_uri):
+    """Split an ``s3://bucket/key`` URI into bucket and key.
+
+    Parameters
+    ----------
+    s3_uri : str
+        e.g. ``s3://sds-n-cumulus-prod-nisar-products/path/file.h5``
+
+    Returns
+    -------
+    tuple of (str, str)
+        ``(bucket, key)``
+    """
+    without_scheme = s3_uri[len('s3://'):]
+    bucket, key = without_scheme.split('/', 1)
+    return bucket, key

--- a/tools/ARIAtools/util/s3.py
+++ b/tools/ARIAtools/util/s3.py
@@ -206,6 +206,10 @@ def configure_gdal_s3(endpoint_key='default'):
     Automatically fetches/refreshes temporary credentials from the
     appropriate DAAC endpoint.
 
+    Credentials are also exported as environment variables so that
+    child processes (GNU parallel workers, Dask process workers)
+    inherit them automatically.
+
     Parameters
     ----------
     endpoint_key : str
@@ -221,8 +225,34 @@ def configure_gdal_s3(endpoint_key='default'):
     _set('AWS_REGION', 'us-west-2')
     _set('AWS_NO_SIGN_REQUEST', 'NO')
 
+    # Export as env vars so child processes inherit the credentials
+    os.environ['AWS_ACCESS_KEY_ID'] = creds['accessKeyId']
+    os.environ['AWS_SECRET_ACCESS_KEY'] = creds['secretAccessKey']
+    os.environ['AWS_SESSION_TOKEN'] = creds['sessionToken']
+    os.environ['AWS_DEFAULT_REGION'] = 'us-west-2'
+
     LOGGER.info('GDAL configured for S3 direct access '
                 '(endpoint: %s, region: us-west-2)', endpoint_key)
+
+
+def restore_gdal_s3_from_env():
+    """Restore GDAL S3 config from environment variables.
+
+    Called by worker processes (GNU parallel, Dask) that inherit
+    AWS credentials via environment variables but need the GDAL
+    config options set in their own process.
+    """
+    key_id = os.environ.get('AWS_ACCESS_KEY_ID')
+    if not key_id:
+        return
+
+    _set = osgeo.gdal.SetConfigOption
+    _set('AWS_ACCESS_KEY_ID', key_id)
+    _set('AWS_SECRET_ACCESS_KEY', os.environ['AWS_SECRET_ACCESS_KEY'])
+    _set('AWS_SESSION_TOKEN', os.environ['AWS_SESSION_TOKEN'])
+    _set('AWS_REGION', os.environ.get('AWS_DEFAULT_REGION', 'us-west-2'))
+    _set('AWS_NO_SIGN_REQUEST', 'NO')
+    LOGGER.debug('GDAL S3 config restored from environment variables')
 
 
 def s3uri_to_vsis3(s3_uri):

--- a/tools/ARIAtools/util/s3.py
+++ b/tools/ARIAtools/util/s3.py
@@ -37,13 +37,22 @@ import requests
 
 LOGGER = logging.getLogger(__name__)
 
-# ASF DAAC S3 credential endpoint — returns temporary AWS credentials
-# for in-cloud access to NASA Earthdata products hosted on S3.
-_ASF_S3_CREDS_URL = 'https://cumulus.asf.alaska.edu/s3credentials'
+# S3 credential endpoints — each NASA DAAC Cumulus deployment has its
+# own endpoint that exchanges Earthdata Login tokens for temporary
+# AWS credentials scoped to that DAAC's S3 bucket(s).
+_S3_CREDS_ENDPOINTS = {
+    'default': 'https://cumulus.asf.alaska.edu/s3credentials',
+    'nisar':   'https://nisar.asf.earthdatacloud.nasa.gov/s3credentials',
+}
 
-# Cached credentials (module-level) — refreshed when expired
-_s3_creds = None
-_s3_creds_expiry = 0
+# Map S3 bucket names to credential endpoint keys
+_BUCKET_TO_ENDPOINT = {
+    'sds-n-cumulus-prod-nisar-products': 'nisar',
+}
+
+# Cached credentials (module-level) — keyed by endpoint name
+_s3_creds_cache = {}       # endpoint_key → creds dict
+_s3_creds_expiry_cache = {}  # endpoint_key → expiry timestamp
 
 # Reverse mapping: /vsis3/ path → HTTPS URL, populated by maybe_use_s3.
 # Used by open_gunw_h5 to resolve /vsis3/ paths back to HTTPS for h5py.
@@ -108,11 +117,28 @@ def is_on_aws():
     return False
 
 
-def _fetch_s3_credentials():
-    """Fetch temporary S3 credentials from the ASF DAAC endpoint.
+def _endpoint_key_for_bucket(bucket):
+    """Return the credential endpoint key for a given S3 bucket."""
+    return _BUCKET_TO_ENDPOINT.get(bucket, 'default')
+
+
+def _endpoint_key_for_s3uri(s3_uri):
+    """Return the credential endpoint key for an ``s3://`` URI."""
+    bucket = s3_uri[len('s3://'):].split('/', 1)[0]
+    return _endpoint_key_for_bucket(bucket)
+
+
+def _fetch_s3_credentials(endpoint_key='default'):
+    """Fetch temporary S3 credentials from a DAAC endpoint.
 
     Requires Earthdata Login credentials in ``~/.netrc``.  The
     returned credentials are valid for ~1 hour.
+
+    Parameters
+    ----------
+    endpoint_key : str
+        Key into ``_S3_CREDS_ENDPOINTS`` (e.g. ``'default'``,
+        ``'nisar'``).
 
     Returns
     -------
@@ -125,14 +151,15 @@ def _fetch_s3_credentials():
     RuntimeError
         If credential retrieval fails.
     """
-    LOGGER.info('Fetching temporary S3 credentials from ASF')
+    url = _S3_CREDS_ENDPOINTS[endpoint_key]
+    LOGGER.info('Fetching temporary S3 credentials from %s', url)
     try:
-        resp = requests.get(_ASF_S3_CREDS_URL, timeout=30)
+        resp = requests.get(url, timeout=30)
         resp.raise_for_status()
         creds = resp.json()
     except Exception as exc:
         raise RuntimeError(
-            f'Failed to fetch S3 credentials from {_ASF_S3_CREDS_URL}: '
+            f'Failed to fetch S3 credentials from {url}: '
             f'{exc}') from exc
 
     required = ('accessKeyId', 'secretAccessKey', 'sessionToken')
@@ -141,36 +168,51 @@ def _fetch_s3_credentials():
             raise RuntimeError(
                 f'S3 credential response missing key {key!r}')
 
-    LOGGER.debug('S3 credentials obtained (expires: %s)',
-                 creds.get('expiration', 'unknown'))
+    LOGGER.debug('S3 credentials obtained from %s (expires: %s)',
+                 endpoint_key, creds.get('expiration', 'unknown'))
     return creds
 
 
-def get_s3_credentials():
+def get_s3_credentials(endpoint_key='default'):
     """Return cached S3 credentials, refreshing if expired.
+
+    Parameters
+    ----------
+    endpoint_key : str
+        Key into ``_S3_CREDS_ENDPOINTS`` (e.g. ``'default'``,
+        ``'nisar'``).
 
     Returns
     -------
     dict
         Keys: ``accessKeyId``, ``secretAccessKey``, ``sessionToken``.
     """
-    global _s3_creds, _s3_creds_expiry
+    expiry = _s3_creds_expiry_cache.get(endpoint_key, 0)
 
     # Refresh 5 minutes before expiry to avoid mid-operation failures
-    if _s3_creds is None or time.time() > (_s3_creds_expiry - 300):
-        _s3_creds = _fetch_s3_credentials()
+    if endpoint_key not in _s3_creds_cache or \
+            time.time() > (expiry - 300):
+        _s3_creds_cache[endpoint_key] = \
+            _fetch_s3_credentials(endpoint_key)
         # Default to 1 hour if no expiration provided
-        _s3_creds_expiry = time.time() + 3600
-    return _s3_creds
+        _s3_creds_expiry_cache[endpoint_key] = time.time() + 3600
+    return _s3_creds_cache[endpoint_key]
 
 
-def configure_gdal_s3():
-    """Set GDAL config options for S3 access using ASF credentials.
+def configure_gdal_s3(endpoint_key='default'):
+    """Set GDAL config options for S3 access.
 
     Should be called once before opening ``/vsis3/`` paths with GDAL.
-    Automatically fetches/refreshes temporary credentials.
+    Automatically fetches/refreshes temporary credentials from the
+    appropriate DAAC endpoint.
+
+    Parameters
+    ----------
+    endpoint_key : str
+        Key into ``_S3_CREDS_ENDPOINTS`` (e.g. ``'default'``,
+        ``'nisar'``).
     """
-    creds = get_s3_credentials()
+    creds = get_s3_credentials(endpoint_key)
 
     _set = osgeo.gdal.SetConfigOption
     _set('AWS_ACCESS_KEY_ID', creds['accessKeyId'])
@@ -179,7 +221,8 @@ def configure_gdal_s3():
     _set('AWS_REGION', 'us-west-2')
     _set('AWS_NO_SIGN_REQUEST', 'NO')
 
-    LOGGER.info('GDAL configured for S3 direct access (region: us-west-2)')
+    LOGGER.info('GDAL configured for S3 direct access '
+                '(endpoint: %s, region: us-west-2)', endpoint_key)
 
 
 def s3uri_to_vsis3(s3_uri):
@@ -254,8 +297,12 @@ def maybe_use_s3(https_urls, s3_urls):
         LOGGER.info('Not on AWS — using HTTPS (vsicurl) access')
         return https_urls, False
 
+    # Determine credential endpoint from the first available S3 URL
+    first_s3 = next(u for u in s3_urls if u is not None)
+    endpoint_key = _endpoint_key_for_s3uri(first_s3)
+
     # We're on AWS with S3 URLs — set up credentials and convert
-    configure_gdal_s3()
+    configure_gdal_s3(endpoint_key)
 
     converted = []
     for https_url, s3_url in zip(https_urls, s3_urls):
@@ -284,23 +331,36 @@ def vsis3_to_https(vsis3_path):
     return _vsis3_to_https.get(vsis3_path)
 
 
-def get_s3_client():
-    """Create a boto3 S3 client using ASF temporary credentials.
+def get_s3_client(endpoint_key='default', max_pool_connections=10):
+    """Create a boto3 S3 client using temporary DAAC credentials.
 
-    Credentials are automatically fetched/refreshed.
+    Parameters
+    ----------
+    endpoint_key : str
+        Key into ``_S3_CREDS_ENDPOINTS`` (e.g. ``'default'``,
+        ``'nisar'``).
+    max_pool_connections : int
+        Maximum number of connections in the urllib3 pool.
+        Set this to match the number of concurrent download
+        threads to avoid connection pool overflow warnings.
 
     Returns
     -------
     boto3.client
     """
     import boto3
-    creds = get_s3_credentials()
+    from botocore.config import Config
+    creds = get_s3_credentials(endpoint_key)
+    config = Config(
+        max_pool_connections=max_pool_connections,
+    )
     return boto3.client(
         's3',
         aws_access_key_id=creds['accessKeyId'],
         aws_secret_access_key=creds['secretAccessKey'],
         aws_session_token=creds['sessionToken'],
-        region_name='us-west-2')
+        region_name='us-west-2',
+        config=config)
 
 
 def parse_s3_uri(s3_uri):

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -26,6 +26,7 @@ from requests.exceptions import RequestException
 import ARIAtools.util.log
 from ARIAtools.util.shp import open_shp
 from ARIAtools.util.url import url_versions
+import ARIAtools.util.s3
 
 LOGGER = logging.getLogger('ariaDownload.py')
 
@@ -393,11 +394,24 @@ class Downloader:
         nt = int(self.args.num_threads)
         LOGGER.info("Downloading %d products...", len(scenes))
 
+        # Check if we can use S3 direct download (on AWS)
+        use_s3 = ARIAtools.util.s3.is_on_aws()
+        s3_client = None
+        if use_s3:
+            try:
+                s3_client = ARIAtools.util.s3.get_s3_client()
+                LOGGER.info('Using S3 direct download')
+            except Exception as exc:
+                LOGGER.warning('S3 client setup failed, falling back '
+                               'to HTTPS: %s', exc)
+                use_s3 = False
+
         session = asf_search.ASFSession()
         if self.args.user:
             session.auth_with_creds(self.args.user, self.args.passw)
 
-        def download_file(url, max_retries=3, retry_delay=5):
+        def download_file(scene, max_retries=3, retry_delay=5):
+            url = scene.properties['url']
             local_filename = url.split("/")[-1]
             filepath = os.path.join(self.args.wd, local_filename)
 
@@ -407,6 +421,31 @@ class Downloader:
                 LOGGER.info("Product already in directory: %s", filepath)
                 return filepath
 
+            # Try S3 download first if available
+            s3_url = _get_s3_data_url(scene) if use_s3 else None
+            if s3_client and s3_url:
+                attempt = 0
+                while attempt < max_retries:
+                    attempt += 1
+                    try:
+                        bucket, key = \
+                            ARIAtools.util.s3.parse_s3_uri(s3_url)
+                        s3_client.download_file(
+                            bucket, key, filepath)
+                        LOGGER.debug('S3 download: %s', filepath)
+                        return filepath
+                    except Exception as exc:
+                        LOGGER.warning(
+                            'S3 download attempt %d failed: %s',
+                            attempt, exc)
+                        if os.path.exists(filepath):
+                            os.remove(filepath)
+                        if attempt < max_retries:
+                            time.sleep(retry_delay)
+                LOGGER.warning('S3 download failed, falling back '
+                               'to HTTPS for %s', local_filename)
+
+            # HTTPS download (default or fallback)
             attempt = 0
             while attempt < max_retries:
                 attempt += 1
@@ -415,7 +454,8 @@ class Downloader:
                     response.raise_for_status()
 
                     with open(filepath, "wb") as f:
-                        for chunk in response.iter_content(chunk_size=8192):
+                        for chunk in response.iter_content(
+                                chunk_size=8192):
                             if chunk:
                                 f.write(chunk)
 
@@ -426,36 +466,41 @@ class Downloader:
                     file_size = os.path.getsize(filepath)
                     if expected_size > 0 and file_size < expected_size:
                         LOGGER.warning(
-                            "Incomplete download detected (%d/%d bytes). "
-                            "Retrying...",
+                            "Incomplete download detected "
+                            "(%d/%d bytes). Retrying...",
                             file_size, expected_size
                         )
                         os.remove(filepath)
                         time.sleep(retry_delay)
-                        continue  # Retry download
+                        continue
 
                 except RequestException as e:
-                    LOGGER.error("Error downloading %s: %s", url, e)
+                    LOGGER.error("Error downloading %s: %s",
+                                 url, e)
 
             return filepath
 
         # Create a progress bar
-        pbar = tqdm.tqdm(total=len(scenes), unit="file", desc="Downloading")
+        pbar = tqdm.tqdm(total=len(scenes), unit="file",
+                         desc="Downloading")
         try:
-            urls = [scene.properties["url"] for scene in scenes]
-            with concurrent.futures.ThreadPoolExecutor(max_workers=nt) \
-                as executor:
-                future_to_url = {
-                    executor.submit(download_file, url): url for url in urls
+            with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=nt) as executor:
+                future_to_scene = {
+                    executor.submit(download_file, scene): scene
+                    for scene in scenes
                 }
-                for future in concurrent.futures.as_completed(future_to_url):
-                    url = future_to_url[future]
+                for future in concurrent.futures.as_completed(
+                        future_to_scene):
+                    scene = future_to_scene[future]
                     try:
                         filepath = future.result()
                         LOGGER.debug("Downloaded: %s", filepath)
                         pbar.update(1)
                     except Exception as exc:
-                        LOGGER.error("%s generated an exception: %s", url, exc)
+                        LOGGER.error(
+                            "%s generated an exception: %s",
+                            scene.properties['url'], exc)
         finally:
             pbar.close()
 

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# Author: Brett A. Buzzanga
+# Author: Brett A. Buzzanga, David Bekaert
 # Copyright (c) 2023, by the California Institute of Technology. ALL RIGHTS
 # RESERVED. United States Government Sponsorship acknowledged.
 #
@@ -175,6 +175,27 @@ def make_bbox(inp_bbox):
     return poly
 
 
+def _get_s3_data_url(scene):
+    """Extract the S3 data URL for the main product file from a scene.
+
+    ASF search results include ``s3Urls`` with multiple files (browse,
+    metadata, QA, etc.).  This returns the S3 URL matching the
+    product's primary data file (same filename as the HTTPS URL).
+
+    Returns
+    -------
+    str or None
+        ``s3://bucket/path/file`` or ``None`` if not available.
+    """
+    props = scene.geojson()['properties']
+    filename = props.get('fileName', '')
+    s3_urls = props.get('s3Urls', [])
+    for s3_url in s3_urls:
+        if s3_url.endswith(filename):
+            return s3_url
+    return None
+
+
 def get_url_ifg(scenes):
     """Get url, ifg of fetched ASF scene"""
     urls, ifgs = [], []
@@ -267,7 +288,7 @@ class Downloader:
         if self.args.output == "Count":
             LOGGER.info("Found -- %d -- products", len(scenes))
         elif self.args.output == "Url":
-            self.write_urls(urls)
+            self.write_urls(urls, scenes)
         elif self.args.output == "Download":
             self.download_scenes(scenes)
             
@@ -359,11 +380,12 @@ class Downloader:
         elap_chk = self.args.daysgt <= elap <= self.args.dayslt
         return sten_chk and elap_chk
 
-    def write_urls(self, urls):
+    def write_urls(self, urls, scenes):
         dst = fmt_dst(self.args)
         with open(dst, "w") as fh:
-            for url in urls:
-                print(url, file=fh)
+            for url, scene in zip(urls, scenes):
+                s3_url = _get_s3_data_url(scene) or ''
+                print(f'{url},{s3_url}', file=fh)
         LOGGER.info("Wrote -- %d -- product urls to: %s", len(urls), dst)
 
     def download_scenes(self, scenes):

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -398,9 +398,18 @@ class Downloader:
         use_s3 = ARIAtools.util.s3.is_on_aws()
         s3_client = None
         if use_s3:
+            # Determine credential endpoint from first S3 URL
+            first_s3 = next(
+                (_get_s3_data_url(s) for s in scenes
+                 if _get_s3_data_url(s)), None)
+            endpoint_key = ARIAtools.util.s3._endpoint_key_for_s3uri(
+                first_s3) if first_s3 else 'default'
             try:
-                s3_client = ARIAtools.util.s3.get_s3_client()
-                LOGGER.info('Using S3 direct download')
+                s3_client = ARIAtools.util.s3.get_s3_client(
+                    endpoint_key,
+                    max_pool_connections=max(nt, 10))
+                LOGGER.info('Using S3 direct download (endpoint: %s)',
+                            endpoint_key)
             except Exception as exc:
                 LOGGER.warning('S3 client setup failed, falling back '
                                'to HTTPS: %s', exc)

--- a/tools/bin/ariaDownload.py
+++ b/tools/bin/ariaDownload.py
@@ -407,7 +407,7 @@ class Downloader:
             try:
                 s3_client = ARIAtools.util.s3.get_s3_client(
                     endpoint_key,
-                    max_pool_connections=max(nt, 10))
+                    max_pool_connections=nt * 10)
                 LOGGER.info('Using S3 direct download (endpoint: %s)',
                             endpoint_key)
             except Exception as exc:

--- a/tools/bin/ariaExtract.py
+++ b/tools/bin/ariaExtract.py
@@ -41,10 +41,10 @@ def createParser():
         '-f', '--file', dest='imgfile', type=str, required=True,
         help='List of Sentinel-1 GUNW or NISAR GUNW products '
              '(wildcards supported) or txt file with product urls '
-             'for virtual access without downloading (only for '
-             'Sentinel-1 GUNW). For virtual processing a local '
-             'metadata cache is created on first run; subsequent '
-             'runs read from the cache for faster initialization.')
+             'for virtual access without downloading. For virtual '
+             'processing a local metadata cache is created on '
+             'first run; subsequent runs read from the cache for '
+             'faster initialization.')
     parser.add_argument(
         '-w', '--workdir', dest='workdir', default='./',
         help='Specify directory to deposit all outputs. Default is local '

--- a/tools/bin/ariaPlot.py
+++ b/tools/bin/ariaPlot.py
@@ -42,10 +42,10 @@ def createParser():
         '-f', '--file', dest='imgfile', type=str, required=True,
         help='List of Sentinel-1 GUNW or NISAR GUNW products '
              '(wildcards supported) or txt file with product urls '
-             'for virtual access without downloading (only for '
-             'Sentinel-1 GUNW). For virtual processing a local '
-             'metadata cache is created on first run; subsequent '
-             'runs read from the cache for faster initialization.')
+             'for virtual access without downloading. For virtual '
+             'processing a local metadata cache is created on '
+             'first run; subsequent runs read from the cache for '
+             'faster initialization.')
     parser.add_argument(
         '-w', '--workdir', dest='workdir', default='./',
         help='Specify directory to deposit all outputs. Default is local '

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -15,6 +15,7 @@ baseline, LOS file(s), and (where available) tropospheric correction layers.
 """
 import os
 import sys
+import h5py
 import glob
 import copy
 import logging

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -58,10 +58,10 @@ def create_parser():
         '-f', '--file', dest='imgfile', type=str, required=True,
         help='List of Sentinel-1 GUNW or NISAR GUNW products '
              '(wildcards supported) or txt file with product urls '
-             'for virtual access without downloading (only for '
-             'Sentinel-1 GUNW). For virtual processing a local '
-             'metadata cache is created on first run; subsequent '
-             'runs read from the cache for faster initialization.')
+             'for virtual access without downloading. For virtual '
+             'processing a local metadata cache is created on '
+             'first run; subsequent runs read from the cache for '
+             'faster initialization.')
     parser.add_argument(
         '-w', '--workdir', dest='workdir', default='./',
         help='Specify directory to deposit all outputs. Default is local '

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -36,6 +36,7 @@ import ARIAtools.util.log
 import ARIAtools.util.mask
 import ARIAtools.util.misc
 import ARIAtools.util.vrt
+import ARIAtools.util.s3
 import ARIAtools.constants
 import ARIAtools.util.runlog
 
@@ -698,6 +699,10 @@ def main():
 
         # Track consistency of dimensions
         ARIAtools.util.vrt.dim_check(ref_arr_record, prod_arr_record)
+
+    # Fix VRT files: replace /vsis3/ paths with /vsicurl/ for
+    # downstream tool compatibility (e.g. MintPy).
+    ARIAtools.util.s3.fixup_vrt_s3_paths(args.workdir)
 
     # Generate UNW stack
     ref_dlist = generate_stack(

--- a/tools/bin/ariaTSsetup.py
+++ b/tools/bin/ariaTSsetup.py
@@ -623,8 +623,8 @@ def main():
     LOGGER.info('Extracting %s for each interferogram pair' % layers)
     ref_arr_record = ARIAtools.extractProduct.export_products(
         standardproduct_info.products[1], tropo_total=False, layers=layers,
-        rankedResampling=args.rankedResampling, multiproc_method='threads',
-        **export_dict, runlog=runlog)
+        rankedResampling=args.rankedResampling,
+        multiproc_method='gnu_parallel', **export_dict, runlog=runlog)
 
     # Remove pairing and pass combined dictionary of all layers
     extract_dict = collections.defaultdict(list)

--- a/tools/bin/export_product.py
+++ b/tools/bin/export_product.py
@@ -34,7 +34,6 @@ os.environ['GDAL_HTTP_MULTIPLEX'] = 'YES'
 
 # 3. Disable HDF5 locking and remote directory scanning
 os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
-os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
 os.environ['VSI_CACHE'] = 'YES'
 # ---------------------------------------------------------
 

--- a/tools/bin/export_product.py
+++ b/tools/bin/export_product.py
@@ -8,48 +8,9 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import os
 import sys
+import h5py
 import argparse
-import logging
 import json
-import shutil
-
-# --- INJECT THIS BLOCK BEFORE ANY ARIA OR GDAL IMPORTS ---
-
-# 1. Safely clone the authenticated Earthdata cookie to a unique worker file.
-# Without this, the worker sends an unauthenticated request, receives an HTML 
-# login page instead of data, and crashes the HDF5 parser!
-master_cookie = os.environ.get('GDAL_HTTP_COOKIEFILE', '/tmp/cookies.txt')
-if not os.path.exists(master_cookie):
-    master_cookie = '/tmp/cookies.txt'
-
-worker_cookie = f"/tmp/cookies_worker_{os.getpid()}.txt"
-
-if os.path.exists(master_cookie):
-    try:
-        shutil.copy(master_cookie, worker_cookie)
-    except Exception:
-        pass
-
-os.environ['GDAL_HTTP_COOKIEFILE'] = worker_cookie
-os.environ['GDAL_HTTP_COOKIEJAR'] = worker_cookie
-
-# 2. Disable HDF5 locking and enable cache
-os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
-os.environ['VSI_CACHE'] = 'YES'
-os.environ['VSI_CACHE_SIZE'] = '536870912'
-
-# 3. Disable HTTP Multiplexing to prevent HDF5 byte-parser corruption
-os.environ['GDAL_HTTP_MULTIPLEX'] = 'NO'
-os.environ['GDAL_HTTP_MERGE_CONSECUTIVE_RANGES'] = 'NO'
-os.environ['CPL_VSIL_CURL_USE_HEAD'] = 'NO'
-
-# 4. Destroy dead sockets instantly to prevent connection timeouts
-os.environ['GDAL_MAX_DATASET_POOL_SIZE'] = '0'
-
-# 5. Aggressive Retries for AWS Rate Limits
-os.environ['GDAL_HTTP_MAX_RETRY'] = '10'
-os.environ['GDAL_HTTP_RETRY_DELAY'] = '3'
-# ---------------------------------------------------------
 
 import ARIAtools.extractProduct
 

--- a/tools/bin/export_product.py
+++ b/tools/bin/export_product.py
@@ -14,25 +14,39 @@ import json
 import shutil
 
 # --- INJECT THIS BLOCK BEFORE ANY ARIA OR GDAL IMPORTS ---
-# 1. Unique cookies per process to prevent Auth collisions
-cookie_path = f"/tmp/cookies_worker_{os.getpid()}.txt"
-os.environ['GDAL_HTTP_COOKIEFILE'] = cookie_path
-os.environ['GDAL_HTTP_COOKIEJAR'] = cookie_path
 
-# 2. Disable HDF5 locking and enable heavy caching
+# 1. Safely clone the authenticated Earthdata cookie to a unique worker file.
+# Without this, the worker sends an unauthenticated request, receives an HTML 
+# login page instead of data, and crashes the HDF5 parser!
+master_cookie = os.environ.get('GDAL_HTTP_COOKIEFILE', '/tmp/cookies.txt')
+if not os.path.exists(master_cookie):
+    master_cookie = '/tmp/cookies.txt'
+
+worker_cookie = f"/tmp/cookies_worker_{os.getpid()}.txt"
+
+if os.path.exists(master_cookie):
+    try:
+        shutil.copy(master_cookie, worker_cookie)
+    except Exception:
+        pass
+
+os.environ['GDAL_HTTP_COOKIEFILE'] = worker_cookie
+os.environ['GDAL_HTTP_COOKIEJAR'] = worker_cookie
+
+# 2. Disable HDF5 locking and enable cache
 os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
 os.environ['VSI_CACHE'] = 'YES'
-os.environ['VSI_CACHE_SIZE'] = '536870912' # 512MB cache to prevent thrashing
+os.environ['VSI_CACHE_SIZE'] = '536870912'
 
-# 3. CRITICAL: Disable HTTP Multiplexing and Range Merging
-# This prevents GDAL from merging the losX and losY byte requests, 
-# which corrupts the HDF5 C-library's strict byte parser.
+# 3. Disable HTTP Multiplexing to prevent HDF5 byte-parser corruption
 os.environ['GDAL_HTTP_MULTIPLEX'] = 'NO'
 os.environ['GDAL_HTTP_MERGE_CONSECUTIVE_RANGES'] = 'NO'
 os.environ['CPL_VSIL_CURL_USE_HEAD'] = 'NO'
+
+# 4. Destroy dead sockets instantly to prevent connection timeouts
 os.environ['GDAL_MAX_DATASET_POOL_SIZE'] = '0'
 
-# 4. Aggressive Retries for AWS Rate Limits
+# 5. Aggressive Retries for AWS Rate Limits
 os.environ['GDAL_HTTP_MAX_RETRY'] = '10'
 os.environ['GDAL_HTTP_RETRY_DELAY'] = '3'
 # ---------------------------------------------------------

--- a/tools/bin/export_product.py
+++ b/tools/bin/export_product.py
@@ -6,21 +6,36 @@
 # RESERVED. United States Government Sponsorship acknowledged.
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-import argparse
-import json
 import os
 import sys
+import argparse
+import logging
+import json
+import shutil
 
 # --- INJECT THIS BLOCK BEFORE ANY ARIA OR GDAL IMPORTS ---
-# Force completely unique cookie files at the OS level. 
-# This guarantees GDAL obeys the isolation, regardless of site-packages!
-cookie_path = f"/tmp/cookies_worker_{os.getpid()}.txt"
-os.environ['GDAL_HTTP_COOKIEFILE'] = cookie_path
-os.environ['GDAL_HTTP_COOKIEJAR'] = cookie_path
-os.environ['VSI_CACHE'] = 'YES'
+# 1. Inherit Earthdata cookies from parent to avoid unauthenticated 403s
+reference_cookie = os.environ.get('GDAL_HTTP_COOKIEFILE', '/tmp/cookies.txt')
+secondary_cookie = f"/tmp/cookies_worker_{os.getpid()}.txt"
 
-# --- ADD THIS: Disable HDF5 file locking for cloud streaming ---
+if os.path.exists(reference_cookie):
+    try:
+        shutil.copy(reference_cookie, secondary_cookie)
+    except Exception:
+        pass
+
+os.environ['GDAL_HTTP_COOKIEFILE'] = secondary_cookie
+os.environ['GDAL_HTTP_COOKIEJAR'] = secondary_cookie
+
+# 2. Aggressive GDAL HTTP Retry settings (Catches AWS 503 SlowDown / 429 Rate Limits)
+os.environ['GDAL_HTTP_MAX_RETRY'] = '10'
+os.environ['GDAL_HTTP_RETRY_DELAY'] = '3'
+os.environ['GDAL_HTTP_MULTIPLEX'] = 'YES'
+
+# 3. Disable HDF5 locking and remote directory scanning
 os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
+os.environ['GDAL_DISABLE_READDIR_ON_OPEN'] = 'EMPTY_DIR'
+os.environ['VSI_CACHE'] = 'YES'
 # ---------------------------------------------------------
 
 import ARIAtools.extractProduct

--- a/tools/bin/export_product.py
+++ b/tools/bin/export_product.py
@@ -11,6 +11,18 @@ import json
 import os
 import sys
 
+# --- INJECT THIS BLOCK BEFORE ANY ARIA OR GDAL IMPORTS ---
+# Force completely unique cookie files at the OS level. 
+# This guarantees GDAL obeys the isolation, regardless of site-packages!
+cookie_path = f"/tmp/cookies_worker_{os.getpid()}.txt"
+os.environ['GDAL_HTTP_COOKIEFILE'] = cookie_path
+os.environ['GDAL_HTTP_COOKIEJAR'] = cookie_path
+os.environ['VSI_CACHE'] = 'YES'
+
+# --- ADD THIS: Disable HDF5 file locking for cloud streaming ---
+os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
+# ---------------------------------------------------------
+
 import ARIAtools.extractProduct
 
 

--- a/tools/bin/export_product.py
+++ b/tools/bin/export_product.py
@@ -14,27 +14,26 @@ import json
 import shutil
 
 # --- INJECT THIS BLOCK BEFORE ANY ARIA OR GDAL IMPORTS ---
-# 1. Inherit Earthdata cookies from parent to avoid unauthenticated 403s
-reference_cookie = os.environ.get('GDAL_HTTP_COOKIEFILE', '/tmp/cookies.txt')
-secondary_cookie = f"/tmp/cookies_worker_{os.getpid()}.txt"
+# 1. Unique cookies per process to prevent Auth collisions
+cookie_path = f"/tmp/cookies_worker_{os.getpid()}.txt"
+os.environ['GDAL_HTTP_COOKIEFILE'] = cookie_path
+os.environ['GDAL_HTTP_COOKIEJAR'] = cookie_path
 
-if os.path.exists(reference_cookie):
-    try:
-        shutil.copy(reference_cookie, secondary_cookie)
-    except Exception:
-        pass
-
-os.environ['GDAL_HTTP_COOKIEFILE'] = secondary_cookie
-os.environ['GDAL_HTTP_COOKIEJAR'] = secondary_cookie
-
-# 2. Aggressive GDAL HTTP Retry settings (Catches AWS 503 SlowDown / 429 Rate Limits)
-os.environ['GDAL_HTTP_MAX_RETRY'] = '10'
-os.environ['GDAL_HTTP_RETRY_DELAY'] = '3'
-os.environ['GDAL_HTTP_MULTIPLEX'] = 'YES'
-
-# 3. Disable HDF5 locking and remote directory scanning
+# 2. Disable HDF5 locking and enable heavy caching
 os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
 os.environ['VSI_CACHE'] = 'YES'
+os.environ['VSI_CACHE_SIZE'] = '536870912' # 512MB cache to prevent thrashing
+
+# 3. CRITICAL: Disable HTTP Multiplexing and Range Merging
+# This prevents GDAL from merging the losX and losY byte requests, 
+# which corrupts the HDF5 C-library's strict byte parser.
+os.environ['GDAL_HTTP_MULTIPLEX'] = 'NO'
+os.environ['GDAL_HTTP_MERGE_CONSECUTIVE_RANGES'] = 'NO'
+os.environ['CPL_VSIL_CURL_USE_HEAD'] = 'NO'
+
+# 4. Aggressive Retries for AWS Rate Limits
+os.environ['GDAL_HTTP_MAX_RETRY'] = '10'
+os.environ['GDAL_HTTP_RETRY_DELAY'] = '3'
 # ---------------------------------------------------------
 
 import ARIAtools.extractProduct

--- a/tools/bin/export_product.py
+++ b/tools/bin/export_product.py
@@ -30,6 +30,7 @@ os.environ['VSI_CACHE_SIZE'] = '536870912' # 512MB cache to prevent thrashing
 os.environ['GDAL_HTTP_MULTIPLEX'] = 'NO'
 os.environ['GDAL_HTTP_MERGE_CONSECUTIVE_RANGES'] = 'NO'
 os.environ['CPL_VSIL_CURL_USE_HEAD'] = 'NO'
+os.environ['GDAL_MAX_DATASET_POOL_SIZE'] = '0'
 
 # 4. Aggressive Retries for AWS Rate Limits
 os.environ['GDAL_HTTP_MAX_RETRY'] = '10'


### PR DESCRIPTION
Adding Virtual support for NISAR GUNW using VSI curl. This removed some of the h5py calls as needed. some meta-data fetching needed to stay. Rasters via vsi netcdf reader. The 3D datasets are not well suited and add overhead.

Some potential feedback to the project:

```
Here's the per-layer diagnosis:

Summary table
Layer	Shape	Chunks	Compress	#Chunks	Issues
incidenceAngle	20×690×703	(1,512,512)	gzip(1)	80	Band-dim chunk=1
perpendicularBaseline	20×690×703	(1,512,512)	NONE	80	Band-dim chunk=1 + no compression
parallelBaseline	20×690×703	(1,512,512)	NONE	80	Band-dim chunk=1 + no compression
losUnitVectorX	20×690×703	(1,512,512)	gzip(1)	80	Band-dim chunk=1
losUnitVectorY	20×690×703	(1,512,512)	gzip(1)	80	Band-dim chunk=1
elevationAngle	20×690×703	(1,512,512)	gzip(1)	80	Band-dim chunk=1
referenceSlantRange	20×690×703	(1,512,512)	gzip(1)	80	Band-dim chunk=1 + float64
The root cause: 80 HTTP range requests per layer
Every layer has chunks (1, 512, 512) — i.e., 1 band per chunk. The spatial grid of 690×703 fits in a 2×2 tile of 512×512 chunks. So each layer needs: 20 bands × 4 spatial tiles = 80 chunks = 80 HTTP range requests. Each HTTP round-trip takes ~200–300ms of latency, so 80 requests alone costs 16–24s just in overhead.

Per-layer recommendations for the product spec
All layers — Change chunks from (1, 512, 512) to (20, 690, 703) (single chunk). The entire dataset is only 37 MB (74 MB for slantRange) — small enough for a single chunk. This turns 80 HTTP requests into 1 request. That alone would cut fetch time from ~20s to ~2s per layer.

perpendicularBaseline, parallelBaseline — Add gzip(1) compression. They're currently stored uncompressed so the full 37 MB raw bytes go over the wire. With gzip(1), baseline data typically compresses 3–5x (slowly varying spatial fields compress well), reducing transfer to ~8–12 MB, with negligible CPU cost.

referenceSlantRange — Consider float32 instead of float64. Slant range values (833,205–1,119,833 m) have 6 significant digits — float32 gives 7 digits of precision, which is sub-meter. That alone halves from 74 MB to 37 MB. (If sub-mm precision is truly needed, keep float64.)

Impact estimate
With these fixes, fetching all 7 metadata layers would drop from ~2–3 min to ~15–20s total (7 layers × 1 HTTP request × ~2s each).
```