### PR TITLE
Fix bug with undefined variable name

### DIFF
--- a/tools/ARIAtools/product.py
+++ b/tools/ARIAtools/product.py
@@ -1567,7 +1567,7 @@ class Product:
             if file not in prev_files:
                 self.products += self.__readproduct__(file)
             else:
-                LOGGER.info('Product already read: %s', prod_name)
+                LOGGER.info('Product already read: %s', file)
 
         if self.runlog is not None:
             self.runlog.update('files', self.files)


### PR DESCRIPTION
Test scenario which helped me isolate this bug:
```
ariaDownload.py --mission NISAR -d d -b '38.6172 39.0107 -120.6543 -120.328' -t 42 -o Download -s 20260201 -e 20260430

ariaTSsetup.py -f "products/*.h5" -w TS_output -d Download -m Download -l 'troposphereTotal,ionosphere,solidEarthTide,amplitude,coherence' -of ISCE -b '37.17228 39.86056 -121.45554 -118.45571'
```